### PR TITLE
feat: implement room cache, service management flow, and infinite scroll

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,12 +25,12 @@ fun keysProperty(
 
 android {
     namespace = "must.kdroiders.hustlehub"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "must.kdroiders.hustlehub"
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/main/java/must/kdroiders/hustlehub/data/local/AppDatabase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/local/AppDatabase.kt
@@ -1,0 +1,34 @@
+package must.kdroiders.hustlehub.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import must.kdroiders.hustlehub.data.local.dao.ServiceDao
+import must.kdroiders.hustlehub.data.local.entity.ServiceEntity
+
+@Database(
+    entities = [ServiceEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class AppDatabase : RoomDatabase() {
+
+    abstract fun serviceDao(): ServiceDao
+
+    companion object {
+        private const val DB_NAME = "hustlehub.db"
+
+        @Volatile
+        private var instance: AppDatabase? = null
+
+        fun getInstance(context: Context): AppDatabase =
+            instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    DB_NAME
+                ).build().also { instance = it }
+            }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/data/local/AppDatabase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/local/AppDatabase.kt
@@ -1,8 +1,6 @@
 package must.kdroiders.hustlehub.data.local
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import must.kdroiders.hustlehub.data.local.dao.ServiceDao
 import must.kdroiders.hustlehub.data.local.entity.ServiceEntity
@@ -15,20 +13,4 @@ import must.kdroiders.hustlehub.data.local.entity.ServiceEntity
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun serviceDao(): ServiceDao
-
-    companion object {
-        private const val DB_NAME = "hustlehub.db"
-
-        @Volatile
-        private var instance: AppDatabase? = null
-
-        fun getInstance(context: Context): AppDatabase =
-            instance ?: synchronized(this) {
-                instance ?: Room.databaseBuilder(
-                    context.applicationContext,
-                    AppDatabase::class.java,
-                    DB_NAME
-                ).build().also { instance = it }
-            }
-    }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/data/local/dao/ServiceDao.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/local/dao/ServiceDao.kt
@@ -1,0 +1,47 @@
+package must.kdroiders.hustlehub.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import must.kdroiders.hustlehub.data.local.entity.ServiceEntity
+
+@Dao
+interface ServiceDao {
+
+    /** Returns all cached services ordered by most recently updated. */
+    @Query("SELECT * FROM cached_services ORDER BY lastUpdated DESC")
+    suspend fun getAllServices(): List<ServiceEntity>
+
+    /** Returns services belonging to a specific provider. */
+    @Query("SELECT * FROM cached_services WHERE providerId = :providerId ORDER BY lastUpdated DESC")
+    suspend fun getServicesByProvider(providerId: String): List<ServiceEntity>
+
+    /** Returns a single cached service by ID, or null if not cached. */
+    @Query("SELECT * FROM cached_services WHERE id = :id")
+    suspend fun getServiceById(id: String): ServiceEntity?
+
+    /** Insert or replace services — used after a successful remote fetch. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(services: List<ServiceEntity>)
+
+    /** Insert or replace a single service. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(service: ServiceEntity)
+
+    /** Delete a specific cached service (e.g. after a remote delete). */
+    @Query("DELETE FROM cached_services WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    /** Delete all entries older than the given timestamp (cache eviction). */
+    @Query("DELETE FROM cached_services WHERE lastUpdated < :cutoffMs")
+    suspend fun deleteStaleEntries(cutoffMs: Long)
+
+    /** Returns the most recent lastUpdated value across all cached entries. */
+    @Query("SELECT MAX(lastUpdated) FROM cached_services")
+    suspend fun getLastSyncTime(): Long?
+
+    /** Wipe everything — used on sign-out. */
+    @Query("DELETE FROM cached_services")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/data/local/entity/ServiceEntity.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/local/entity/ServiceEntity.kt
@@ -1,0 +1,26 @@
+package must.kdroiders.hustlehub.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Room entity for caching service listings locally.
+ * Portfolio images and tags are stored as JSON strings.
+ */
+@Entity(tableName = "cached_services")
+data class ServiceEntity(
+    @PrimaryKey val id: String,
+    val providerId: String,
+    val title: String,
+    val category: String,
+    val description: String,
+    val priceRange: String,
+    val averageRating: Float,
+    val reviewCount: Int,
+    val availability: String,
+    val openToBarter: Boolean,
+    val portfolioJson: String,  // JSON array of image URLs
+    val tagsJson: String,       // JSON array of tags
+    val iconUrl: String,
+    val lastUpdated: Long       // epoch ms — used for 30-min cache invalidation
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/data/local/entity/ServiceEntityMapper.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/local/entity/ServiceEntityMapper.kt
@@ -1,0 +1,58 @@
+package must.kdroiders.hustlehub.data.local.entity
+
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+import org.json.JSONArray
+
+/** Converts a cached [ServiceEntity] back to the domain [Service] model. */
+fun ServiceEntity.toDomain(): Service = Service(
+    id = id,
+    providerId = providerId,
+    title = title,
+    category = parseCategory(category),
+    description = description,
+    priceRange = priceRange,
+    portfolio = parseJsonArray(portfolioJson),
+    availability = parseAvailability(availability),
+    averageRating = averageRating,
+    reviewCount = reviewCount,
+    openToBarter = openToBarter,
+    tags = parseJsonArray(tagsJson),
+    createdAt = lastUpdated,
+    updatedAt = lastUpdated,
+    iconUrl = iconUrl
+)
+
+/** Converts a domain [Service] to a [ServiceEntity] for local storage. */
+fun Service.toEntity(now: Long = System.currentTimeMillis()): ServiceEntity = ServiceEntity(
+    id = id,
+    providerId = providerId,
+    title = title,
+    category = category.name,
+    description = description,
+    priceRange = priceRange,
+    averageRating = averageRating,
+    reviewCount = reviewCount,
+    availability = availability.name,
+    openToBarter = openToBarter,
+    portfolioJson = toJsonArray(portfolio),
+    tagsJson = toJsonArray(tags),
+    iconUrl = iconUrl,
+    lastUpdated = now
+)
+
+private fun parseCategory(name: String): ServiceCategory =
+    runCatching { ServiceCategory.valueOf(name) }.getOrDefault(ServiceCategory.OTHER)
+
+private fun parseAvailability(name: String): ServiceAvailability =
+    runCatching { ServiceAvailability.valueOf(name) }.getOrDefault(ServiceAvailability.AVAILABLE)
+
+private fun parseJsonArray(json: String): List<String> =
+    runCatching {
+        val arr = JSONArray(json)
+        List(arr.length()) { arr.getString(it) }
+    }.getOrDefault(emptyList())
+
+private fun toJsonArray(items: List<String>): String =
+    JSONArray(items).toString()

--- a/app/src/main/java/must/kdroiders/hustlehub/data/model/Service.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/model/Service.kt
@@ -1,13 +1,22 @@
 package must.kdroiders.hustlehub.data.model
 
-/**
- * Represents a service offered by a hustle provider.
- */
 data class Service(
     val id: String = "",
+    val providerId: String = "",
     val title: String = "",
-    val priceRange: String = "",
-    val isActive: Boolean = true,
+    val category: ServiceCategory = ServiceCategory.OTHER,
+    val description: String = "",
+    val priceRange: String = "",       // e.g. "300-800"
+    val portfolio: List<String> = emptyList(),  // image URLs
+    val availability: ServiceAvailability = ServiceAvailability.AVAILABLE,
+    val averageRating: Float = 0f,
+    val reviewCount: Int = 0,
+    val openToBarter: Boolean = false,
     val tags: List<String> = emptyList(),
+    val createdAt: Long = 0L,
+    val updatedAt: Long = 0L,
+    
+    // UI-specific fallback field for existing components if needed
+    // (Could be removed after fully refactoring the UI to use portfolio)
     val iconUrl: String = ""
 )

--- a/app/src/main/java/must/kdroiders/hustlehub/data/model/ServiceAvailability.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/model/ServiceAvailability.kt
@@ -1,0 +1,7 @@
+package must.kdroiders.hustlehub.data.model
+
+enum class ServiceAvailability {
+    AVAILABLE,
+    BUSY,
+    OFFLINE
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/data/model/ServiceCategory.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/model/ServiceCategory.kt
@@ -1,4 +1,4 @@
-package must.kdroiders.hustlehub.ui.features.home.domain.model
+package must.kdroiders.hustlehub.data.model
 
 enum class ServiceCategory(val label: String) {
     ALL("All"),
@@ -7,7 +7,8 @@ enum class ServiceCategory(val label: String) {
     TUTORING("Tutoring"),
     FOOD("Food"),
     TECH("Tech"),
+    FASHION("Fashion"),
     PHOTOGRAPHY("Photography"),
     DESIGN("Design"),
-    TAILORING("Tailoring")
+    OTHER("Other")
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/data/remote/ServiceApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/remote/ServiceApiService.kt
@@ -4,7 +4,7 @@ import must.kdroiders.hustlehub.core.api.ApiResponse
 import must.kdroiders.hustlehub.core.api.PageResponse
 import must.kdroiders.hustlehub.data.remote.dto.CreateServiceRequest
 import must.kdroiders.hustlehub.data.remote.dto.ServiceResponse
-import must.kdroiders.hustlehub.data.remote.dto.UpdateAvailabilityRequest
+import must.kdroiders.hustlehub.data.remote.dto.AvailabilityRequest
 import must.kdroiders.hustlehub.data.remote.dto.UpdateServiceRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -40,7 +40,7 @@ interface ServiceApiService {
     @PUT("services/{serviceId}/availability")
     suspend fun updateAvailability(
         @Path("serviceId") serviceId: String,
-        @Body request: UpdateAvailabilityRequest
+        @Body request: AvailabilityRequest
     ): ApiResponse<ServiceResponse>
 
     @GET("services/me")

--- a/app/src/main/java/must/kdroiders/hustlehub/data/remote/ServiceApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/remote/ServiceApiService.kt
@@ -1,0 +1,56 @@
+package must.kdroiders.hustlehub.data.remote
+
+import must.kdroiders.hustlehub.core.api.ApiResponse
+import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.data.remote.dto.CreateServiceRequest
+import must.kdroiders.hustlehub.data.remote.dto.ServiceResponse
+import must.kdroiders.hustlehub.data.remote.dto.UpdateAvailabilityRequest
+import must.kdroiders.hustlehub.data.remote.dto.UpdateServiceRequest
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface ServiceApiService {
+
+    @POST("services")
+    suspend fun createService(
+        @Body request: CreateServiceRequest
+    ): ApiResponse<ServiceResponse>
+
+    @GET("services/{serviceId}")
+    suspend fun getServiceById(
+        @Path("serviceId") serviceId: String
+    ): ApiResponse<ServiceResponse>
+
+    @PUT("services/{serviceId}")
+    suspend fun updateService(
+        @Path("serviceId") serviceId: String,
+        @Body request: UpdateServiceRequest
+    ): ApiResponse<ServiceResponse>
+
+    @DELETE("services/{serviceId}")
+    suspend fun deleteService(
+        @Path("serviceId") serviceId: String
+    ): ApiResponse<Unit>
+
+    @PUT("services/{serviceId}/availability")
+    suspend fun updateAvailability(
+        @Path("serviceId") serviceId: String,
+        @Body request: UpdateAvailabilityRequest
+    ): ApiResponse<ServiceResponse>
+
+    @GET("services/me")
+    suspend fun getMyServices(): ApiResponse<List<ServiceResponse>>
+
+    @GET("discovery/services")
+    suspend fun browseServices(
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 20,
+        @Query("category") category: String? = null,
+        @Query("query") query: String? = null
+    ): ApiResponse<PageResponse<ServiceResponse>>
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/data/remote/dto/ServiceDto.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/remote/dto/ServiceDto.kt
@@ -1,0 +1,42 @@
+package must.kdroiders.hustlehub.data.remote.dto
+
+data class ServiceResponse(
+    val serviceId: String,
+    val providerId: String,
+    val title: String,
+    val category: String,
+    val description: String?,
+    val priceRange: String?,
+    val portfolio: List<String>?,
+    val availability: String,
+    val averageRating: Float,
+    val reviewCount: Int,
+    val openToBarter: Boolean,
+    val tags: List<String>?,
+    val createdAt: String,
+    val updatedAt: String
+)
+
+data class CreateServiceRequest(
+    val title: String,
+    val category: String,
+    val description: String?,
+    val priceRange: String?,
+    val portfolio: List<String>,
+    val openToBarter: Boolean,
+    val tags: List<String>
+)
+
+data class UpdateServiceRequest(
+    val title: String?,
+    val category: String?,
+    val description: String?,
+    val priceRange: String?,
+    val portfolio: List<String>?,
+    val openToBarter: Boolean?,
+    val tags: List<String>?
+)
+
+data class UpdateAvailabilityRequest(
+    val availability: String
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/data/remote/dto/ServiceDto.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/remote/dto/ServiceDto.kt
@@ -6,13 +6,15 @@ data class ServiceResponse(
     val title: String,
     val category: String,
     val description: String?,
-    val priceRange: String?,
-    val portfolio: List<String>?,
+    val priceRange: String,
+    val portfolioImages: List<String>?,
     val availability: String,
-    val averageRating: Float,
+    val avgRating: Double,
     val reviewCount: Int,
     val openToBarter: Boolean,
     val tags: List<String>?,
+    val location: LocationDto?,
+    val distanceMeters: Double?,
     val createdAt: String,
     val updatedAt: String
 )
@@ -21,22 +23,30 @@ data class CreateServiceRequest(
     val title: String,
     val category: String,
     val description: String?,
-    val priceRange: String?,
-    val portfolio: List<String>,
+    val minPrice: Int,
+    val maxPrice: Int,
     val openToBarter: Boolean,
-    val tags: List<String>
+    val tags: List<String>,
+    val location: LocationDto? = null
 )
 
 data class UpdateServiceRequest(
     val title: String?,
     val category: String?,
     val description: String?,
-    val priceRange: String?,
-    val portfolio: List<String>?,
+    val minPrice: Int?,
+    val maxPrice: Int?,
     val openToBarter: Boolean?,
-    val tags: List<String>?
+    val tags: List<String>?,
+    val location: LocationDto? = null
 )
 
-data class UpdateAvailabilityRequest(
+data class AvailabilityRequest(
     val availability: String
+)
+
+data class LocationDto(
+    val lat: Double?,
+    val lng: Double?,
+    val label: String?
 )

--- a/app/src/main/java/must/kdroiders/hustlehub/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/repository/ServiceRepositoryImpl.kt
@@ -9,7 +9,7 @@ import must.kdroiders.hustlehub.data.model.ServiceCategory
 import must.kdroiders.hustlehub.data.remote.ServiceApiService
 import must.kdroiders.hustlehub.data.remote.dto.CreateServiceRequest
 import must.kdroiders.hustlehub.data.remote.dto.ServiceResponse
-import must.kdroiders.hustlehub.data.remote.dto.UpdateAvailabilityRequest
+import must.kdroiders.hustlehub.data.remote.dto.AvailabilityRequest
 import must.kdroiders.hustlehub.data.remote.dto.UpdateServiceRequest
 import must.kdroiders.hustlehub.domain.repository.ServiceRepository
 
@@ -21,8 +21,8 @@ class ServiceRepositoryImpl(
         title: String,
         category: ServiceCategory,
         description: String?,
-        priceRange: String?,
-        portfolio: List<String>,
+        minPrice: Int,
+        maxPrice: Int,
         openToBarter: Boolean,
         tags: List<String>
     ): Result<Service> = withContext(Dispatchers.IO) {
@@ -31,8 +31,8 @@ class ServiceRepositoryImpl(
                 title = title,
                 category = category.name,
                 description = description,
-                priceRange = priceRange,
-                portfolio = portfolio,
+                minPrice = minPrice,
+                maxPrice = maxPrice,
                 openToBarter = openToBarter,
                 tags = tags
             )
@@ -65,8 +65,8 @@ class ServiceRepositoryImpl(
         title: String?,
         category: ServiceCategory?,
         description: String?,
-        priceRange: String?,
-        portfolio: List<String>?,
+        minPrice: Int?,
+        maxPrice: Int?,
         openToBarter: Boolean?,
         tags: List<String>?
     ): Result<Service> = withContext(Dispatchers.IO) {
@@ -75,8 +75,8 @@ class ServiceRepositoryImpl(
                 title = title,
                 category = category?.name,
                 description = description,
-                priceRange = priceRange,
-                portfolio = portfolio,
+                minPrice = minPrice,
+                maxPrice = maxPrice,
                 openToBarter = openToBarter,
                 tags = tags
             )
@@ -109,7 +109,7 @@ class ServiceRepositoryImpl(
         availability: ServiceAvailability
     ): Result<Service> = withContext(Dispatchers.IO) {
         try {
-            val request = UpdateAvailabilityRequest(availability = availability.name)
+            val request = AvailabilityRequest(availability = availability.name)
             val response = apiService.updateAvailability(serviceId, request)
             if (response.success && response.data != null) {
                 Result.success(response.data.toDomainModel())
@@ -175,17 +175,17 @@ private fun ServiceResponse.toDomainModel(): Service {
         title = this.title,
         category = parseCategory(this.category),
         description = this.description ?: "",
-        priceRange = this.priceRange ?: "",
-        portfolio = this.portfolio ?: emptyList(),
+        priceRange = this.priceRange,
+        portfolio = this.portfolioImages ?: emptyList(),
         availability = parseAvailability(this.availability),
-        averageRating = this.averageRating,
+        averageRating = this.avgRating.toFloat(),
         reviewCount = this.reviewCount,
         openToBarter = this.openToBarter,
         tags = this.tags ?: emptyList(),
         // Simple mapping, proper date parsing could be added later
         createdAt = 0L, 
         updatedAt = 0L,
-        iconUrl = this.portfolio?.firstOrNull() ?: ""
+        iconUrl = this.portfolioImages?.firstOrNull() ?: ""
     )
 }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/repository/ServiceRepositoryImpl.kt
@@ -15,6 +15,7 @@ import must.kdroiders.hustlehub.data.remote.dto.CreateServiceRequest
 import must.kdroiders.hustlehub.data.remote.dto.ServiceResponse
 import must.kdroiders.hustlehub.data.remote.dto.UpdateServiceRequest
 import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import must.kdroiders.hustlehub.core.auth.AuthManager
 import timber.log.Timber
 
 // Cache TTL — entries older than this are evicted before each read
@@ -22,7 +23,8 @@ private const val CACHE_TTL_MS = 30 * 60 * 1_000L
 
 class ServiceRepositoryImpl(
     private val apiService: ServiceApiService,
-    private val serviceDao: ServiceDao
+    private val serviceDao: ServiceDao,
+    private val authManager: AuthManager
 ) : ServiceRepository {
 
     // Create
@@ -176,9 +178,10 @@ class ServiceRepositoryImpl(
                     Result.failure(Exception(response.message))
                 }
             } catch (e: Exception) {
-                // Network unavailable — return whatever is in cache
+                // Network unavailable — return only the current user's services from cache
                 Timber.w(e, "getMyServices network miss, serving cache")
-                val cached = serviceDao.getAllServices()
+                val currentUser = authManager.currentUser()?.uid ?: ""
+                val cached = serviceDao.getServicesByProvider(currentUser)
                 if (cached.isNotEmpty()) {
                     Result.success(cached.map { it.toDomain() })
                 } else {

--- a/app/src/main/java/must/kdroiders/hustlehub/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/repository/ServiceRepositoryImpl.kt
@@ -1,0 +1,206 @@
+package must.kdroiders.hustlehub.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+import must.kdroiders.hustlehub.data.remote.ServiceApiService
+import must.kdroiders.hustlehub.data.remote.dto.CreateServiceRequest
+import must.kdroiders.hustlehub.data.remote.dto.ServiceResponse
+import must.kdroiders.hustlehub.data.remote.dto.UpdateAvailabilityRequest
+import must.kdroiders.hustlehub.data.remote.dto.UpdateServiceRequest
+import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+
+class ServiceRepositoryImpl(
+    private val apiService: ServiceApiService
+) : ServiceRepository {
+
+    override suspend fun createService(
+        title: String,
+        category: ServiceCategory,
+        description: String?,
+        priceRange: String?,
+        portfolio: List<String>,
+        openToBarter: Boolean,
+        tags: List<String>
+    ): Result<Service> = withContext(Dispatchers.IO) {
+        try {
+            val request = CreateServiceRequest(
+                title = title,
+                category = category.name,
+                description = description,
+                priceRange = priceRange,
+                portfolio = portfolio,
+                openToBarter = openToBarter,
+                tags = tags
+            )
+            val response = apiService.createService(request)
+            if (response.success && response.data != null) {
+                Result.success(response.data.toDomainModel())
+            } else {
+                Result.failure(Exception(response.message))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getServiceById(serviceId: String): Result<Service> = withContext(Dispatchers.IO) {
+        try {
+            val response = apiService.getServiceById(serviceId)
+            if (response.success && response.data != null) {
+                Result.success(response.data.toDomainModel())
+            } else {
+                Result.failure(Exception(response.message))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun updateService(
+        serviceId: String,
+        title: String?,
+        category: ServiceCategory?,
+        description: String?,
+        priceRange: String?,
+        portfolio: List<String>?,
+        openToBarter: Boolean?,
+        tags: List<String>?
+    ): Result<Service> = withContext(Dispatchers.IO) {
+        try {
+            val request = UpdateServiceRequest(
+                title = title,
+                category = category?.name,
+                description = description,
+                priceRange = priceRange,
+                portfolio = portfolio,
+                openToBarter = openToBarter,
+                tags = tags
+            )
+            val response = apiService.updateService(serviceId, request)
+            if (response.success && response.data != null) {
+                Result.success(response.data.toDomainModel())
+            } else {
+                Result.failure(Exception(response.message))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteService(serviceId: String): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            val response = apiService.deleteService(serviceId)
+            if (response.success) {
+                Result.success(Unit)
+            } else {
+                Result.failure(Exception(response.message))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun updateAvailability(
+        serviceId: String,
+        availability: ServiceAvailability
+    ): Result<Service> = withContext(Dispatchers.IO) {
+        try {
+            val request = UpdateAvailabilityRequest(availability = availability.name)
+            val response = apiService.updateAvailability(serviceId, request)
+            if (response.success && response.data != null) {
+                Result.success(response.data.toDomainModel())
+            } else {
+                Result.failure(Exception(response.message))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getMyServices(): Result<List<Service>> = withContext(Dispatchers.IO) {
+        try {
+            val response = apiService.getMyServices()
+            if (response.success && response.data != null) {
+                Result.success(response.data.map { it.toDomainModel() })
+            } else {
+                Result.failure(Exception(response.message))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun browseServices(
+        page: Int,
+        size: Int,
+        category: ServiceCategory?,
+        query: String?
+    ): Result<PageResponse<Service>> = withContext(Dispatchers.IO) {
+        try {
+            // ALL means no category filter
+            val categoryStr = if (category == ServiceCategory.ALL) null else category?.name
+            val response = apiService.browseServices(
+                page = page,
+                size = size,
+                category = categoryStr,
+                query = query
+            )
+            if (response.success && response.data != null) {
+                val pageData = response.data
+                val mappedPage = PageResponse(
+                    content = pageData.content.map { it.toDomainModel() },
+                    page = pageData.page,
+                    size = pageData.size,
+                    totalElements = pageData.totalElements,
+                    totalPages = pageData.totalPages
+                )
+                Result.success(mappedPage)
+            } else {
+                Result.failure(Exception(response.message))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+
+private fun ServiceResponse.toDomainModel(): Service {
+    return Service(
+        id = this.serviceId,
+        providerId = this.providerId,
+        title = this.title,
+        category = parseCategory(this.category),
+        description = this.description ?: "",
+        priceRange = this.priceRange ?: "",
+        portfolio = this.portfolio ?: emptyList(),
+        availability = parseAvailability(this.availability),
+        averageRating = this.averageRating,
+        reviewCount = this.reviewCount,
+        openToBarter = this.openToBarter,
+        tags = this.tags ?: emptyList(),
+        // Simple mapping, proper date parsing could be added later
+        createdAt = 0L, 
+        updatedAt = 0L,
+        iconUrl = this.portfolio?.firstOrNull() ?: ""
+    )
+}
+
+private fun parseCategory(name: String): ServiceCategory {
+    return try {
+        ServiceCategory.valueOf(name)
+    } catch (e: IllegalArgumentException) {
+        ServiceCategory.OTHER
+    }
+}
+
+private fun parseAvailability(name: String): ServiceAvailability {
+    return try {
+        ServiceAvailability.valueOf(name)
+    } catch (e: IllegalArgumentException) {
+        ServiceAvailability.AVAILABLE
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/repository/ServiceRepositoryImpl.kt
@@ -3,19 +3,29 @@ package must.kdroiders.hustlehub.data.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.data.local.dao.ServiceDao
+import must.kdroiders.hustlehub.data.local.entity.toDomain
+import must.kdroiders.hustlehub.data.local.entity.toEntity
 import must.kdroiders.hustlehub.data.model.Service
 import must.kdroiders.hustlehub.data.model.ServiceAvailability
 import must.kdroiders.hustlehub.data.model.ServiceCategory
 import must.kdroiders.hustlehub.data.remote.ServiceApiService
+import must.kdroiders.hustlehub.data.remote.dto.AvailabilityRequest
 import must.kdroiders.hustlehub.data.remote.dto.CreateServiceRequest
 import must.kdroiders.hustlehub.data.remote.dto.ServiceResponse
-import must.kdroiders.hustlehub.data.remote.dto.AvailabilityRequest
 import must.kdroiders.hustlehub.data.remote.dto.UpdateServiceRequest
 import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import timber.log.Timber
+
+// Cache TTL — entries older than this are evicted before each read
+private const val CACHE_TTL_MS = 30 * 60 * 1_000L
 
 class ServiceRepositoryImpl(
-    private val apiService: ServiceApiService
+    private val apiService: ServiceApiService,
+    private val serviceDao: ServiceDao
 ) : ServiceRepository {
+
+    // Create
 
     override suspend fun createService(
         title: String,
@@ -38,7 +48,10 @@ class ServiceRepositoryImpl(
             )
             val response = apiService.createService(request)
             if (response.success && response.data != null) {
-                Result.success(response.data.toDomainModel())
+                val service = response.data.toDomainModel()
+                // Write-through: cache the newly created service immediately
+                serviceDao.upsert(service.toEntity())
+                Result.success(service)
             } else {
                 Result.failure(Exception(response.message))
             }
@@ -47,18 +60,29 @@ class ServiceRepositoryImpl(
         }
     }
 
-    override suspend fun getServiceById(serviceId: String): Result<Service> = withContext(Dispatchers.IO) {
-        try {
-            val response = apiService.getServiceById(serviceId)
-            if (response.success && response.data != null) {
-                Result.success(response.data.toDomainModel())
-            } else {
-                Result.failure(Exception(response.message))
+    // Read single
+
+    override suspend fun getServiceById(serviceId: String): Result<Service> =
+        withContext(Dispatchers.IO) {
+            try {
+                val response = apiService.getServiceById(serviceId)
+                if (response.success && response.data != null) {
+                    val service = response.data.toDomainModel()
+                    serviceDao.upsert(service.toEntity())
+                    Result.success(service)
+                } else {
+                    Result.failure(Exception(response.message))
+                }
+            } catch (e: Exception) {
+                // Network unavailable — try cache
+                Timber.w(e, "getServiceById network miss, checking cache")
+                val cached = serviceDao.getServiceById(serviceId)
+                if (cached != null) Result.success(cached.toDomain())
+                else Result.failure(e)
             }
-        } catch (e: Exception) {
-            Result.failure(e)
         }
-    }
+
+    // Update
 
     override suspend fun updateService(
         serviceId: String,
@@ -82,7 +106,9 @@ class ServiceRepositoryImpl(
             )
             val response = apiService.updateService(serviceId, request)
             if (response.success && response.data != null) {
-                Result.success(response.data.toDomainModel())
+                val service = response.data.toDomainModel()
+                serviceDao.upsert(service.toEntity())
+                Result.success(service)
             } else {
                 Result.failure(Exception(response.message))
             }
@@ -91,18 +117,25 @@ class ServiceRepositoryImpl(
         }
     }
 
-    override suspend fun deleteService(serviceId: String): Result<Unit> = withContext(Dispatchers.IO) {
-        try {
-            val response = apiService.deleteService(serviceId)
-            if (response.success) {
-                Result.success(Unit)
-            } else {
-                Result.failure(Exception(response.message))
+    // Delete
+
+    override suspend fun deleteService(serviceId: String): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            try {
+                val response = apiService.deleteService(serviceId)
+                if (response.success) {
+                    // Remove from cache immediately on confirmed delete
+                    serviceDao.deleteById(serviceId)
+                    Result.success(Unit)
+                } else {
+                    Result.failure(Exception(response.message))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
             }
-        } catch (e: Exception) {
-            Result.failure(e)
         }
-    }
+
+    // Availability toggle
 
     override suspend fun updateAvailability(
         serviceId: String,
@@ -112,7 +145,9 @@ class ServiceRepositoryImpl(
             val request = AvailabilityRequest(availability = availability.name)
             val response = apiService.updateAvailability(serviceId, request)
             if (response.success && response.data != null) {
-                Result.success(response.data.toDomainModel())
+                val service = response.data.toDomainModel()
+                serviceDao.upsert(service.toEntity())
+                Result.success(service)
             } else {
                 Result.failure(Exception(response.message))
             }
@@ -121,18 +156,38 @@ class ServiceRepositoryImpl(
         }
     }
 
-    override suspend fun getMyServices(): Result<List<Service>> = withContext(Dispatchers.IO) {
-        try {
-            val response = apiService.getMyServices()
-            if (response.success && response.data != null) {
-                Result.success(response.data.map { it.toDomainModel() })
-            } else {
-                Result.failure(Exception(response.message))
+    // My services — cache-first
+
+    override suspend fun getMyServices(): Result<List<Service>> =
+        withContext(Dispatchers.IO) {
+            val now = System.currentTimeMillis()
+
+            // Evict anything older than 30 minutes before serving cache
+            serviceDao.deleteStaleEntries(now - CACHE_TTL_MS)
+
+            try {
+                val response = apiService.getMyServices()
+                if (response.success && response.data != null) {
+                    val services = response.data.map { it.toDomainModel() }
+                    // Refresh cache with latest data
+                    serviceDao.upsertAll(services.map { it.toEntity(now) })
+                    Result.success(services)
+                } else {
+                    Result.failure(Exception(response.message))
+                }
+            } catch (e: Exception) {
+                // Network unavailable — return whatever is in cache
+                Timber.w(e, "getMyServices network miss, serving cache")
+                val cached = serviceDao.getAllServices()
+                if (cached.isNotEmpty()) {
+                    Result.success(cached.map { it.toDomain() })
+                } else {
+                    Result.failure(e)
+                }
             }
-        } catch (e: Exception) {
-            Result.failure(e)
         }
-    }
+
+    // Browse / discovery — cache-first
 
     override suspend fun browseServices(
         page: Int,
@@ -140,8 +195,10 @@ class ServiceRepositoryImpl(
         category: ServiceCategory?,
         query: String?
     ): Result<PageResponse<Service>> = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        serviceDao.deleteStaleEntries(now - CACHE_TTL_MS)
+
         try {
-            // ALL means no category filter
             val categoryStr = if (category == ServiceCategory.ALL) null else category?.name
             val response = apiService.browseServices(
                 page = page,
@@ -151,56 +208,63 @@ class ServiceRepositoryImpl(
             )
             if (response.success && response.data != null) {
                 val pageData = response.data
-                val mappedPage = PageResponse(
-                    content = pageData.content.map { it.toDomainModel() },
-                    page = pageData.page,
-                    size = pageData.size,
-                    totalElements = pageData.totalElements,
-                    totalPages = pageData.totalPages
+                val services = pageData.content.map { it.toDomainModel() }
+                // Cache the discovered services (page 0 only to avoid stale pagination)
+                if (page == 0) serviceDao.upsertAll(services.map { it.toEntity(now) })
+                Result.success(
+                    PageResponse(
+                        content = services,
+                        page = pageData.page,
+                        size = pageData.size,
+                        totalElements = pageData.totalElements,
+                        totalPages = pageData.totalPages
+                    )
                 )
-                Result.success(mappedPage)
             } else {
                 Result.failure(Exception(response.message))
             }
         } catch (e: Exception) {
-            Result.failure(e)
+            // Serve cache for first page only
+            Timber.w(e, "browseServices network miss, serving cache (page $page)")
+            if (page == 0) {
+                val cached = serviceDao.getAllServices()
+                if (cached.isNotEmpty()) {
+                    val services = cached.map { it.toDomain() }
+                    Result.success(
+                        PageResponse(
+                            content = services,
+                            page = 0,
+                            size = services.size,
+                            totalElements = services.size.toLong(),
+                            totalPages = 1
+                        )
+                    )
+                } else Result.failure(e)
+            } else {
+                Result.failure(e)
+            }
         }
     }
 }
 
-private fun ServiceResponse.toDomainModel(): Service {
-    return Service(
-        id = this.serviceId,
-        providerId = this.providerId,
-        title = this.title,
-        category = parseCategory(this.category),
-        description = this.description ?: "",
-        priceRange = this.priceRange,
-        portfolio = this.portfolioImages ?: emptyList(),
-        availability = parseAvailability(this.availability),
-        averageRating = this.avgRating.toFloat(),
-        reviewCount = this.reviewCount,
-        openToBarter = this.openToBarter,
-        tags = this.tags ?: emptyList(),
-        // Simple mapping, proper date parsing could be added later
-        createdAt = 0L, 
-        updatedAt = 0L,
-        iconUrl = this.portfolioImages?.firstOrNull() ?: ""
-    )
-}
+// DTO → Domain mapper
 
-private fun parseCategory(name: String): ServiceCategory {
-    return try {
-        ServiceCategory.valueOf(name)
-    } catch (e: IllegalArgumentException) {
-        ServiceCategory.OTHER
-    }
-}
-
-private fun parseAvailability(name: String): ServiceAvailability {
-    return try {
-        ServiceAvailability.valueOf(name)
-    } catch (e: IllegalArgumentException) {
-        ServiceAvailability.AVAILABLE
-    }
-}
+private fun ServiceResponse.toDomainModel(): Service = Service(
+    id = serviceId,
+    providerId = providerId,
+    title = title,
+    category = runCatching { ServiceCategory.valueOf(category) }.getOrDefault(ServiceCategory.OTHER),
+    description = description ?: "",
+    priceRange = priceRange,
+    portfolio = portfolioImages ?: emptyList(),
+    availability = runCatching {
+        ServiceAvailability.valueOf(availability)
+    }.getOrDefault(ServiceAvailability.AVAILABLE),
+    averageRating = avgRating.toFloat(),
+    reviewCount = reviewCount,
+    openToBarter = openToBarter,
+    tags = tags ?: emptyList(),
+    createdAt = 0L,
+    updatedAt = 0L,
+    iconUrl = portfolioImages?.firstOrNull() ?: ""
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -21,6 +21,9 @@ import must.kdroiders.hustlehub.data.remote.MediaApiService
 import must.kdroiders.hustlehub.datastore.UserPreferences
 import must.kdroiders.hustlehub.datastore.dataStore
 import must.kdroiders.hustlehub.core.auth.AuthManager
+import must.kdroiders.hustlehub.data.remote.ServiceApiService
+import must.kdroiders.hustlehub.data.repository.ServiceRepositoryImpl
+import must.kdroiders.hustlehub.domain.repository.ServiceRepository
 import timber.log.Timber
 import javax.inject.Singleton
 
@@ -75,6 +78,14 @@ object AppModule {
         mediaApiService: MediaApiService
     ): UserRepository {
         return UserRepositoryImpl(context, authApiService, userApiService, mediaApiService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideServiceRepository(
+        serviceApiService: ServiceApiService
+    ): ServiceRepository {
+        return ServiceRepositoryImpl(serviceApiService)
     }
 }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -3,12 +3,15 @@ package must.kdroiders.hustlehub.di
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.room.Room
 import com.google.firebase.auth.FirebaseAuth
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import must.kdroiders.hustlehub.data.local.AppDatabase
+import must.kdroiders.hustlehub.data.local.dao.ServiceDao
 import must.kdroiders.hustlehub.data.model.User
 import must.kdroiders.hustlehub.ui.features.auth.domain.repository.AuthRepository
 import must.kdroiders.hustlehub.ui.features.auth.data.repository.AuthRepositoryImpl
@@ -82,10 +85,25 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideAppDatabase(
+        @ApplicationContext context: Context
+    ): AppDatabase = Room.databaseBuilder(
+        context.applicationContext,
+        AppDatabase::class.java,
+        "hustlehub.db"
+    ).build()
+
+    @Provides
+    @Singleton
+    fun provideServiceDao(db: AppDatabase): ServiceDao = db.serviceDao()
+
+    @Provides
+    @Singleton
     fun provideServiceRepository(
-        serviceApiService: ServiceApiService
+        serviceApiService: ServiceApiService,
+        serviceDao: ServiceDao
     ): ServiceRepository {
-        return ServiceRepositoryImpl(serviceApiService)
+        return ServiceRepositoryImpl(serviceApiService, serviceDao)
     }
 }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -101,9 +101,10 @@ object AppModule {
     @Singleton
     fun provideServiceRepository(
         serviceApiService: ServiceApiService,
-        serviceDao: ServiceDao
+        serviceDao: ServiceDao,
+        authManager: AuthManager
     ): ServiceRepository {
-        return ServiceRepositoryImpl(serviceApiService, serviceDao)
+        return ServiceRepositoryImpl(serviceApiService, serviceDao, authManager)
     }
 }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/di/NetworkModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/NetworkModule.kt
@@ -10,6 +10,7 @@ import must.kdroiders.hustlehub.core.api.AuthInterceptor
 import must.kdroiders.hustlehub.core.api.TokenAuthenticator
 import must.kdroiders.hustlehub.core.auth.AuthManager
 import must.kdroiders.hustlehub.data.remote.MediaApiService
+import must.kdroiders.hustlehub.data.remote.ServiceApiService
 import must.kdroiders.hustlehub.ui.features.auth.data.remote.AuthApiService
 import must.kdroiders.hustlehub.data.remote.UserApiService
 import okhttp3.OkHttpClient
@@ -78,5 +79,11 @@ object NetworkModule {
     @Singleton
     fun provideMediaApiService(retrofit: Retrofit): MediaApiService {
         return retrofit.create(MediaApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideServiceApiService(retrofit: Retrofit): ServiceApiService {
+        return retrofit.create(ServiceApiService::class.java)
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/domain/repository/ServiceRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/domain/repository/ServiceRepository.kt
@@ -6,7 +6,7 @@ import must.kdroiders.hustlehub.data.model.ServiceAvailability
 import must.kdroiders.hustlehub.data.model.ServiceCategory
 
 interface ServiceRepository {
-    
+
     suspend fun createService(
         title: String,
         category: ServiceCategory,

--- a/app/src/main/java/must/kdroiders/hustlehub/domain/repository/ServiceRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/domain/repository/ServiceRepository.kt
@@ -1,0 +1,48 @@
+package must.kdroiders.hustlehub.domain.repository
+
+import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+
+interface ServiceRepository {
+    
+    suspend fun createService(
+        title: String,
+        category: ServiceCategory,
+        description: String?,
+        priceRange: String?,
+        portfolio: List<String>,
+        openToBarter: Boolean,
+        tags: List<String>
+    ): Result<Service>
+
+    suspend fun getServiceById(serviceId: String): Result<Service>
+
+    suspend fun updateService(
+        serviceId: String,
+        title: String? = null,
+        category: ServiceCategory? = null,
+        description: String? = null,
+        priceRange: String? = null,
+        portfolio: List<String>? = null,
+        openToBarter: Boolean? = null,
+        tags: List<String>? = null
+    ): Result<Service>
+
+    suspend fun deleteService(serviceId: String): Result<Unit>
+
+    suspend fun updateAvailability(
+        serviceId: String,
+        availability: ServiceAvailability
+    ): Result<Service>
+
+    suspend fun getMyServices(): Result<List<Service>>
+
+    suspend fun browseServices(
+        page: Int = 0,
+        size: Int = 20,
+        category: ServiceCategory? = null,
+        query: String? = null
+    ): Result<PageResponse<Service>>
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/domain/repository/ServiceRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/domain/repository/ServiceRepository.kt
@@ -11,8 +11,8 @@ interface ServiceRepository {
         title: String,
         category: ServiceCategory,
         description: String?,
-        priceRange: String?,
-        portfolio: List<String>,
+        minPrice: Int,
+        maxPrice: Int,
         openToBarter: Boolean,
         tags: List<String>
     ): Result<Service>
@@ -24,8 +24,8 @@ interface ServiceRepository {
         title: String? = null,
         category: ServiceCategory? = null,
         description: String? = null,
-        priceRange: String? = null,
-        portfolio: List<String>? = null,
+        minPrice: Int? = null,
+        maxPrice: Int? = null,
         openToBarter: Boolean? = null,
         tags: List<String>? = null
     ): Result<Service>

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -37,6 +37,7 @@ import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.LoginVie
 import must.kdroiders.hustlehub.ui.features.portfolio.PortfolioUploadScreen
 import must.kdroiders.hustlehub.ui.features.profilesetup.presentation.view.ProfileSetupScreen
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.CreateServiceScreen
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.MyServicesScreen
 import must.kdroiders.hustlehub.ui.features.settings.presentation.view.SettingsScreen
 
 /**
@@ -205,7 +206,8 @@ fun HustleHubNav(
                     onNavigateToPortfolio = { backstack.add(PortfolioUpload) },
                     onNavigateToProfileSetup = { backstack.add(ProfileSetup) },
                     onNavigateToSettings = { backstack.add(Settings) },
-                    onNavigateToCreateService = { backstack.add(CreateService) }
+                    onNavigateToCreateService = { backstack.add(CreateService()) },
+                    onNavigateToMyServices = { backstack.add(MyServices) }
                 )
             }
 
@@ -220,11 +222,21 @@ fun HustleHubNav(
                 )
             }
 
-            // Create service
-            entry<CreateService> {
+            // Create / Edit service
+            entry<CreateService> { key ->
                 CreateServiceScreen(
+                    serviceId = key.serviceId,
                     onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
                     onSuccess = { if (backstack.size > 1) backstack.remove(backstack.last()) }
+                )
+            }
+
+            // My services management
+            entry<MyServices> {
+                MyServicesScreen(
+                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    onCreateService = { backstack.add(CreateService()) },
+                    onEditService = { serviceId -> backstack.add(CreateService(serviceId = serviceId)) }
                 )
             }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -36,6 +36,7 @@ import must.kdroiders.hustlehub.ui.features.auth.presentation.view.SignUpScreen
 import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.LoginViewModel
 import must.kdroiders.hustlehub.ui.features.portfolio.PortfolioUploadScreen
 import must.kdroiders.hustlehub.ui.features.profilesetup.presentation.view.ProfileSetupScreen
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.CreateServiceScreen
 import must.kdroiders.hustlehub.ui.features.settings.presentation.view.SettingsScreen
 
 /**
@@ -203,7 +204,8 @@ fun HustleHubNav(
                 MainShellScreen(
                     onNavigateToPortfolio = { backstack.add(PortfolioUpload) },
                     onNavigateToProfileSetup = { backstack.add(ProfileSetup) },
-                    onNavigateToSettings = { backstack.add(Settings) }
+                    onNavigateToSettings = { backstack.add(Settings) },
+                    onNavigateToCreateService = { backstack.add(CreateService) }
                 )
             }
 
@@ -215,6 +217,14 @@ fun HustleHubNav(
             entry<Settings> {
                 SettingsScreen(
                     onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) }
+                )
+            }
+
+            // Create service
+            entry<CreateService> {
+                CreateServiceScreen(
+                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    onSuccess = { if (backstack.size > 1) backstack.remove(backstack.last()) }
                 )
             }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
@@ -79,6 +79,13 @@ data class ChatDetail(val chatId: String) : NavKey
 @Serializable
 data object Settings : NavKey
 
-/** Create a new service listing. */
+/**
+ * Create or edit a service listing.
+ * When [serviceId] is provided the screen loads existing data for editing.
+ */
 @Serializable
-data object CreateService : NavKey
+data class CreateService(val serviceId: String? = null) : NavKey
+
+/** Full-screen management list of the current user's own services. */
+@Serializable
+data object MyServices : NavKey

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
@@ -78,3 +78,7 @@ data class ChatDetail(val chatId: String) : NavKey
 /** App settings screen — pushed from the Profile tab header. */
 @Serializable
 data object Settings : NavKey
+
+/** Create a new service listing. */
+@Serializable
+data object CreateService : NavKey

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
@@ -38,6 +38,7 @@ fun MainShellScreen(
     onNavigateToPortfolio: () -> Unit = {},
     onNavigateToProfileSetup: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
+    onNavigateToCreateService: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val innerBackstack = rememberNavBackStack(BottomHome)
@@ -72,7 +73,7 @@ fun MainShellScreen(
                 entry<BottomProfile> {
                     ProfileScreen(
                         onEditClick = onNavigateToProfileSetup,
-                        onAddNewServiceClick = onNavigateToPortfolio,
+                        onAddNewServiceClick = onNavigateToCreateService,
                         onSettingsClick = onNavigateToSettings
                     )
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
@@ -39,6 +39,7 @@ fun MainShellScreen(
     onNavigateToProfileSetup: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
     onNavigateToCreateService: () -> Unit = {},
+    onNavigateToMyServices: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val innerBackstack = rememberNavBackStack(BottomHome)
@@ -74,6 +75,7 @@ fun MainShellScreen(
                     ProfileScreen(
                         onEditClick = onNavigateToProfileSetup,
                         onAddNewServiceClick = onNavigateToCreateService,
+                        onManageServicesClick = onNavigateToMyServices,
                         onSettingsClick = onNavigateToSettings
                     )
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/model/TopHustler.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/model/TopHustler.kt
@@ -1,5 +1,7 @@
 package must.kdroiders.hustlehub.ui.features.home.domain.model
 
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+
 data class TopHustler(
     val id: String,
     val providerName: String,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/usecase/BrowseServicesUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/usecase/BrowseServicesUseCase.kt
@@ -1,0 +1,19 @@
+package must.kdroiders.hustlehub.ui.features.home.domain.usecase
+
+import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import javax.inject.Inject
+
+class BrowseServicesUseCase @Inject constructor(
+    private val repository: ServiceRepository
+) {
+    suspend operator fun invoke(
+        page: Int = 0,
+        size: Int = 10,
+        category: ServiceCategory? = null,
+        query: String? = null
+    ): Result<PageResponse<Service>> =
+        repository.browseServices(page = page, size = size, category = category, query = query)
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/CategoryChipRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/CategoryChipRow.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import must.kdroiders.hustlehub.ui.features.home.domain.model.ServiceCategory
+import must.kdroiders.hustlehub.data.model.ServiceCategory
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/EmptyServicesView.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/EmptyServicesView.kt
@@ -1,0 +1,51 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptyServicesView(
+    message: String = "No services found",
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Default.SearchOff,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "Try a different category or search term.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/ServiceCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/ServiceCard.kt
@@ -1,0 +1,150 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
+import must.kdroiders.hustlehub.ui.theme.HustleOfflineGray
+import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
+
+@Composable
+fun ServiceCard(
+    service: Service,
+    onClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .clickable(onClick = onClick)
+            .padding(bottom = 12.dp)
+    ) {
+        // Thumbnail image
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f / 9f)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            val imageUrl = service.portfolio.firstOrNull() ?: service.iconUrl
+            if (imageUrl.isNotBlank()) {
+                AsyncImage(
+                    model = imageUrl,
+                    contentDescription = service.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            // Availability badge overlay
+            AvailabilityBadge(
+                availability = service.availability,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+            )
+        }
+
+        Spacer(Modifier.height(10.dp))
+
+        Column(modifier = Modifier.padding(horizontal = 12.dp)) {
+            // Title
+            Text(
+                text = service.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            // Rating + review count
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Star,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(Modifier.width(3.dp))
+                Text(
+                    text = if (service.averageRating > 0f)
+                        "${"%.1f".format(service.averageRating)} (${service.reviewCount})"
+                    else "New",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Spacer(Modifier.height(4.dp))
+
+            // Price range
+            Text(
+                text = service.priceRange,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 12.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun AvailabilityBadge(
+    availability: ServiceAvailability,
+    modifier: Modifier = Modifier
+) {
+    val (label, color) = when (availability) {
+        ServiceAvailability.AVAILABLE -> "Available" to HustleActiveGreen
+        ServiceAvailability.BUSY -> "Busy" to HustleWarningAmber
+        ServiceAvailability.OFFLINE -> "Offline" to HustleOfflineGray
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(color.copy(alpha = 0.9f))
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = label,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.surface
+        )
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/ServiceCardShimmer.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/ServiceCardShimmer.kt
@@ -1,0 +1,113 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ServiceCardShimmer(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val translateX by transition.animateFloat(
+        initialValue = -300f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1000),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmer_x"
+    )
+
+    val shimmerColors = listOf(
+        MaterialTheme.colorScheme.surfaceVariant,
+        MaterialTheme.colorScheme.surface,
+        MaterialTheme.colorScheme.surfaceVariant
+    )
+
+    val brush = Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset(translateX, 0f),
+        end = Offset(translateX + 300f, 300f)
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        // Image placeholder
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(140.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(brush)
+        )
+        // Provider name placeholder
+        Box(
+            modifier = Modifier
+                .width(100.dp)
+                .height(12.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(brush)
+        )
+        // Title placeholder
+        Box(
+            modifier = Modifier
+                .width(160.dp)
+                .height(14.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(brush)
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            // Rating placeholder
+            Box(
+                modifier = Modifier
+                    .width(60.dp)
+                    .height(12.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(brush)
+            )
+            // Price placeholder
+            Box(
+                modifier = Modifier
+                    .width(80.dp)
+                    .height(12.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(brush)
+            )
+        }
+        // Badge placeholder
+        Box(
+            modifier = Modifier
+                .width(70.dp)
+                .height(20.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(brush)
+        )
+        Spacer(Modifier.height(4.dp))
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/TopHustlersRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/TopHustlersRow.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import must.kdroiders.hustlehub.ui.features.home.domain.model.ServiceCategory
+import must.kdroiders.hustlehub.data.model.ServiceCategory
 import must.kdroiders.hustlehub.ui.features.home.domain.model.TopHustler
 import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -58,11 +58,16 @@ fun HomeScreen(
         derivedStateOf {
             val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
             val totalItems = listState.layoutInfo.totalItemsCount
-            lastVisible >= totalItems - 3
+            // Gate loading more on common pagination conditions
+            lastVisible >= totalItems - 3 &&
+                !state.isLoadingServices &&
+                !state.isLoadingMore &&
+                state.hasMorePages &&
+                state.services.isNotEmpty()
         }
     }
 
-    LaunchedEffect(shouldLoadMore) {
+    LaunchedEffect(listState) {
         snapshotFlow { shouldLoadMore }
             .distinctUntilChanged()
             .collect { atEnd ->

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -1,148 +1,196 @@
 package must.kdroiders.hustlehub.ui.features.home.presentation.view
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import must.kdroiders.hustlehub.sharedComposables.SectionHeader
-import must.kdroiders.hustlehub.ui.features.home.presentation.components.AvailableNowGrid
-import must.kdroiders.hustlehub.ui.features.home.presentation.components.AvailableNowHeader
+import kotlinx.coroutines.flow.distinctUntilChanged
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.CategoryChipRow
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.EmptyServicesView
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.HomeSearchBar
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.HomeTopBar
-import must.kdroiders.hustlehub.ui.features.home.presentation.components.TopHustlersRow
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCard
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCardShimmer
 import must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel.HomeViewModel
-import must.kdroiders.hustlehub.ui.theme.HustleHubTheme
 
-/**
- * HomeScreen — Discovery Feed
- *
- * NavKey: [BottomHome]
- * Displays the top app bar, category chips, "Top Hustlers" carousel,
- * and the "Available Now" 2-column grid.
- */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val state by viewModel.uiState.collectAsState()
+    val listState = rememberLazyListState()
+    val snackbarHostState = remember { SnackbarHostState() }
 
-    Column(
+    // Detect end of list to trigger next page
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            val totalItems = listState.layoutInfo.totalItemsCount
+            lastVisible >= totalItems - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        snapshotFlow { shouldLoadMore }
+            .distinctUntilChanged()
+            .collect { atEnd ->
+                if (atEnd) viewModel.loadNextPage()
+            }
+    }
+
+    // Show errors as snackbar
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    Box(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .statusBarsPadding()
     ) {
-        // Top App Bar
-        HomeTopBar(
-            initials = state.providerInitials,
-            notificationCount = state.notificationCount
-        )
-
-        // Scrollable body
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+        PullToRefreshBox(
+            isRefreshing = state.isRefreshing,
+            onRefresh = viewModel::onRefresh,
+            modifier = Modifier.fillMaxSize()
         ) {
-            Spacer(Modifier.height(16.dp))
-
-            // Search bar
-            HomeSearchBar(
-                query = state.searchQuery,
-                onQueryChanged = viewModel::onSearchQueryChanged,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-            )
-
-            Spacer(Modifier.height(16.dp))
-
-            // Category chips
-            CategoryChipRow(
-                selected = state.selectedCategory,
-                onSelected = viewModel::onCategorySelected
-            )
-
-            Spacer(Modifier.height(24.dp))
-
-            // Top Hustlers section
-            SectionHeader(
-                title = "Top Hustlers",
-                actionLabel = "View All",
-                onAction = { /* TODO: navigate to full list */ },
-                modifier = Modifier.padding(horizontal = 16.dp)
-            )
-
-            Spacer(Modifier.height(12.dp))
-
-            TopHustlersRow(hustlers = state.topHustlers)
-
-            Spacer(Modifier.height(24.dp))
-
-            // Available Now section
-            AvailableNowHeader(
-                modifier = Modifier.padding(horizontal = 16.dp)
-            )
-
-            Spacer(Modifier.height(12.dp))
-
-            AvailableNowGrid(
-                services = state.availableNow,
-                modifier = Modifier.padding(horizontal = 16.dp)
-            )
-
-            Spacer(Modifier.height(24.dp))
-        }
-    }
-}
-
-@Preview(showBackground = true, showSystemUi = true)
-@Composable
-private fun HomeScreenPreview() {
-    HustleHubTheme(darkTheme = false) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-        ) {
-            Column(
+            LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .statusBarsPadding()
+                    .statusBarsPadding(),
+                contentPadding = PaddingValues(bottom = 100.dp)
             ) {
-                HomeTopBar(initials = "JK", notificationCount = 3)
-                HomeSearchBar(
-                    query = "",
-                    onQueryChanged = {},
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                )
-                Spacer(Modifier.height(12.dp))
-                SectionHeader(
-                    title = "Top Hustlers",
-                    actionLabel = "View All",
-                    onAction = {},
-                    modifier = Modifier.padding(horizontal = 16.dp)
-                )
+                // Top app bar
+                item(key = "topbar") {
+                    HomeTopBar(
+                        initials = state.providerInitials,
+                        notificationCount = state.notificationCount
+                    )
+                }
+
+                // Search bar
+                item(key = "search") {
+                    Spacer(Modifier.height(16.dp))
+                    HomeSearchBar(
+                        query = state.searchQuery,
+                        onQueryChanged = viewModel::onSearchQueryChanged,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    )
+                }
+
+                // Category chips
+                item(key = "categories") {
+                    Spacer(Modifier.height(16.dp))
+                    CategoryChipRow(
+                        selected = state.selectedCategory,
+                        onSelected = viewModel::onCategorySelected
+                    )
+                }
+
+                // Browse services section header
+                item(key = "browse_header") {
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = "Browse Services",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                    Spacer(Modifier.height(12.dp))
+                }
+
+                // Shimmer placeholders while initial load
+                if (state.isLoadingServices) {
+                    items(count = 4, key = { "shimmer_$it" }) {
+                        ServiceCardShimmer(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)
+                        )
+                    }
+                }
+
+                // Empty state
+                if (!state.isLoadingServices && state.services.isEmpty()) {
+                    item(key = "empty") {
+                        EmptyServicesView(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 32.dp)
+                        )
+                    }
+                }
+
+                // Real service cards
+                itemsIndexed(
+                    items = state.services,
+                    key = { _, service -> service.id }
+                ) { _, service ->
+                    ServiceCard(
+                        service = service,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)
+                    )
+                }
+
+                // Load-more spinner at the bottom
+                if (state.isLoadingMore) {
+                    item(key = "loading_more") {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.padding(8.dp),
+                                color = MaterialTheme.colorScheme.primary,
+                                strokeWidth = 2.dp
+                            )
+                        }
+                    }
+                }
             }
         }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import must.kdroiders.hustlehub.ui.features.home.domain.model.LiveService
-import must.kdroiders.hustlehub.ui.features.home.domain.model.ServiceCategory
+import must.kdroiders.hustlehub.data.model.ServiceCategory
 import must.kdroiders.hustlehub.ui.features.home.domain.model.TopHustler
 import javax.inject.Inject
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
@@ -1,103 +1,126 @@
 package must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import must.kdroiders.hustlehub.ui.features.home.domain.model.LiveService
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.data.model.Service
 import must.kdroiders.hustlehub.data.model.ServiceCategory
-import must.kdroiders.hustlehub.ui.features.home.domain.model.TopHustler
+import must.kdroiders.hustlehub.ui.features.home.domain.usecase.BrowseServicesUseCase
+import timber.log.Timber
 import javax.inject.Inject
+
+private const val PAGE_SIZE = 10
 
 data class HomeUiState(
     val selectedCategory: ServiceCategory = ServiceCategory.ALL,
     val searchQuery: String = "",
-    val topHustlers: List<TopHustler> = emptyList(),
-    val availableNow: List<LiveService> = emptyList(),
-    val providerInitials: String = "JK",   // logged-in user initials for avatar
-    val notificationCount: Int = 3,
-    val isLoading: Boolean = false,
-    val error: String? = null
+    val providerInitials: String = "JK",
+    val notificationCount: Int = 0,
+    // Paginated real services from backend
+    val services: List<Service> = emptyList(),
+    val isLoadingServices: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val hasMorePages: Boolean = true,
+    val currentPage: Int = 0,
+    val error: String? = null,
+    val isLoading: Boolean = false
 )
 
 @HiltViewModel
-class HomeViewModel @Inject constructor() : ViewModel() {
+class HomeViewModel @Inject constructor(
+    private val browseServices: BrowseServicesUseCase
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
+    private var searchJob: Job? = null
+
     init {
-        loadMockData()
+        fetchServices(reset = true)
+    }
+
+    // Fetch services — reset=true for fresh load or filter change, false for next page
+    fun fetchServices(reset: Boolean = false) {
+        val state = _uiState.value
+
+        // Don't load more if already at the end or currently loading
+        if (!reset && (!state.hasMorePages || state.isLoadingMore)) return
+
+        val page = if (reset) 0 else state.currentPage
+        val category = state.selectedCategory.takeIf { it != ServiceCategory.ALL }
+        val query = state.searchQuery.trim().takeIf { it.isNotEmpty() }
+
+        viewModelScope.launch {
+            _uiState.update {
+                if (reset) it.copy(isLoadingServices = true, error = null)
+                else it.copy(isLoadingMore = true)
+            }
+
+            browseServices(page = page, size = PAGE_SIZE, category = category, query = query)
+                .onSuccess { pageResponse ->
+                    _uiState.update { current ->
+                        val merged = if (reset) pageResponse.content
+                        else current.services + pageResponse.content
+
+                        current.copy(
+                            services = merged,
+                            isLoadingServices = false,
+                            isRefreshing = false,
+                            isLoadingMore = false,
+                            currentPage = page + 1,
+                            hasMorePages = pageResponse.content.size == PAGE_SIZE
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    Timber.e(e, "Failed to browse services (page $page)")
+                    _uiState.update {
+                        it.copy(
+                            isLoadingServices = false,
+                            isRefreshing = false,
+                            isLoadingMore = false,
+                            error = if (reset) "Could not load services. Showing cached data." else null
+                        )
+                    }
+                }
+        }
     }
 
     fun onCategorySelected(category: ServiceCategory) {
-        _uiState.update { it.copy(selectedCategory = category) }
+        _uiState.update { it.copy(selectedCategory = category, searchQuery = "") }
+        fetchServices(reset = true)
     }
 
     fun onSearchQueryChanged(query: String) {
         _uiState.update { it.copy(searchQuery = query) }
-    }
-
-    // TODO: replace with real API calls to GET /api/v1/discovery/feed
-    private fun loadMockData() {
-        _uiState.update {
-            it.copy(
-                topHustlers = listOf(
-                    TopHustler(
-                        id = "1",
-                        providerName = "Wanjiku M.",
-                        serviceTitle = "Braids by Wanjiku",
-                        category = ServiceCategory.SALON,
-                        rating = 4.9f,
-                        priceLabel = "from KES 500"
-                    ),
-                    TopHustler(
-                        id = "2",
-                        providerName = "James K.",
-                        serviceTitle = "Calculus 101",
-                        category = ServiceCategory.TUTORING,
-                        rating = 5.0f,
-                        priceLabel = "per hr KES 300"
-                    ),
-                    TopHustler(
-                        id = "3",
-                        providerName = "Grace N.",
-                        serviceTitle = "Graphic Design",
-                        category = ServiceCategory.DESIGN,
-                        rating = 4.7f,
-                        priceLabel = "from KES 800"
-                    )
-                ),
-                availableNow = listOf(
-                    LiveService(
-                        id = "4",
-                        title = "Fast Laundry",
-                        price = "KES 250",
-                        location = "Hall 6, Room 102"
-                    ),
-                    LiveService(
-                        id = "5",
-                        title = "Phone Fix",
-                        price = "KES 1K",
-                        location = "Student Center"
-                    ),
-                    LiveService(
-                        id = "6",
-                        title = "Event Pics",
-                        price = "KES 500",
-                        location = "Sports Field"
-                    ),
-                    LiveService(
-                        id = "7",
-                        title = "Fresh Fruit",
-                        price = "KES 50",
-                        location = "Gate A"
-                    )
-                ),
-                isLoading = false
-            )
+        // Debounce search by 400ms
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(400)
+            fetchServices(reset = true)
         }
     }
+
+    fun onRefresh() {
+        _uiState.update { it.copy(isRefreshing = true) }
+        fetchServices(reset = true)
+    }
+
+    fun loadNextPage() {
+        fetchServices(reset = false)
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
@@ -15,6 +15,8 @@ import must.kdroiders.hustlehub.data.model.ServiceCategory
 import must.kdroiders.hustlehub.ui.features.home.domain.usecase.BrowseServicesUseCase
 import timber.log.Timber
 import javax.inject.Inject
+import must.kdroiders.hustlehub.core.auth.AuthManager
+import must.kdroiders.hustlehub.data.repository.UserRepository
 
 private const val PAGE_SIZE = 10
 
@@ -36,7 +38,9 @@ data class HomeUiState(
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val browseServices: BrowseServicesUseCase
+    private val browseServices: BrowseServicesUseCase,
+    private val authManager: AuthManager,
+    private val userRepository: UserRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -45,7 +49,26 @@ class HomeViewModel @Inject constructor(
     private var searchJob: Job? = null
 
     init {
+        loadUserInitials()
         fetchServices(reset = true)
+    }
+
+    private fun loadUserInitials() {
+        viewModelScope.launch {
+            val uid = authManager.currentUser()?.uid ?: return@launch
+            userRepository.getUserProfile(uid)
+                .onSuccess { user ->
+                    if (user != null && user.name.isNotBlank()) {
+                        val parts = user.name.trim().split("\\s+".toRegex())
+                        val initials = if (parts.size >= 2) {
+                            "${parts[0].first().uppercase()}${parts[1].first().uppercase()}"
+                        } else {
+                            parts[0].take(2).uppercase()
+                        }
+                        _uiState.update { it.copy(providerInitials = initials) }
+                    }
+                }
+        }
     }
 
     // Fetch services — reset=true for fresh load or filter change, false for next page
@@ -69,7 +92,7 @@ class HomeViewModel @Inject constructor(
                 .onSuccess { pageResponse ->
                     _uiState.update { current ->
                         val merged = if (reset) pageResponse.content
-                        else current.services + pageResponse.content
+                        else (current.services + pageResponse.content).distinctBy { it.id }
 
                         current.copy(
                             services = merged,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -45,6 +45,7 @@ fun ProfileScreen(
     profileViewModel: ProfileViewModel = hiltViewModel(),
     onEditClick: () -> Unit = {},
     onAddNewServiceClick: () -> Unit = {},
+    onManageServicesClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {}
 ) {
     val state by profileViewModel.uiState.collectAsState()
@@ -65,6 +66,7 @@ fun ProfileScreen(
                 onEditClick = onEditClick,
                 onToggleService = profileViewModel::toggleServiceActive,
                 onAddNewServiceClick = onAddNewServiceClick,
+                onManageServicesClick = onManageServicesClick,
                 onSettingsClick = onSettingsClick
             )
         }
@@ -79,6 +81,7 @@ private fun ProfileContent(
     onEditClick: () -> Unit,
     onToggleService: (String) -> Unit,
     onAddNewServiceClick: () -> Unit,
+    onManageServicesClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {}
 ) {
     val user = state.user ?: return
@@ -185,9 +188,8 @@ private fun ProfileContent(
             Spacer(Modifier.height(24.dp))
             ServicesHeader(
                 onAddNewServiceClick = onAddNewServiceClick,
-                modifier = Modifier.padding(
-                    horizontal = 16.dp
-                )
+                onManageServicesClick = onManageServicesClick,
+                modifier = Modifier.padding(horizontal = 16.dp)
             )
             Spacer(Modifier.height(12.dp))
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ServicesSection.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ServicesSection.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
 import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
 import must.kdroiders.hustlehub.ui.theme.HustleOfflineGray
 
@@ -157,7 +158,7 @@ fun ServiceCard(
                         Alignment.End
                 ) {
                     Switch(
-                        checked = service.isActive,
+                        checked = service.availability == ServiceAvailability.AVAILABLE,
                         onCheckedChange = {
                             onToggle()
                         },
@@ -174,11 +175,11 @@ fun ServiceCard(
                         )
                     )
                     Text(
-                        text = if (service.isActive)
+                        text = if (service.availability == ServiceAvailability.AVAILABLE)
                             "Active" else "Offline",
                         fontSize = 11.sp,
                         fontWeight = FontWeight.Medium,
-                        color = if (service.isActive)
+                        color = if (service.availability == ServiceAvailability.AVAILABLE)
                             HustleActiveGreen
                         else HustleOfflineGray
                     )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ServicesSection.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ServicesSection.kt
@@ -40,6 +40,7 @@ import must.kdroiders.hustlehub.ui.theme.HustleOfflineGray
 @Composable
 fun ServicesHeader(
     onAddNewServiceClick: () -> Unit,
+    onManageServicesClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -53,13 +54,22 @@ fun ServicesHeader(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground
         )
-        TextButton(onClick = onAddNewServiceClick) {
-            Text(
-                text = "Add New +",
-                fontSize = 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.primary
-            )
+        Row {
+            TextButton(onClick = onManageServicesClick) {
+                Text(
+                    text = "Manage",
+                    fontSize = 13.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            TextButton(onClick = onAddNewServiceClick) {
+                Text(
+                    text = "Add New +",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
 import must.kdroiders.hustlehub.data.repository.UserRepository
 import must.kdroiders.hustlehub.ui.features.auth.domain.repository.AuthRepository
 import timber.log.Timber
@@ -62,7 +63,14 @@ class ProfileViewModel @Inject constructor(
         _uiState.update { state ->
             state.copy(
                 services = state.services.map { svc ->
-                    if (svc.id == serviceId) svc.copy(isActive = !svc.isActive) else svc
+                    if (svc.id == serviceId) {
+                        val newAvailability = if (svc.availability == ServiceAvailability.AVAILABLE) {
+                            ServiceAvailability.OFFLINE
+                        } else {
+                            ServiceAvailability.AVAILABLE
+                        }
+                        svc.copy(availability = newAvailability)
+                    } else svc
                 }
             )
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/DeleteServiceUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/DeleteServiceUseCase.kt
@@ -1,0 +1,11 @@
+package must.kdroiders.hustlehub.ui.features.service.domain.usecase
+
+import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import javax.inject.Inject
+
+class DeleteServiceUseCase @Inject constructor(
+    private val repository: ServiceRepository
+) {
+    suspend operator fun invoke(serviceId: String): Result<Unit> =
+        repository.deleteService(serviceId)
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/GetMyServicesUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/GetMyServicesUseCase.kt
@@ -1,0 +1,11 @@
+package must.kdroiders.hustlehub.ui.features.service.domain.usecase
+
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import javax.inject.Inject
+
+class GetMyServicesUseCase @Inject constructor(
+    private val repository: ServiceRepository
+) {
+    suspend operator fun invoke(): Result<List<Service>> = repository.getMyServices()
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/GetServiceByIdUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/GetServiceByIdUseCase.kt
@@ -1,0 +1,12 @@
+package must.kdroiders.hustlehub.ui.features.service.domain.usecase
+
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import javax.inject.Inject
+
+class GetServiceByIdUseCase @Inject constructor(
+    private val repository: ServiceRepository
+) {
+    suspend operator fun invoke(serviceId: String): Result<Service> =
+        repository.getServiceById(serviceId)
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/UpdateAvailabilityUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/UpdateAvailabilityUseCase.kt
@@ -1,0 +1,15 @@
+package must.kdroiders.hustlehub.ui.features.service.domain.usecase
+
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import javax.inject.Inject
+
+class UpdateAvailabilityUseCase @Inject constructor(
+    private val repository: ServiceRepository
+) {
+    suspend operator fun invoke(
+        serviceId: String,
+        availability: ServiceAvailability
+    ): Result<Service> = repository.updateAvailability(serviceId, availability)
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -1,0 +1,546 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.view
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceEvent
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceUiState
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceViewModel
+import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
+import must.kdroiders.hustlehub.ui.theme.HustleDarkBackground
+import must.kdroiders.hustlehub.ui.theme.HustleDarkOutline
+import must.kdroiders.hustlehub.ui.theme.HustleDarkSurface
+import must.kdroiders.hustlehub.ui.theme.HustleDarkSurfaceVariant
+import must.kdroiders.hustlehub.ui.theme.HustleError
+import must.kdroiders.hustlehub.ui.theme.HustlePrimaryBlue
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun CreateServiceScreen(
+    viewModel: CreateServiceViewModel = hiltViewModel(),
+    onBack: () -> Unit,
+    onSuccess: () -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is CreateServiceEvent.Success -> onSuccess()
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(HustleDarkBackground)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .imePadding()
+        ) {
+            // Top bar
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        tint = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+                Text(
+                    text = "Create Service",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp)
+            ) {
+                Spacer(Modifier.height(8.dp))
+
+                // Title
+                SectionLabel(text = "Service Title", required = true)
+                HustleOutlinedTextField(
+                    value = state.title,
+                    onValueChange = viewModel::onTitleChange,
+                    placeholder = "e.g. Professional Braiding Services",
+                    error = state.titleError,
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences,
+                        imeAction = ImeAction.Next
+                    )
+                )
+                ErrorText(state.titleError)
+                Spacer(Modifier.height(16.dp))
+
+                // Category
+                SectionLabel(text = "Category", required = true)
+                CategoryDropdown(
+                    selected = state.category,
+                    onSelect = viewModel::onCategoryChange,
+                    error = state.categoryError
+                )
+                ErrorText(state.categoryError)
+                Spacer(Modifier.height(16.dp))
+
+                // Description
+                SectionLabel(text = "Description")
+                HustleOutlinedTextField(
+                    value = state.description,
+                    onValueChange = viewModel::onDescriptionChange,
+                    placeholder = "What do you offer? (max 300 characters)",
+                    error = state.descriptionError,
+                    minLines = 3,
+                    maxLines = 5,
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences,
+                        imeAction = ImeAction.Next
+                    ),
+                    suffix = {
+                        Text(
+                            text = "${state.description.length}/300",
+                            fontSize = 11.sp,
+                            color = if (state.description.length > 280)
+                                HustleError else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                )
+                ErrorText(state.descriptionError)
+                Spacer(Modifier.height(16.dp))
+
+                // Price range
+                SectionLabel(text = "Price Range (KES)", required = true)
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    HustleOutlinedTextField(
+                        value = state.minPrice,
+                        onValueChange = viewModel::onMinPriceChange,
+                        placeholder = "Min",
+                        error = if (state.priceError != null) "" else null,
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                            imeAction = ImeAction.Next
+                        ),
+                        modifier = Modifier.weight(1f)
+                    )
+                    HustleOutlinedTextField(
+                        value = state.maxPrice,
+                        onValueChange = viewModel::onMaxPriceChange,
+                        placeholder = "Max",
+                        error = if (state.priceError != null) "" else null,
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                            imeAction = ImeAction.Next
+                        ),
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                ErrorText(state.priceError)
+                Spacer(Modifier.height(16.dp))
+
+                // Tags
+                SectionLabel(text = "Tags")
+                Text(
+                    text = "Max 5 tags • press Enter or + to add",
+                    fontSize = 11.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                // Tag chips
+                if (state.tags.isNotEmpty()) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    ) {
+                        state.tags.forEach { tag ->
+                            TagChip(
+                                label = tag,
+                                onRemove = { viewModel.removeTag(tag) }
+                            )
+                        }
+                    }
+                }
+                // Tag input row
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    HustleOutlinedTextField(
+                        value = state.tagInput,
+                        onValueChange = viewModel::onTagInputChange,
+                        placeholder = "e.g. braids",
+                        error = if (state.tagError != null) "" else null,
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.None,
+                            imeAction = ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                viewModel.addTag()
+                                focusManager.clearFocus()
+                            }
+                        ),
+                        modifier = Modifier.weight(1f)
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(HustlePrimaryBlue)
+                            .clickable { viewModel.addTag() },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "Add tag",
+                            tint = Color.White,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+                ErrorText(state.tagError)
+                Spacer(Modifier.height(16.dp))
+
+                // Open to Barter
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(HustleDarkSurface)
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column {
+                        Text(
+                            text = "Open to Barter",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            text = "Accept service exchanges instead of cash",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = state.openToBarter,
+                        onCheckedChange = viewModel::onOpenToBarterChange,
+                        colors = SwitchDefaults.colors(
+                            checkedTrackColor = HustleActiveGreen,
+                            checkedThumbColor = Color.White
+                        )
+                    )
+                }
+
+                // Global error
+                AnimatedVisibility(
+                    visible = state.error != null,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    state.error?.let {
+                        Spacer(Modifier.height(12.dp))
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(HustleError.copy(alpha = 0.12f))
+                                .padding(12.dp)
+                        ) {
+                            Text(
+                                text = it,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = HustleError
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(28.dp))
+
+                // Publish button
+                HustleButton(
+                    text = if (state.isLoading) "Publishing…" else "Publish Service",
+                    onClick = {
+                        focusManager.clearFocus()
+                        viewModel.publish()
+                    },
+                    enabled = !state.isLoading,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(Modifier.height(32.dp))
+            }
+        }
+
+        // Full-screen loading overlay
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.4f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = HustlePrimaryBlue)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String, required: Boolean = false) {
+    Row(modifier = Modifier.padding(bottom = 6.dp)) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        if (required) {
+            Text(
+                text = " *",
+                style = MaterialTheme.typography.labelLarge,
+                color = HustleError
+            )
+        }
+    }
+}
+
+@Composable
+private fun HustleOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+    error: String? = null,
+    minLines: Int = 1,
+    maxLines: Int = 1,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    suffix: @Composable (() -> Unit)? = null
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        placeholder = {
+            Text(
+                text = placeholder,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        isError = error != null,
+        minLines = minLines,
+        maxLines = maxLines,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        suffix = suffix,
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedBorderColor = HustlePrimaryBlue,
+            unfocusedBorderColor = HustleDarkOutline,
+            focusedContainerColor = HustleDarkSurface,
+            unfocusedContainerColor = HustleDarkSurface,
+            errorBorderColor = HustleError,
+            errorContainerColor = HustleDarkSurface,
+            cursorColor = HustlePrimaryBlue
+        ),
+        shape = RoundedCornerShape(12.dp),
+        modifier = modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun ErrorText(error: String?) {
+    AnimatedVisibility(
+        visible = !error.isNullOrEmpty(),
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+        error?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = HustleError,
+                modifier = Modifier.padding(start = 4.dp, top = 4.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryDropdown(
+    selected: ServiceCategory?,
+    onSelect: (ServiceCategory) -> Unit,
+    error: String?
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val categories = ServiceCategory.entries.filter { it != ServiceCategory.ALL }
+
+    Box {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(HustleDarkSurface)
+                .border(
+                    width = 1.dp,
+                    color = if (error != null) HustleError else HustleDarkOutline,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .clickable { expanded = true }
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = selected?.label ?: "Select category",
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (selected != null)
+                    MaterialTheme.colorScheme.onSurface
+                else
+                    MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Icon(
+                imageVector = Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.background(HustleDarkSurfaceVariant)
+        ) {
+            categories.forEach { category ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = category.label,
+                            color = if (category == selected)
+                                HustlePrimaryBlue
+                            else
+                                MaterialTheme.colorScheme.onSurface
+                        )
+                    },
+                    onClick = {
+                        onSelect(category)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagChip(label: String, onRemove: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(
+                Brush.horizontalGradient(
+                    listOf(HustlePrimaryBlue.copy(alpha = 0.2f), HustlePrimaryBlue.copy(alpha = 0.1f))
+                )
+            )
+            .border(1.dp, HustlePrimaryBlue.copy(alpha = 0.4f), RoundedCornerShape(20.dp))
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            color = HustlePrimaryBlue,
+            fontWeight = FontWeight.Medium
+        )
+        Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = "Remove tag",
+            tint = HustlePrimaryBlue.copy(alpha = 0.7f),
+            modifier = Modifier
+                .size(14.dp)
+                .clickable { onRemove() }
+        )
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -20,9 +20,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -35,7 +33,6 @@ import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -54,7 +51,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
@@ -70,14 +66,8 @@ import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.Creat
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceUiState
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceViewModel
 import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
-import must.kdroiders.hustlehub.ui.theme.HustleDarkBackground
-import must.kdroiders.hustlehub.ui.theme.HustleDarkOutline
-import must.kdroiders.hustlehub.ui.theme.HustleDarkSurface
-import must.kdroiders.hustlehub.ui.theme.HustleDarkSurfaceVariant
-import must.kdroiders.hustlehub.ui.theme.HustleError
-import must.kdroiders.hustlehub.ui.theme.HustlePrimaryBlue
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CreateServiceScreen(
     viewModel: CreateServiceViewModel = hiltViewModel(),
@@ -98,7 +88,7 @@ fun CreateServiceScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(HustleDarkBackground)
+            .background(MaterialTheme.colorScheme.background)
     ) {
         Column(
             modifier = Modifier
@@ -142,7 +132,7 @@ fun CreateServiceScreen(
                     value = state.title,
                     onValueChange = viewModel::onTitleChange,
                     placeholder = "e.g. Professional Braiding Services",
-                    error = state.titleError,
+                    isError = state.titleError != null,
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Sentences,
                         imeAction = ImeAction.Next
@@ -156,7 +146,7 @@ fun CreateServiceScreen(
                 CategoryDropdown(
                     selected = state.category,
                     onSelect = viewModel::onCategoryChange,
-                    error = state.categoryError
+                    hasError = state.categoryError != null
                 )
                 ErrorText(state.categoryError)
                 Spacer(Modifier.height(16.dp))
@@ -167,7 +157,7 @@ fun CreateServiceScreen(
                     value = state.description,
                     onValueChange = viewModel::onDescriptionChange,
                     placeholder = "What do you offer? (max 300 characters)",
-                    error = state.descriptionError,
+                    isError = state.descriptionError != null,
                     minLines = 3,
                     maxLines = 5,
                     keyboardOptions = KeyboardOptions(
@@ -179,7 +169,9 @@ fun CreateServiceScreen(
                             text = "${state.description.length}/300",
                             fontSize = 11.sp,
                             color = if (state.description.length > 280)
-                                HustleError else MaterialTheme.colorScheme.onSurfaceVariant
+                                MaterialTheme.colorScheme.error
+                            else
+                                MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 )
@@ -193,7 +185,7 @@ fun CreateServiceScreen(
                         value = state.minPrice,
                         onValueChange = viewModel::onMinPriceChange,
                         placeholder = "Min",
-                        error = if (state.priceError != null) "" else null,
+                        isError = state.priceError != null,
                         keyboardOptions = KeyboardOptions(
                             keyboardType = KeyboardType.Number,
                             imeAction = ImeAction.Next
@@ -204,7 +196,7 @@ fun CreateServiceScreen(
                         value = state.maxPrice,
                         onValueChange = viewModel::onMaxPriceChange,
                         placeholder = "Max",
-                        error = if (state.priceError != null) "" else null,
+                        isError = state.priceError != null,
                         keyboardOptions = KeyboardOptions(
                             keyboardType = KeyboardType.Number,
                             imeAction = ImeAction.Next
@@ -223,7 +215,6 @@ fun CreateServiceScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
-                // Tag chips
                 if (state.tags.isNotEmpty()) {
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -238,7 +229,6 @@ fun CreateServiceScreen(
                         }
                     }
                 }
-                // Tag input row
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -247,7 +237,7 @@ fun CreateServiceScreen(
                         value = state.tagInput,
                         onValueChange = viewModel::onTagInputChange,
                         placeholder = "e.g. braids",
-                        error = if (state.tagError != null) "" else null,
+                        isError = state.tagError != null,
                         keyboardOptions = KeyboardOptions(
                             capitalization = KeyboardCapitalization.None,
                             imeAction = ImeAction.Done
@@ -264,14 +254,14 @@ fun CreateServiceScreen(
                         modifier = Modifier
                             .size(48.dp)
                             .clip(RoundedCornerShape(12.dp))
-                            .background(HustlePrimaryBlue)
+                            .background(MaterialTheme.colorScheme.primary)
                             .clickable { viewModel.addTag() },
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(
                             imageVector = Icons.Default.Add,
                             contentDescription = "Add tag",
-                            tint = Color.White,
+                            tint = MaterialTheme.colorScheme.onPrimary,
                             modifier = Modifier.size(20.dp)
                         )
                     }
@@ -284,22 +274,22 @@ fun CreateServiceScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(12.dp))
-                        .background(HustleDarkSurface)
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Column {
+                    Column(modifier = Modifier.weight(1f)) {
                         Text(
                             text = "Open to Barter",
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Text(
                             text = "Accept service exchanges instead of cash",
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                         )
                     }
                     Switch(
@@ -307,7 +297,9 @@ fun CreateServiceScreen(
                         onCheckedChange = viewModel::onOpenToBarterChange,
                         colors = SwitchDefaults.colors(
                             checkedTrackColor = HustleActiveGreen,
-                            checkedThumbColor = Color.White
+                            checkedThumbColor = Color.White,
+                            uncheckedTrackColor = MaterialTheme.colorScheme.outline,
+                            uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     )
                 }
@@ -324,13 +316,13 @@ fun CreateServiceScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clip(RoundedCornerShape(10.dp))
-                                .background(HustleError.copy(alpha = 0.12f))
+                                .background(MaterialTheme.colorScheme.errorContainer)
                                 .padding(12.dp)
                         ) {
                             Text(
                                 text = it,
                                 style = MaterialTheme.typography.bodySmall,
-                                color = HustleError
+                                color = MaterialTheme.colorScheme.onErrorContainer
                             )
                         }
                     }
@@ -338,7 +330,6 @@ fun CreateServiceScreen(
 
                 Spacer(Modifier.height(28.dp))
 
-                // Publish button
                 HustleButton(
                     text = if (state.isLoading) "Publishing…" else "Publish Service",
                     onClick = {
@@ -361,7 +352,7 @@ fun CreateServiceScreen(
                     .background(Color.Black.copy(alpha = 0.4f)),
                 contentAlignment = Alignment.Center
             ) {
-                CircularProgressIndicator(color = HustlePrimaryBlue)
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
             }
         }
     }
@@ -380,7 +371,7 @@ private fun SectionLabel(text: String, required: Boolean = false) {
             Text(
                 text = " *",
                 style = MaterialTheme.typography.labelLarge,
-                color = HustleError
+                color = MaterialTheme.colorScheme.error
             )
         }
     }
@@ -392,7 +383,7 @@ private fun HustleOutlinedTextField(
     onValueChange: (String) -> Unit,
     placeholder: String,
     modifier: Modifier = Modifier,
-    error: String? = null,
+    isError: Boolean = false,
     minLines: Int = 1,
     maxLines: Int = 1,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -409,20 +400,22 @@ private fun HustleOutlinedTextField(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         },
-        isError = error != null,
+        isError = isError,
         minLines = minLines,
         maxLines = maxLines,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         suffix = suffix,
         colors = OutlinedTextFieldDefaults.colors(
-            focusedBorderColor = HustlePrimaryBlue,
-            unfocusedBorderColor = HustleDarkOutline,
-            focusedContainerColor = HustleDarkSurface,
-            unfocusedContainerColor = HustleDarkSurface,
-            errorBorderColor = HustleError,
-            errorContainerColor = HustleDarkSurface,
-            cursorColor = HustlePrimaryBlue
+            focusedBorderColor = MaterialTheme.colorScheme.primary,
+            unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+            focusedContainerColor = MaterialTheme.colorScheme.surface,
+            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+            errorBorderColor = MaterialTheme.colorScheme.error,
+            errorContainerColor = MaterialTheme.colorScheme.surface,
+            cursorColor = MaterialTheme.colorScheme.primary,
+            focusedTextColor = MaterialTheme.colorScheme.onSurface,
+            unfocusedTextColor = MaterialTheme.colorScheme.onSurface
         ),
         shape = RoundedCornerShape(12.dp),
         modifier = modifier.fillMaxWidth()
@@ -440,7 +433,7 @@ private fun ErrorText(error: String?) {
             Text(
                 text = it,
                 style = MaterialTheme.typography.bodySmall,
-                color = HustleError,
+                color = MaterialTheme.colorScheme.error,
                 modifier = Modifier.padding(start = 4.dp, top = 4.dp)
             )
         }
@@ -451,7 +444,7 @@ private fun ErrorText(error: String?) {
 private fun CategoryDropdown(
     selected: ServiceCategory?,
     onSelect: (ServiceCategory) -> Unit,
-    error: String?
+    hasError: Boolean
 ) {
     var expanded by remember { mutableStateOf(false) }
     val categories = ServiceCategory.entries.filter { it != ServiceCategory.ALL }
@@ -461,10 +454,13 @@ private fun CategoryDropdown(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(12.dp))
-                .background(HustleDarkSurface)
+                .background(MaterialTheme.colorScheme.surface)
                 .border(
                     width = 1.dp,
-                    color = if (error != null) HustleError else HustleDarkOutline,
+                    color = if (hasError)
+                        MaterialTheme.colorScheme.error
+                    else
+                        MaterialTheme.colorScheme.outline,
                     shape = RoundedCornerShape(12.dp)
                 )
                 .clickable { expanded = true }
@@ -490,7 +486,7 @@ private fun CategoryDropdown(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            modifier = Modifier.background(HustleDarkSurfaceVariant)
+            modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant)
         ) {
             categories.forEach { category ->
                 DropdownMenuItem(
@@ -498,7 +494,7 @@ private fun CategoryDropdown(
                         Text(
                             text = category.label,
                             color = if (category == selected)
-                                HustlePrimaryBlue
+                                MaterialTheme.colorScheme.primary
                             else
                                 MaterialTheme.colorScheme.onSurface
                         )
@@ -518,12 +514,12 @@ private fun TagChip(label: String, onRemove: () -> Unit) {
     Row(
         modifier = Modifier
             .clip(RoundedCornerShape(20.dp))
-            .background(
-                Brush.horizontalGradient(
-                    listOf(HustlePrimaryBlue.copy(alpha = 0.2f), HustlePrimaryBlue.copy(alpha = 0.1f))
-                )
+            .background(MaterialTheme.colorScheme.primaryContainer)
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
+                shape = RoundedCornerShape(20.dp)
             )
-            .border(1.dp, HustlePrimaryBlue.copy(alpha = 0.4f), RoundedCornerShape(20.dp))
             .padding(horizontal = 10.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
@@ -531,13 +527,13 @@ private fun TagChip(label: String, onRemove: () -> Unit) {
         Text(
             text = label,
             fontSize = 12.sp,
-            color = HustlePrimaryBlue,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
             fontWeight = FontWeight.Medium
         )
         Icon(
             imageVector = Icons.Default.Close,
             contentDescription = "Remove tag",
-            tint = HustlePrimaryBlue.copy(alpha = 0.7f),
+            tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
             modifier = Modifier
                 .size(14.dp)
                 .clickable { onRemove() }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -70,12 +70,18 @@ import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CreateServiceScreen(
+    serviceId: String? = null,
     viewModel: CreateServiceViewModel = hiltViewModel(),
     onBack: () -> Unit,
     onSuccess: () -> Unit
 ) {
     val state by viewModel.uiState.collectAsState()
     val focusManager = LocalFocusManager.current
+
+    // Pre-fill form when editing an existing service
+    LaunchedEffect(serviceId) {
+        if (serviceId != null) viewModel.loadForEdit(serviceId)
+    }
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -111,7 +117,7 @@ fun CreateServiceScreen(
                     )
                 }
                 Text(
-                    text = "Create Service",
+                    text = if (state.isEditMode) "Edit Service" else "Create Service",
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/MyServicesScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/MyServicesScreen.kt
@@ -1,0 +1,214 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.WorkOff
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.DeleteConfirmDialog
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ServiceManagementCard
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.MyServicesViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyServicesScreen(
+    viewModel: MyServicesViewModel = hiltViewModel(),
+    onBack: () -> Unit,
+    onCreateService: () -> Unit,
+    onEditService: (String) -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Show errors as snackbar
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    // Refresh list when navigating back from the edit screen
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.loadServices()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // Delete confirmation dialog
+    val pendingDeleteId = state.pendingDeleteServiceId
+    if (pendingDeleteId != null) {
+        val serviceName = state.services
+            .find { it.id == pendingDeleteId }?.title ?: "this service"
+        DeleteConfirmDialog(
+            serviceName = serviceName,
+            onConfirm = viewModel::confirmDelete,
+            onDismiss = viewModel::cancelDelete
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "My Services",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onBackground
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onCreateService,
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Add service")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background
+    ) { innerPadding ->
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+
+            when {
+                state.isLoading -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.Center),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                state.services.isEmpty() -> {
+                    EmptyServicesPlaceholder(
+                        onCreateClick = onCreateService,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(
+                            horizontal = 16.dp,
+                            vertical = 12.dp
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        items(
+                            items = state.services,
+                            key = { it.id }
+                        ) { service ->
+                            ServiceManagementCard(
+                                service = service,
+                                isUpdating = state.updatingServiceId == service.id,
+                                onEditClick = { onEditService(service.id) },
+                                onDeleteClick = { viewModel.requestDelete(service.id) },
+                                onAvailabilityChange = { newAvailability ->
+                                    viewModel.onAvailabilityChange(service.id, newAvailability)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyServicesPlaceholder(
+    onCreateClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Default.WorkOff,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = "No services yet",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "Tap + to publish your first service and start earning.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
@@ -1,0 +1,103 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
+import must.kdroiders.hustlehub.ui.theme.HustleOfflineGray
+import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
+
+/**
+ * 3-state availability selector chip row.
+ * 🟢 Available  🟡 Busy  🔴 Offline
+ */
+@Composable
+fun AvailabilityChipSelector(
+    current: ServiceAvailability,
+    onSelect: (ServiceAvailability) -> Unit,
+    enabled: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        AvailabilityChip(
+            label = "Available",
+            dotColor = HustleActiveGreen,
+            selected = current == ServiceAvailability.AVAILABLE,
+            enabled = enabled,
+            onClick = { onSelect(ServiceAvailability.AVAILABLE) }
+        )
+        AvailabilityChip(
+            label = "Busy",
+            dotColor = HustleWarningAmber,
+            selected = current == ServiceAvailability.BUSY,
+            enabled = enabled,
+            onClick = { onSelect(ServiceAvailability.BUSY) }
+        )
+        AvailabilityChip(
+            label = "Offline",
+            dotColor = HustleOfflineGray,
+            selected = current == ServiceAvailability.OFFLINE,
+            enabled = enabled,
+            onClick = { onSelect(ServiceAvailability.OFFLINE) }
+        )
+    }
+}
+
+@Composable
+private fun AvailabilityChip(
+    label: String,
+    dotColor: Color,
+    selected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    val bgColor = if (selected)
+        dotColor.copy(alpha = 0.15f)
+    else
+        MaterialTheme.colorScheme.surfaceVariant
+
+    val borderColor = if (selected) dotColor else Color.Transparent
+
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(bgColor)
+            .border(1.dp, borderColor, RoundedCornerShape(20.dp))
+            .clickable(enabled = enabled) { onClick() }
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        // Dot indicator
+        androidx.compose.foundation.Canvas(modifier = Modifier.size(8.dp)) {
+            drawCircle(color = dotColor)
+        }
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (selected) dotColor else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/DeleteConfirmDialog.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/DeleteConfirmDialog.kt
@@ -1,0 +1,48 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+
+@Composable
+fun DeleteConfirmDialog(
+    serviceName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = "Delete Service",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Text(
+                text = "Are you sure you want to delete \"$serviceName\"? This action cannot be undone.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = "Delete",
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surface
+    )
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
@@ -1,0 +1,230 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
+import must.kdroiders.hustlehub.ui.theme.HustleOfflineGray
+import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ServiceManagementCard(
+    service: Service,
+    isUpdating: Boolean,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit,
+    onAvailabilityChange: (ServiceAvailability) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp)
+    ) {
+        Column {
+
+            // Top row: icon, title, action buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                // Service icon / thumbnail
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (service.iconUrl.isNotBlank()) {
+                        AsyncImage(
+                            model = service.iconUrl,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.Description,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+
+                Spacer(Modifier.width(12.dp))
+
+                // Title + price
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = service.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = service.priceRange,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                // Edit + Delete actions
+                Row {
+                    IconButton(
+                        onClick = onEditClick,
+                        enabled = !isUpdating
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "Edit service",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    IconButton(
+                        onClick = onDeleteClick,
+                        enabled = !isUpdating
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete service",
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(12.dp))
+
+            // Stats row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                StatItem(
+                    label = "Rating",
+                    value = if (service.averageRating > 0f)
+                        "%.1f".format(service.averageRating) else "—"
+                )
+                StatItem(label = "Reviews", value = service.reviewCount.toString())
+            }
+
+            // Tags
+            if (service.tags.isNotEmpty()) {
+                Spacer(Modifier.height(10.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    service.tags.forEach { tag ->
+                        MiniTagChip(label = tag)
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // Availability selector
+            Text(
+                text = "Availability",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 6.dp)
+            )
+
+            Box(contentAlignment = Alignment.CenterStart) {
+                AvailabilityChipSelector(
+                    current = service.availability,
+                    onSelect = onAvailabilityChange,
+                    enabled = !isUpdating
+                )
+                if (isUpdating) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(18.dp)
+                            .align(Alignment.CenterEnd),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatItem(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun MiniTagChip(label: String) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    ) {
+        Text(
+            text = label,
+            fontSize = 11.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
@@ -13,10 +13,13 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.data.model.ServiceCategory
 import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceByIdUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
 data class CreateServiceUiState(
+    val isEditMode: Boolean = false,
+    val isLoadingExisting: Boolean = false,
     val title: String = "",
     val titleError: String? = null,
     val category: ServiceCategory? = null,
@@ -40,14 +43,65 @@ sealed class CreateServiceEvent {
 
 @HiltViewModel
 class CreateServiceViewModel @Inject constructor(
-    private val serviceRepository: ServiceRepository
+    private val serviceRepository: ServiceRepository,
+    private val getServiceById: GetServiceByIdUseCase
 ) : ViewModel() {
+
+    // Set by the screen via loadForEdit() when navigating from edit flow
+    private var editServiceId: String? = null
 
     private val _uiState = MutableStateFlow(CreateServiceUiState())
     val uiState: StateFlow<CreateServiceUiState> = _uiState.asStateFlow()
 
     private val _events = MutableSharedFlow<CreateServiceEvent>()
     val events: SharedFlow<CreateServiceEvent> = _events.asSharedFlow()
+
+    /**
+     * Called by the screen when opened in edit mode.
+     * Guards against re-loading if already pre-filled.
+     */
+    fun loadForEdit(serviceId: String) {
+        if (_uiState.value.isEditMode) return
+        editServiceId = serviceId
+        _uiState.update { it.copy(isEditMode = true, isLoadingExisting = true) }
+        loadExistingService(serviceId)
+    }
+
+    private fun loadExistingService(serviceId: String) {
+        viewModelScope.launch {
+            getServiceById(serviceId)
+                .onSuccess { service ->
+                    // Parse minPrice / maxPrice back out of the "300 - 800 KSh" formatted string
+                    val parts = service.priceRange
+                        .replace("KSh", "").replace("ksh", "")
+                        .split("-").map { it.trim() }
+                    val min = parts.getOrNull(0)?.filter { it.isDigit() } ?: ""
+                    val max = parts.getOrNull(1)?.filter { it.isDigit() } ?: ""
+
+                    _uiState.update {
+                        it.copy(
+                            isLoadingExisting = false,
+                            title = service.title,
+                            category = service.category,
+                            description = service.description,
+                            minPrice = min,
+                            maxPrice = max,
+                            tags = service.tags,
+                            openToBarter = service.openToBarter
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    Timber.e(e, "Failed to load service for editing")
+                    _uiState.update {
+                        it.copy(
+                            isLoadingExisting = false,
+                            error = "Could not load service details. Please try again."
+                        )
+                    }
+                }
+        }
+    }
 
     fun onTitleChange(value: String) {
         _uiState.update { it.copy(title = value, titleError = null) }
@@ -84,9 +138,7 @@ class CreateServiceViewModel @Inject constructor(
         val trimmed = state.tagInput.trim().lowercase()
         when {
             trimmed.isEmpty() -> return
-            state.tags.size >= 5 -> _uiState.update {
-                it.copy(tagError = "Maximum 5 tags allowed")
-            }
+            state.tags.size >= 5 -> _uiState.update { it.copy(tagError = "Maximum 5 tags allowed") }
             state.tags.contains(trimmed) -> _uiState.update {
                 it.copy(tagError = "Tag already added", tagInput = "")
             }
@@ -104,6 +156,11 @@ class CreateServiceViewModel @Inject constructor(
         _uiState.update { it.copy(openToBarter = value) }
     }
 
+    private fun resetForm() {
+        editServiceId = null
+        _uiState.value = CreateServiceUiState()
+    }
+
     fun publish() {
         if (!validate()) return
 
@@ -111,34 +168,53 @@ class CreateServiceViewModel @Inject constructor(
         val minPrice = state.minPrice.toIntOrNull() ?: 0
         val maxPrice = state.maxPrice.toIntOrNull() ?: 0
 
+        val snapshot = editServiceId
+
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            serviceRepository.createService(
-                title = state.title.trim(),
-                category = state.category!!,
-                description = state.description.trim().ifEmpty { null },
-                minPrice = minPrice,
-                maxPrice = maxPrice,
-                openToBarter = state.openToBarter,
-                tags = state.tags
-            ).onSuccess {
-                _uiState.update { it.copy(isLoading = false) }
-                _events.emit(CreateServiceEvent.Success)
-            }.onFailure { e ->
-                Timber.e(e, "Failed to create service")
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        error = e.message ?: "Failed to publish service. Please try again."
-                    )
-                }
+
+            val result = if (state.isEditMode && snapshot != null) {
+                serviceRepository.updateService(
+                    serviceId = snapshot,
+                    title = state.title.trim(),
+                    category = state.category!!,
+                    description = state.description.trim().ifEmpty { null },
+                    minPrice = minPrice,
+                    maxPrice = maxPrice,
+                    openToBarter = state.openToBarter,
+                    tags = state.tags
+                )
+            } else {
+                serviceRepository.createService(
+                    title = state.title.trim(),
+                    category = state.category!!,
+                    description = state.description.trim().ifEmpty { null },
+                    minPrice = minPrice,
+                    maxPrice = maxPrice,
+                    openToBarter = state.openToBarter,
+                    tags = state.tags
+                )
             }
+
+            result
+                .onSuccess {
+                    resetForm()
+                    _events.emit(CreateServiceEvent.Success)
+                }
+                .onFailure { e ->
+                    Timber.e(e, "Failed to save service")
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = e.message ?: "Failed to save service. Please try again."
+                        )
+                    }
+                }
         }
     }
 
     private fun validate(): Boolean {
         val state = _uiState.value
-        var valid = true
 
         val titleError = when {
             state.title.isBlank() -> "Title is required"
@@ -162,10 +238,6 @@ class CreateServiceViewModel @Inject constructor(
             else -> null
         }
 
-        if (titleError != null || categoryError != null || descriptionError != null || priceError != null) {
-            valid = false
-        }
-
         _uiState.update {
             it.copy(
                 titleError = titleError,
@@ -175,6 +247,7 @@ class CreateServiceViewModel @Inject constructor(
             )
         }
 
-        return valid
+        return titleError == null && categoryError == null &&
+            descriptionError == null && priceError == null
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
@@ -219,7 +219,7 @@ class CreateServiceViewModel @Inject constructor(
         val titleError = when {
             state.title.isBlank() -> "Title is required"
             state.title.trim().length < 5 -> "Title must be at least 5 characters"
-            state.title.trim().length > 150 -> "Title must be less than 150 characters"
+            state.title.trim().length > 50 -> "Title must be less than 50 characters"
             else -> null
         }
         val categoryError = if (state.category == null) "Please select a category" else null

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
@@ -1,0 +1,180 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+import must.kdroiders.hustlehub.domain.repository.ServiceRepository
+import timber.log.Timber
+import javax.inject.Inject
+
+data class CreateServiceUiState(
+    val title: String = "",
+    val titleError: String? = null,
+    val category: ServiceCategory? = null,
+    val categoryError: String? = null,
+    val description: String = "",
+    val descriptionError: String? = null,
+    val minPrice: String = "",
+    val maxPrice: String = "",
+    val priceError: String? = null,
+    val tagInput: String = "",
+    val tags: List<String> = emptyList(),
+    val tagError: String? = null,
+    val openToBarter: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+sealed class CreateServiceEvent {
+    data object Success : CreateServiceEvent()
+}
+
+@HiltViewModel
+class CreateServiceViewModel @Inject constructor(
+    private val serviceRepository: ServiceRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CreateServiceUiState())
+    val uiState: StateFlow<CreateServiceUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<CreateServiceEvent>()
+    val events: SharedFlow<CreateServiceEvent> = _events.asSharedFlow()
+
+    fun onTitleChange(value: String) {
+        _uiState.update { it.copy(title = value, titleError = null) }
+    }
+
+    fun onCategoryChange(value: ServiceCategory) {
+        _uiState.update { it.copy(category = value, categoryError = null) }
+    }
+
+    fun onDescriptionChange(value: String) {
+        if (value.length <= 300) {
+            _uiState.update { it.copy(description = value, descriptionError = null) }
+        }
+    }
+
+    fun onMinPriceChange(value: String) {
+        if (value.all { it.isDigit() }) {
+            _uiState.update { it.copy(minPrice = value, priceError = null) }
+        }
+    }
+
+    fun onMaxPriceChange(value: String) {
+        if (value.all { it.isDigit() }) {
+            _uiState.update { it.copy(maxPrice = value, priceError = null) }
+        }
+    }
+
+    fun onTagInputChange(value: String) {
+        _uiState.update { it.copy(tagInput = value, tagError = null) }
+    }
+
+    fun addTag() {
+        val state = _uiState.value
+        val trimmed = state.tagInput.trim().lowercase()
+        when {
+            trimmed.isEmpty() -> return
+            state.tags.size >= 5 -> _uiState.update {
+                it.copy(tagError = "Maximum 5 tags allowed")
+            }
+            state.tags.contains(trimmed) -> _uiState.update {
+                it.copy(tagError = "Tag already added", tagInput = "")
+            }
+            else -> _uiState.update {
+                it.copy(tags = it.tags + trimmed, tagInput = "", tagError = null)
+            }
+        }
+    }
+
+    fun removeTag(tag: String) {
+        _uiState.update { it.copy(tags = it.tags - tag) }
+    }
+
+    fun onOpenToBarterChange(value: Boolean) {
+        _uiState.update { it.copy(openToBarter = value) }
+    }
+
+    fun publish() {
+        if (!validate()) return
+
+        val state = _uiState.value
+        val minPrice = state.minPrice.toIntOrNull() ?: 0
+        val maxPrice = state.maxPrice.toIntOrNull() ?: 0
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            serviceRepository.createService(
+                title = state.title.trim(),
+                category = state.category!!,
+                description = state.description.trim().ifEmpty { null },
+                minPrice = minPrice,
+                maxPrice = maxPrice,
+                openToBarter = state.openToBarter,
+                tags = state.tags
+            ).onSuccess {
+                _uiState.update { it.copy(isLoading = false) }
+                _events.emit(CreateServiceEvent.Success)
+            }.onFailure { e ->
+                Timber.e(e, "Failed to create service")
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "Failed to publish service. Please try again."
+                    )
+                }
+            }
+        }
+    }
+
+    private fun validate(): Boolean {
+        val state = _uiState.value
+        var valid = true
+
+        val titleError = when {
+            state.title.isBlank() -> "Title is required"
+            state.title.trim().length < 5 -> "Title must be at least 5 characters"
+            state.title.trim().length > 150 -> "Title must be less than 150 characters"
+            else -> null
+        }
+        val categoryError = if (state.category == null) "Please select a category" else null
+
+        val descriptionError = if (state.description.length > 300) {
+            "Description must be 300 characters or less"
+        } else null
+
+        val minPrice = state.minPrice.toIntOrNull()
+        val maxPrice = state.maxPrice.toIntOrNull()
+        val priceError = when {
+            state.minPrice.isEmpty() && state.maxPrice.isEmpty() ->
+                "Please enter at least a minimum or maximum price"
+            minPrice != null && maxPrice != null && minPrice > maxPrice ->
+                "Minimum price cannot exceed maximum price"
+            else -> null
+        }
+
+        if (titleError != null || categoryError != null || descriptionError != null || priceError != null) {
+            valid = false
+        }
+
+        _uiState.update {
+            it.copy(
+                titleError = titleError,
+                categoryError = categoryError,
+                descriptionError = descriptionError,
+                priceError = priceError
+            )
+        }
+
+        return valid
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/MyServicesUiState.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/MyServicesUiState.kt
@@ -1,0 +1,14 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel
+
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+
+data class MyServicesUiState(
+    val services: List<Service> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    // ID of the service that is waiting for a network response (optimistic locking)
+    val updatingServiceId: String? = null,
+    // ID of the service pending delete confirmation
+    val pendingDeleteServiceId: String? = null
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/MyServicesViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/MyServicesViewModel.kt
@@ -1,0 +1,121 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.DeleteServiceUseCase
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetMyServicesUseCase
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.UpdateAvailabilityUseCase
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class MyServicesViewModel @Inject constructor(
+    private val getMyServices: GetMyServicesUseCase,
+    private val deleteService: DeleteServiceUseCase,
+    private val updateAvailability: UpdateAvailabilityUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MyServicesUiState())
+    val uiState: StateFlow<MyServicesUiState> = _uiState.asStateFlow()
+
+    init {
+        loadServices()
+    }
+
+    fun loadServices() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            getMyServices()
+                .onSuccess { services ->
+                    _uiState.update { it.copy(services = services, isLoading = false) }
+                }
+                .onFailure { e ->
+                    Timber.e(e, "Failed to load my services")
+                    _uiState.update {
+                        it.copy(isLoading = false, error = e.message ?: "Failed to load services")
+                    }
+                }
+        }
+    }
+
+    // --- Availability ---
+
+    fun onAvailabilityChange(serviceId: String, availability: ServiceAvailability) {
+        // Optimistic update — apply locally first
+        _uiState.update { state ->
+            state.copy(
+                services = state.services.map { s ->
+                    if (s.id == serviceId) s.copy(availability = availability) else s
+                },
+                updatingServiceId = serviceId
+            )
+        }
+
+        viewModelScope.launch {
+            updateAvailability(serviceId, availability)
+                .onSuccess { updated ->
+                    _uiState.update { state ->
+                        state.copy(
+                            services = state.services.map { s ->
+                                if (s.id == updated.id) updated else s
+                            },
+                            updatingServiceId = null
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    Timber.e(e, "Failed to update availability")
+                    // Roll back the optimistic update by reloading
+                    _uiState.update { it.copy(updatingServiceId = null) }
+                    loadServices()
+                }
+        }
+    }
+
+    // --- Delete ---
+
+    fun requestDelete(serviceId: String) {
+        _uiState.update { it.copy(pendingDeleteServiceId = serviceId) }
+    }
+
+    fun cancelDelete() {
+        _uiState.update { it.copy(pendingDeleteServiceId = null) }
+    }
+
+    fun confirmDelete() {
+        val serviceId = _uiState.value.pendingDeleteServiceId ?: return
+        _uiState.update { it.copy(pendingDeleteServiceId = null, updatingServiceId = serviceId) }
+
+        viewModelScope.launch {
+            deleteService(serviceId)
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(
+                            services = state.services.filter { it.id != serviceId },
+                            updatingServiceId = null
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    Timber.e(e, "Failed to delete service")
+                    _uiState.update {
+                        it.copy(
+                            updatingServiceId = null,
+                            error = e.message ?: "Failed to delete service"
+                        )
+                    }
+                }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/viewmodel/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.datastore.UserPreferences
+import must.kdroiders.hustlehub.data.local.dao.ServiceDao
 import must.kdroiders.hustlehub.ui.features.auth.domain.repository.AuthRepository
 import must.kdroiders.hustlehub.ui.features.auth.domain.usecase.SignOutUseCase
 import timber.log.Timber
@@ -58,7 +59,8 @@ sealed interface SettingsEvent {
 class SettingsViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val signOutUseCase: SignOutUseCase,
-    private val userPreferences: UserPreferences
+    private val userPreferences: UserPreferences,
+    private val serviceDao: ServiceDao
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -119,6 +121,7 @@ class SettingsViewModel @Inject constructor(
             try {
                 signOutUseCase()
                 userPreferences.clearUser()
+                serviceDao.clearAll()
                 _events.send(SettingsEvent.LoggedOut)
             } catch (e: Exception) {
                 Timber.e(e, "Sign out failed")

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/auth/SignUpViewModelTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/auth/SignUpViewModelTest.kt
@@ -8,7 +8,9 @@ import io.mockk.Runs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import must.kdroiders.hustlehub.datastore.UserPreferences
 import must.kdroiders.hustlehub.ui.features.auth.domain.usecase.SignUpUseCase
@@ -164,7 +166,7 @@ class SignUpViewModelTest {
     }
 
     @Test
-    fun `signUp persists user to DataStore on success`() {
+    fun `signUp persists user to DataStore on success`() = runTest {
         coEvery { mockSignUpUseCase(any(), any(), any()) } returns Result.success(mockk(relaxed = true))
         coEvery { mockUserPreferences.writeUser(any()) } just Runs
 
@@ -174,8 +176,10 @@ class SignUpViewModelTest {
         viewModel.onConfirmPasswordChanged("Password123!")
 
         viewModel.signUp {}
+        
+        advanceUntilIdle()
 
-        coVerify(timeout = 1000) { mockUserPreferences.writeUser(any()) }
+        coVerify { mockUserPreferences.writeUser(any()) }
     }
 
     @Test


### PR DESCRIPTION
## 📝 What does this PR do?
Implements a complete Service Management flow, an Offline-First Room caching strategy, and a dynamically paginated Discovery feed on the Home Screen.

---

## 🔄 Main Changes

### Added
- **Service Management:** `MyServicesScreen`, updated `CreateServiceScreen` (edit/delete flow), and a 3-state real-time availability toggle.
- **Offline-First Infrastructure:** `AppDatabase`, `ServiceDao`, and `ServiceEntity` with a 30-minute TTL cache strategy.
- **Dynamic Discovery Feed:** `PullToRefresh` and infinite scroll pagination on the `HomeScreen`.
- **UI Components:** `ServiceCard` with Coil, `ServiceCardShimmer`, and `EmptyServicesView`.

### Changed
- **Repository Strategy:** Rewrote `ServiceRepositoryImpl` to enforce a strictly cache-first write-through strategy.
- **Home Screen:** Converted `HomeScreen` to a `LazyColumn` for performance optimization.
- **Dynamic User Data:** `HomeViewModel` now fetches logged-in user profile via `AuthManager` to display dynamic initials.

### Fixed
- Fixed an `IllegalArgumentException` in `LazyColumn` by adding `.distinctBy { it.id }` to prevent duplicate service keys.
- Fixed smart-cast limitations in ViewModels by snapping state to local variables.
- Handled scope issues with `AnimatedVisibility` inside card components.

### Removed
- Wiped all hardcoded static mock data (`TopHustlers`, `LiveServices`) from the Home feature.

---

## ✅ Type of change
- [x] New feature
- [x] Bug fix
- [x] UI update
- [x] Refactor / cleanup
- [ ] Documentation

---

## 🧪 I have tested that...
- [x] The app builds without errors
- [x] My feature/fix works as expected
- [x] I didn't break anything else

---

## 🔍 Code quality
- [x] Ktlint passed  (`./gradlew ktlintCheck`)
- [x] Detekt passed  (`./gradlew detekt`)
- [x] My commit message follows convention (`feat:`, `fix:`, `chore:` etc.)

---

## 📸 Screenshots

---

## Closes #
Closes #21, closes #22, closes #24, closes #25, closes #26
