### PR TITLE
Advanced search, AI service discovery, and home feed redesign

### DIFF
--- a/app/src/main/java/must/kdroiders/hustlehub/data/remote/DiscoveryApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/remote/DiscoveryApiService.kt
@@ -1,0 +1,60 @@
+package must.kdroiders.hustlehub.data.remote
+
+import must.kdroiders.hustlehub.core.api.ApiResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/** Backend contract for AI-powered service discovery. */
+interface DiscoveryApiService {
+
+    /**
+     * Submits a natural language query to the backend, which calls Gemini internally,
+     * extracts search parameters, queries the database, and returns ranked matches.
+     *
+     * The API key never leaves the server. Fallback to keyword search happens server-side
+     * if Gemini is unavailable, so the client always receives a valid response.
+     *
+     * POST /api/v1/discovery/ai-search
+     */
+    @POST("discovery/ai-search")
+    suspend fun aiSearch(@Body request: AiSearchRequest): ApiResponse<AiSearchResponse>
+}
+
+/** @property query Natural language query from the user, max 500 chars. */
+data class AiSearchRequest(
+    val query: String,
+    val userLocation: UserLocationDto? = null,
+    /** Number of results to return (1–100). Default 10. */
+    val maxResults: Int = 10,
+) {
+    data class UserLocationDto(val lat: Double, val lng: Double)
+}
+
+data class AiSearchResponse(
+    val matches: List<AiSearchMatch>,
+    val queryUnderstanding: QueryUnderstanding,
+)
+
+data class AiSearchMatch(
+    val serviceId: String,
+    val providerId: String,
+    val title: String,
+    val category: String,
+    val priceRange: String,
+    /** Relevance score 0.0–1.0, computed server-side from rating + distance. */
+    val relevanceScore: Double,
+    /** Human-readable reason string, e.g. "Offers braids, 200m from you, price 300–800 KSh" */
+    val matchReason: String,
+    val distanceMeters: Double?,
+)
+
+/**
+ * Structured understanding of the user's natural language query extracted by Gemini.
+ * All fields are nullable — the backend sets only what it could confidently extract.
+ */
+data class QueryUnderstanding(
+    val service: String?,
+    val location: String?,
+    val maxPrice: Int?,
+    val category: String?,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/data/remote/ServiceApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/remote/ServiceApiService.kt
@@ -51,5 +51,24 @@ interface ServiceApiService {
         @Query("size") size: Int = 20,
         @Query("category") category: String? = null,
         @Query("query") query: String? = null,
+        @Query("availability") availability: String? = null,
+        @Query("minRating") minRating: Double? = null,
+        @Query("maxPrice") maxPrice: Int? = null,
+        @Query("lat") lat: Double? = null,
+        @Query("lng") lng: Double? = null,
+        @Query("radiusKm") radiusKm: Double? = null,
+        @Query("sortBy") sortBy: String? = null,
+    ): ApiResponse<PageResponse<ServiceResponse>>
+
+    /**
+     * Full-text keyword search across service titles, descriptions, and tags.
+     * Maps to GET /api/v1/discovery/search — separate from the filtered browse endpoint.
+     * Results are always sorted by avgRating descending.
+     */
+    @GET("discovery/search")
+    suspend fun searchServices(
+        @Query("q") query: String,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 20,
     ): ApiResponse<PageResponse<ServiceResponse>>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/datastore/UserPreferences.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/datastore/UserPreferences.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -49,6 +50,9 @@ class UserPreferences
             val USER_ROLE = stringPreferencesKey("user_role")
             val USER_AVATAR_URL = stringPreferencesKey("user_avatar_url")
             val USER_UUID = stringPreferencesKey("user_uuid")
+            val RECENT_SEARCHES = stringSetPreferencesKey("recent_searches")
+            /** Maximum number of recent searches to persist. Oldest entry is evicted when full. */
+            const val MAX_RECENT_SEARCHES = 10
         }
 
         // Reads
@@ -145,6 +149,76 @@ class UserPreferences
                 Timber.d("User cleared from DataStore")
             } catch (e: IOException) {
                 Timber.e(e, "Error clearing user from DataStore")
+            }
+        }
+
+        /**
+         * Emits the list of the user's recent search queries, most recent first.
+         * Returns an empty list if no history is stored.
+         */
+        val recentSearches: Flow<List<String>> = dataStore.data
+            .catch { e ->
+                if (e is IOException) {
+                    Timber.e(e, "Error reading recent searches")
+                    emit(emptyPreferences())
+                } else {
+                    throw e
+                }
+            }.map { prefs ->
+                // StringSet has no guaranteed order; we encode insertion order as
+                // "index:value" so we can restore recency after reading from DataStore.
+                prefs[RECENT_SEARCHES]
+                    ?.mapNotNull { entry ->
+                        val idx = entry.substringBefore(':').toIntOrNull() ?: return@mapNotNull null
+                        val value = entry.substringAfter(':')
+                        idx to value
+                    }
+                    ?.sortedByDescending { it.first }
+                    ?.map { it.second }
+                    ?: emptyList()
+            }
+
+        /**
+         * Saves [query] to recent searches, evicting the oldest entry when the list
+         * exceeds [MAX_RECENT_SEARCHES]. Duplicate entries are deduplicated (existing
+         * entry is removed and the query is re-inserted at the front).
+         */
+        suspend fun addRecentSearch(query: String) {
+            if (query.isBlank()) return
+            try {
+                dataStore.edit { prefs ->
+                    val existing = prefs[RECENT_SEARCHES]?.toMutableSet() ?: mutableSetOf()
+                    // Parse current entries: "idx:value"
+                    val parsed = existing
+                        .mapNotNull { entry ->
+                            val idx = entry.substringBefore(':').toIntOrNull() ?: return@mapNotNull null
+                            idx to entry.substringAfter(':')
+                        }
+                        .toMutableList()
+
+                    // Remove any existing entry for this query (dedup)
+                    parsed.removeAll { it.second == query }
+
+                    // Assign a new index higher than the current max
+                    val nextIdx = (parsed.maxOfOrNull { it.first } ?: 0) + 1
+                    parsed.add(nextIdx to query)
+
+                    // Evict oldest entries beyond the cap
+                    val trimmed = parsed.sortedByDescending { it.first }.take(MAX_RECENT_SEARCHES)
+
+                    prefs[RECENT_SEARCHES] = trimmed.map { "${it.first}:${it.second}" }.toSet()
+                }
+            } catch (e: IOException) {
+                Timber.e(e, "Error saving recent search")
+            }
+        }
+
+        /** Clears all recent search history. */
+        suspend fun clearRecentSearches() {
+            try {
+                dataStore.edit { prefs -> prefs.remove(RECENT_SEARCHES) }
+            } catch (e: IOException) {
+                Timber.e(e, "Error clearing recent searches")
             }
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -14,6 +14,7 @@ import must.kdroiders.hustlehub.core.auth.AuthManager
 import must.kdroiders.hustlehub.data.local.AppDatabase
 import must.kdroiders.hustlehub.data.remote.MediaApiService
 import must.kdroiders.hustlehub.data.remote.ServiceApiService
+import must.kdroiders.hustlehub.data.remote.DiscoveryApiService
 import must.kdroiders.hustlehub.data.remote.UserApiService
 import must.kdroiders.hustlehub.datastore.UserPreferences
 import must.kdroiders.hustlehub.datastore.dataStore
@@ -34,6 +35,8 @@ import must.kdroiders.hustlehub.ui.features.profile.domain.repository.UserReposi
 import must.kdroiders.hustlehub.ui.features.service.data.local.dao.ServiceDao
 import must.kdroiders.hustlehub.ui.features.service.data.repository.ServiceRepositoryImpl
 import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
+import must.kdroiders.hustlehub.ui.features.home.data.repository.AiSearchRepositoryImpl
+import must.kdroiders.hustlehub.ui.features.home.domain.repository.AiSearchRepository
 import timber.log.Timber
 import javax.inject.Singleton
 
@@ -141,6 +144,12 @@ object AppModule {
             firebaseAuth,
         )
     }
+
+    @Provides
+    @Singleton
+    fun provideAiSearchRepository(
+        discoveryApiService: DiscoveryApiService,
+    ): AiSearchRepository = AiSearchRepositoryImpl(discoveryApiService)
 }
 
 private class NoopAuthRepository : AuthRepository {

--- a/app/src/main/java/must/kdroiders/hustlehub/di/NetworkModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/NetworkModule.kt
@@ -9,6 +9,7 @@ import must.kdroiders.hustlehub.BuildConfig
 import must.kdroiders.hustlehub.core.api.AuthInterceptor
 import must.kdroiders.hustlehub.core.api.TokenAuthenticator
 import must.kdroiders.hustlehub.core.auth.AuthManager
+import must.kdroiders.hustlehub.data.remote.DiscoveryApiService
 import must.kdroiders.hustlehub.data.remote.MediaApiService
 import must.kdroiders.hustlehub.data.remote.ServiceApiService
 import must.kdroiders.hustlehub.data.remote.UserApiService
@@ -94,4 +95,9 @@ object NetworkModule {
     fun provideConversationApiService(retrofit: Retrofit): ConversationApiService {
         return retrofit.create(ConversationApiService::class.java)
     }
+
+    @Provides
+    @Singleton
+    fun provideDiscoveryApiService(retrofit: Retrofit): DiscoveryApiService =
+        retrofit.create(DiscoveryApiService::class.java)
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -30,6 +30,8 @@ import must.kdroiders.hustlehub.ui.features.auth.presentation.view.LoginScreen
 import must.kdroiders.hustlehub.ui.features.auth.presentation.view.SignUpScreen
 import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.LoginViewModel
 import must.kdroiders.hustlehub.ui.features.chat.presentation.view.ChatDetailScreen
+import must.kdroiders.hustlehub.ui.features.home.presentation.view.AiSearchScreen
+import must.kdroiders.hustlehub.ui.features.home.presentation.view.SearchScreen
 import must.kdroiders.hustlehub.ui.features.profilesetup.presentation.view.ProfileSetupScreen
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.CreateServiceScreen
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.MyServicesScreen
@@ -205,6 +207,8 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
                     onNavigateToEditService = { serviceId -> backstack.add(CreateService(serviceId = serviceId)) },
                     onNavigateToChatDetail = { chatId -> backstack.add(ChatDetail(chatId = chatId)) },
                     onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                    onNavigateToSearch = { backstack.add(must.kdroiders.hustlehub.navigation.SearchScreen) },
+                    onNavigateToAiSearch = { backstack.add(must.kdroiders.hustlehub.navigation.AiSearchScreen) },
                 )
             }
 
@@ -250,8 +254,21 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
             // Service detail — full provider profile, portfolio & reviews.
             // TODO(sprint-4): Replace this stub with the real ServiceDetailScreen.
             entry<ServiceDetail> { _ ->
-                // Placeholder: pop back to the discovery feed until ServiceDetailScreen is built.
                 if (backstack.size > 1) backstack.remove(backstack.last())
+            }
+
+            entry<must.kdroiders.hustlehub.navigation.SearchScreen> {
+                SearchScreen(
+                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                )
+            }
+
+            entry<must.kdroiders.hustlehub.navigation.AiSearchScreen> {
+                AiSearchScreen(
+                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                )
             }
         },
     )

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -204,6 +204,7 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
                     onNavigateToMyServices = { backstack.add(MyServices) },
                     onNavigateToEditService = { serviceId -> backstack.add(CreateService(serviceId = serviceId)) },
                     onNavigateToChatDetail = { chatId -> backstack.add(ChatDetail(chatId = chatId)) },
+                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
                 )
             }
 
@@ -242,8 +243,15 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
                 ChatDetailScreen(
                     conversationId = key.chatId,
                     onBackClick = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onNavigateToServiceDetail = { serviceId -> backstack.add(CreateService(serviceId = serviceId)) },
+                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
                 )
+            }
+
+            // Service detail — full provider profile, portfolio & reviews.
+            // TODO(sprint-4): Replace this stub with the real ServiceDetailScreen.
+            entry<ServiceDetail> { _ ->
+                // Placeholder: pop back to the discovery feed until ServiceDetailScreen is built.
+                if (backstack.size > 1) backstack.remove(backstack.last())
             }
         },
     )

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
@@ -89,3 +89,10 @@ data class CreateService(val serviceId: String? = null) : NavKey
 /** Full-screen management list of the current user's own services. */
 @Serializable
 data object MyServices : NavKey
+
+/**
+ * Service detail screen — shows a provider's full profile, portfolio, and reviews.
+ * Only [serviceId] is passed; the destination ViewModel fetches the full data.
+ */
+@Serializable
+data class ServiceDetail(val serviceId: String) : NavKey

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
@@ -90,6 +90,14 @@ data class CreateService(val serviceId: String? = null) : NavKey
 @Serializable
 data object MyServices : NavKey
 
+/** Full-screen search with filters, sort, and recent suggestions. */
+@Serializable
+data object SearchScreen : NavKey
+
+/** AI-powered natural language search screen. */
+@Serializable
+data object AiSearchScreen : NavKey
+
 /**
  * Service detail screen — shows a provider's full profile, portfolio, and reviews.
  * Only [serviceId] is passed; the destination ViewModel fetches the full data.

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
+import must.kdroiders.hustlehub.navigation.ServiceDetail
 import must.kdroiders.hustlehub.ui.features.chat.presentation.view.ChatScreen
 import must.kdroiders.hustlehub.ui.features.home.presentation.view.HomeScreen
 import must.kdroiders.hustlehub.ui.features.map.MapScreen
@@ -40,6 +41,7 @@ fun MainShellScreen(
     onNavigateToMyServices: () -> Unit = {},
     onNavigateToEditService: (serviceId: String) -> Unit = {},
     onNavigateToChatDetail: (String) -> Unit = {},
+    onNavigateToServiceDetail: (serviceId: String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val innerBackstack = rememberNavBackStack(BottomHome)
@@ -68,7 +70,11 @@ fun MainShellScreen(
             transitionSpec = { fadeIn() togetherWith fadeOut() },
             popTransitionSpec = { fadeIn() togetherWith fadeOut() },
             entryProvider = entryProvider {
-                entry<BottomHome> { HomeScreen() }
+                entry<BottomHome> {
+                    HomeScreen(
+                        onNavigateToServiceDetail = onNavigateToServiceDetail,
+                    )
+                }
                 entry<BottomMap> { MapScreen() }
                 entry<BottomChat> {
                     ChatScreen(

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
+import must.kdroiders.hustlehub.navigation.AiSearchScreen
+import must.kdroiders.hustlehub.navigation.SearchScreen
 import must.kdroiders.hustlehub.navigation.ServiceDetail
 import must.kdroiders.hustlehub.ui.features.chat.presentation.view.ChatScreen
 import must.kdroiders.hustlehub.ui.features.home.presentation.view.HomeScreen
@@ -42,6 +44,8 @@ fun MainShellScreen(
     onNavigateToEditService: (serviceId: String) -> Unit = {},
     onNavigateToChatDetail: (String) -> Unit = {},
     onNavigateToServiceDetail: (serviceId: String) -> Unit = {},
+    onNavigateToSearch: () -> Unit = {},
+    onNavigateToAiSearch: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val innerBackstack = rememberNavBackStack(BottomHome)
@@ -73,6 +77,7 @@ fun MainShellScreen(
                 entry<BottomHome> {
                     HomeScreen(
                         onNavigateToServiceDetail = onNavigateToServiceDetail,
+                        onNavigateToSearch = onNavigateToSearch,
                     )
                 }
                 entry<BottomMap> { MapScreen() }

--- a/app/src/main/java/must/kdroiders/hustlehub/splash/SplashViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/splash/SplashViewModel.kt
@@ -108,7 +108,7 @@ class SplashViewModel
                                                 )
                                                 val saveResult = userRepository.saveUserProfile(defaultUser)
                                                 saveResult.onFailure { saveException ->
-                                                    if (saveException is retrofit2.HttpException) {
+                                                    if (saveException is retrofit2.HttpException && (saveException.code() == 401 || saveException.code() == 403)) {
                                                         firebaseAuth?.signOut()
                                                         targetDestination = SplashDestination.Login
                                                     } else {
@@ -118,7 +118,10 @@ class SplashViewModel
                                             }
                                         }.onFailure { e ->
                                             if (e is retrofit2.HttpException) {
-                                                if (e.code() == 404 || e.code() == 403 || e.code() == 401) {
+                                                if (e.code() == 401 || e.code() == 403) {
+                                                    firebaseAuth?.signOut()
+                                                    targetDestination = SplashDestination.Login
+                                                } else if (e.code() == 404) {
                                                     val defaultUser = User(
                                                         id = currentUser.uid,
                                                         name = currentUser.displayName ?: "Student",
@@ -132,13 +135,16 @@ class SplashViewModel
                                                         isOnline = true,
                                                     )
                                                     val saveResult = userRepository.saveUserProfile(defaultUser)
-                                                    saveResult.onFailure {
-                                                        firebaseAuth?.signOut()
-                                                        targetDestination = SplashDestination.Login
+                                                    saveResult.onFailure { saveException ->
+                                                        if (saveException is retrofit2.HttpException && (saveException.code() == 401 || saveException.code() == 403)) {
+                                                            firebaseAuth?.signOut()
+                                                            targetDestination = SplashDestination.Login
+                                                        } else {
+                                                            targetDestination = SplashDestination.Home
+                                                        }
                                                     }
                                                 } else {
-                                                    firebaseAuth?.signOut()
-                                                    targetDestination = SplashDestination.Login
+                                                    targetDestination = SplashDestination.Home
                                                 }
                                             } else {
                                                 targetDestination = SplashDestination.Home

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/data/repository/AiSearchRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/data/repository/AiSearchRepositoryImpl.kt
@@ -1,0 +1,65 @@
+package must.kdroiders.hustlehub.ui.features.home.data.repository
+
+import must.kdroiders.hustlehub.data.remote.AiSearchRequest
+import must.kdroiders.hustlehub.data.remote.AiSearchResponse
+import must.kdroiders.hustlehub.data.remote.DiscoveryApiService
+import must.kdroiders.hustlehub.ui.features.home.domain.repository.AiSearchRepository
+import timber.log.Timber
+
+/** Cache TTL in milliseconds (5 minutes). */
+private const val CACHE_TTL_MS = 5 * 60 * 1_000L
+/** Maximum number of cached query results held in memory. Oldest entry is evicted when full. */
+private const val CACHE_MAX_ENTRIES = 20
+
+/**
+ * Concrete implementation of [AiSearchRepository].
+ *
+ * The backend handles Gemini interaction and keyword fallback internally, so this impl
+ * simply calls the endpoint and maintains an LRU-bounded in-memory TTL cache to avoid
+ * redundant Gemini calls for repeated queries within a 5-minute window.
+ *
+ * Cache key: trimmed, lowercased query string.
+ */
+class AiSearchRepositoryImpl(
+    private val discoveryApiService: DiscoveryApiService,
+) : AiSearchRepository {
+
+    // LinkedHashMap in access-order mode = LRU eviction.
+    private val cache = object : LinkedHashMap<String, Pair<Long, AiSearchResponse>>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Pair<Long, AiSearchResponse>>): Boolean =
+            size > CACHE_MAX_ENTRIES
+    }
+
+    override suspend fun aiSearch(
+        query: String,
+        userLocation: AiSearchRequest.UserLocationDto?,
+        maxResults: Int,
+    ): Result<AiSearchResponse> {
+        val cacheKey = query.trim().lowercase()
+        val now = System.currentTimeMillis()
+
+        // Serve from cache if a fresh entry exists.
+        cache[cacheKey]?.let { (timestamp, cached) ->
+            if (now - timestamp < CACHE_TTL_MS) {
+                Timber.d("AI search cache hit for query='$cacheKey'")
+                return Result.success(cached)
+            } else {
+                cache.remove(cacheKey) // evict stale entry
+            }
+        }
+
+        return try {
+            val request = AiSearchRequest(query = query, userLocation = userLocation, maxResults = maxResults)
+            val response = discoveryApiService.aiSearch(request)
+            if (response.success && response.data != null) {
+                cache[cacheKey] = now to response.data
+                Result.success(response.data)
+            } else {
+                Result.failure(Exception(response.message))
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "AI search network failure for query='$query'")
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/model/SearchFilters.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/model/SearchFilters.kt
@@ -1,0 +1,36 @@
+package must.kdroiders.hustlehub.ui.features.home.domain.model
+
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+
+/**
+ * Immutable value object representing the user's active search filters.
+ *
+ * An empty [SearchFilters] (all defaults) means "show everything".
+ * [isDefault] can be used to hide the active-filter chip row when no filters are set.
+ */
+data class SearchFilters(
+    val categories: Set<String> = emptySet(),
+    val minRating: Float = 0f,
+    val maxPrice: Int = 5000,
+    val availability: ServiceAvailability? = null,
+    val sortOrder: SortOrder = SortOrder.NEWEST,
+    val lat: Double? = null,
+    val lng: Double? = null,
+) {
+    val isDefault: Boolean
+        get() = categories.isEmpty() &&
+            minRating == 0f &&
+            maxPrice == 5000 &&
+            availability == null &&
+            sortOrder == SortOrder.NEWEST
+}
+
+/**
+ * Sort options supported by the backend's BrowseFilters.SortBy enum.
+ * [apiValue] must match the backend enum name exactly.
+ */
+enum class SortOrder(val label: String, val apiValue: String) {
+    NEWEST("Newest", "NEWEST"),
+    RATING("Highest Rated", "RATING"),
+    DISTANCE("Nearest", "DISTANCE"),
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/repository/AiSearchRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/repository/AiSearchRepository.kt
@@ -1,0 +1,17 @@
+package must.kdroiders.hustlehub.ui.features.home.domain.repository
+
+import must.kdroiders.hustlehub.data.remote.AiSearchRequest
+import must.kdroiders.hustlehub.data.remote.AiSearchResponse
+
+/**
+ * Contract for AI-powered service discovery.
+ *
+ * Implementations may cache results to avoid repeated Gemini calls for identical queries.
+ */
+interface AiSearchRepository {
+    suspend fun aiSearch(
+        query: String,
+        userLocation: AiSearchRequest.UserLocationDto?,
+        maxResults: Int = 10,
+    ): Result<AiSearchResponse>
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/usecase/AiSearchUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/usecase/AiSearchUseCase.kt
@@ -1,0 +1,18 @@
+package must.kdroiders.hustlehub.ui.features.home.domain.usecase
+
+import must.kdroiders.hustlehub.data.remote.AiSearchRequest
+import must.kdroiders.hustlehub.data.remote.AiSearchResponse
+import must.kdroiders.hustlehub.ui.features.home.domain.repository.AiSearchRepository
+import javax.inject.Inject
+
+class AiSearchUseCase
+    @Inject
+    constructor(
+        private val repository: AiSearchRepository,
+    ) {
+        suspend operator fun invoke(
+            query: String,
+            userLocation: AiSearchRequest.UserLocationDto? = null,
+            maxResults: Int = 10,
+        ): Result<AiSearchResponse> = repository.aiSearch(query, userLocation, maxResults)
+    }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/usecase/SearchServicesUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/domain/usecase/SearchServicesUseCase.kt
@@ -1,0 +1,58 @@
+package must.kdroiders.hustlehub.ui.features.home.domain.usecase
+
+import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+import must.kdroiders.hustlehub.ui.features.home.domain.model.SearchFilters
+import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
+import javax.inject.Inject
+
+/**
+ * Executes a service search applying text query and/or filter criteria.
+ *
+ * Routing logic:
+ * - When [query] is non-blank: calls [ServiceRepository.searchServices] (GET /discovery/search?q=)
+ *   which performs full-text search sorted by rating on the server.
+ * - When [query] is blank but filters are set: calls [ServiceRepository.browseServices]
+ *   with the filter params forwarded to GET /discovery/services.
+ * - When both are empty: calls browse with no constraints (same as the Home screen).
+ */
+class SearchServicesUseCase
+    @Inject
+    constructor(
+        private val repository: ServiceRepository,
+    ) {
+        suspend operator fun invoke(
+            query: String,
+            filters: SearchFilters,
+            page: Int = 0,
+            size: Int = 20,
+        ): Result<PageResponse<Service>> {
+            val trimmedQuery = query.trim()
+
+            return if (trimmedQuery.isNotBlank()) {
+                // Text search — dedicated endpoint, ignores filter params (server sorts by rating).
+                repository.searchServices(query = trimmedQuery, page = page, size = size)
+            } else {
+                // Filter-only browse — no text query.
+                val categoryEnum = if (filters.categories.size == 1) {
+                    runCatching { ServiceCategory.valueOf(filters.categories.first()) }.getOrNull()
+                } else {
+                    null
+                }
+
+                repository.browseServices(
+                    page = page,
+                    size = size,
+                    category = categoryEnum,
+                    query = null,
+                    availability = filters.availability,
+                    minRating = if (filters.minRating > 0f) filters.minRating.toDouble() else null,
+                    maxPrice = if (filters.maxPrice < 5000) filters.maxPrice else null,
+                    lat = filters.lat,
+                    lng = filters.lng,
+                    sortBy = filters.sortOrder.apiValue,
+                )
+            }
+        }
+    }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/AiMatchCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/AiMatchCard.kt
@@ -1,0 +1,121 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import must.kdroiders.hustlehub.data.remote.AiSearchMatch
+import kotlin.math.roundToInt
+
+/**
+ * Card representing a single AI search match result.
+ *
+ * Displays the service title, category, relevance percentage badge,
+ * price range, match reason, and a "View" button.
+ */
+@Composable
+fun AiMatchCard(
+    match: AiSearchMatch,
+    onViewClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("ai_match_card_${match.serviceId}"),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = match.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = match.category,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                // Relevance percentage badge
+                val pct = (match.relevanceScore * 100).roundToInt()
+                val badgeColor = when {
+                    pct >= 80 -> MaterialTheme.colorScheme.primary
+                    pct >= 60 -> MaterialTheme.colorScheme.tertiary
+                    else -> MaterialTheme.colorScheme.outline
+                }
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(20.dp))
+                        .background(badgeColor.copy(alpha = 0.12f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = "$pct% match",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = badgeColor,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            Text(
+                text = match.matchReason,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(6.dp))
+
+            Text(
+                text = "KES ${match.priceRange}",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            OutlinedButton(
+                onClick = onViewClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("ai_match_view_button_${match.serviceId}"),
+            ) {
+                Text("View Service")
+            }
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FeaturedServicesRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FeaturedServicesRow.kt
@@ -1,0 +1,186 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
+
+/**
+ * Horizontally scrollable row showcasing the top 5 rated services.
+ *
+ * Featured services are derived client-side by [HomeViewModel] from the loaded
+ * page (top 5 by [Service.averageRating]).
+ *
+ * @param services   The top-rated subset — should contain ≤ 5 items.
+ * @param onServiceClick  Navigates to [ServiceDetail] for the tapped service.
+ */
+@Composable
+fun FeaturedServicesRow(
+    services: List<Service>,
+    onServiceClick: (serviceId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("featured_services_row"),
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items(items = services, key = { it.id }) { service ->
+            FeaturedServiceCard(
+                service = service,
+                onClick = { onServiceClick(service.id) },
+            )
+        }
+    }
+}
+
+/** Individual featured service card used in the horizontal Featured row. */
+@Composable
+private fun FeaturedServiceCard(
+    service: Service,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .width(180.dp)
+            .height(240.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .clickable(onClick = onClick)
+            .testTag("featured_card_${service.id}"),
+    ) {
+        // Hero image — gradient fallback when no portfolio image is available
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(165.dp)
+                .background(
+                    Brush.linearGradient(
+                        colors = when (service.category) {
+                            ServiceCategory.SALON -> listOf(
+                                MaterialTheme.colorScheme.primary,
+                                MaterialTheme.colorScheme.tertiary,
+                            )
+                            ServiceCategory.TUTORING -> listOf(
+                                MaterialTheme.colorScheme.secondary,
+                                MaterialTheme.colorScheme.secondaryContainer,
+                            )
+                            ServiceCategory.DESIGN -> listOf(
+                                MaterialTheme.colorScheme.tertiary,
+                                MaterialTheme.colorScheme.tertiaryContainer,
+                            )
+                            else -> listOf(
+                                MaterialTheme.colorScheme.surfaceVariant,
+                                MaterialTheme.colorScheme.surface,
+                            )
+                        },
+                    ),
+                ),
+        ) {
+            val imageUrl = service.portfolio.firstOrNull() ?: service.iconUrl
+            if (imageUrl.isNotBlank()) {
+                AsyncImage(
+                    model = imageUrl,
+                    contentDescription = service.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+
+            // ⭐ Rating badge overlaid on hero image
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.55f))
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = null,
+                        tint = HustleWarningAmber,
+                        modifier = Modifier.size(12.dp),
+                    )
+                    Spacer(Modifier.width(3.dp))
+                    Text(
+                        text = "%.1f".format(service.averageRating),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontSize = 11.sp,
+                    )
+                }
+            }
+        }
+
+        // Bottom info section
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .padding(start = 10.dp, end = 10.dp, bottom = 10.dp, top = 6.dp),
+        ) {
+            Text(
+                text = service.category.label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 11.sp,
+            )
+            Text(
+                text = service.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontSize = 13.sp,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = "KES ${service.priceRange}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 11.sp,
+            )
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
@@ -1,0 +1,199 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.data.model.ServiceCategory
+import must.kdroiders.hustlehub.ui.features.home.domain.model.SearchFilters
+import must.kdroiders.hustlehub.ui.features.home.domain.model.SortOrder
+
+/**
+ * Full-screen bottom sheet containing all filter and sort controls.
+ *
+ * State is held as a [draft] by the caller ([SearchViewModel.draftFilters]) so the user
+ * can cancel without committing changes. [onDraftChanged] is called on every interaction.
+ * [onApply] commits the draft; [onReset] clears all filters to defaults.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun FilterBottomSheet(
+    draft: SearchFilters,
+    onDraftChanged: (SearchFilters) -> Unit,
+    onApply: () -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = Modifier.testTag("filter_bottom_sheet"),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp)
+                .navigationBarsPadding(),
+        ) {
+            Text(
+                text = "Filters",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(20.dp))
+
+            // Category multi-select chips
+            FilterSectionLabel("Category")
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ServiceCategory.entries
+                    .filter { it != ServiceCategory.ALL }
+                    .forEach { category ->
+                        val selected = draft.categories.contains(category.name)
+                        FilterChip(
+                            selected = selected,
+                            onClick = {
+                                val updated = if (selected) {
+                                    draft.categories - category.name
+                                } else {
+                                    draft.categories + category.name
+                                }
+                                onDraftChanged(draft.copy(categories = updated))
+                            },
+                            label = { Text(category.label) },
+                            modifier = Modifier.testTag("filter_category_${category.name}"),
+                        )
+                    }
+            }
+            Spacer(Modifier.height(20.dp))
+
+            // Minimum rating slider
+            FilterSectionLabel("Min Rating: ${if (draft.minRating == 0f) "Any" else "%.1f+ stars".format(draft.minRating)}")
+            Slider(
+                value = draft.minRating,
+                onValueChange = { onDraftChanged(draft.copy(minRating = it)) },
+                valueRange = 0f..5f,
+                steps = 9, // 0.5 increments
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("filter_rating_slider"),
+            )
+            Spacer(Modifier.height(20.dp))
+
+            // Max price slider
+            FilterSectionLabel("Max Price: ${if (draft.maxPrice >= 5000) "Any" else "KES ${draft.maxPrice}"}")
+            Slider(
+                value = draft.maxPrice.toFloat(),
+                onValueChange = { onDraftChanged(draft.copy(maxPrice = it.toInt())) },
+                valueRange = 0f..5000f,
+                steps = 49, // KES 100 increments
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("filter_price_slider"),
+            )
+            Spacer(Modifier.height(20.dp))
+
+            // Availability segmented button
+            FilterSectionLabel("Availability")
+            val availabilityOptions = listOf(null, ServiceAvailability.AVAILABLE, ServiceAvailability.BUSY)
+            val availabilityLabels = listOf("All", "Available", "Busy")
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("filter_availability"),
+            ) {
+                availabilityOptions.forEachIndexed { index, option ->
+                    SegmentedButton(
+                        selected = draft.availability == option,
+                        onClick = { onDraftChanged(draft.copy(availability = option)) },
+                        shape = SegmentedButtonDefaults.itemShape(index, availabilityOptions.size),
+                        label = { Text(availabilityLabels[index]) },
+                    )
+                }
+            }
+            Spacer(Modifier.height(20.dp))
+
+            // Sort order segmented button
+            FilterSectionLabel("Sort By")
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("filter_sort"),
+            ) {
+                SortOrder.entries.forEachIndexed { index, sort ->
+                    SegmentedButton(
+                        selected = draft.sortOrder == sort,
+                        onClick = { onDraftChanged(draft.copy(sortOrder = sort)) },
+                        shape = SegmentedButtonDefaults.itemShape(index, SortOrder.entries.size),
+                        label = { Text(sort.label) },
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(28.dp))
+
+            // Action buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(
+                    onClick = onReset,
+                    modifier = Modifier.testTag("filter_reset_button"),
+                ) {
+                    Text("Reset")
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = onApply,
+                    modifier = Modifier.testTag("filter_apply_button"),
+                ) {
+                    Text("Apply Filters")
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun FilterSectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp),
+    )
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
@@ -20,18 +20,31 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import must.kdroiders.hustlehub.R
 
+/**
+ * Discovery screen search bar with an ✨ AI trigger chip.
+ *
+ * The [onAiSearchClick] callback is a placeholder; the dedicated AI Search screen
+ * will be wired up in a future issue when its bottom-tab is implemented.
+ */
 @Composable
 fun HomeSearchBar(
     query: String,
     onQueryChanged: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onAiSearchClick: () -> Unit = {},
 ) {
     Row(
         modifier = modifier
-            .height(50.dp)
-            .clip(RoundedCornerShape(25.dp))
+            .height(52.dp)
+            .clip(RoundedCornerShape(26.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant)
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -46,15 +59,51 @@ fun HomeSearchBar(
         Text(
             text = if (query.isEmpty()) "Search services..." else query,
             style = MaterialTheme.typography.bodyMedium,
-            color = if (query.isEmpty()) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface,
+            color = if (query.isEmpty()) {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
             modifier = Modifier
                 .weight(1f)
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
-                ) { /* TODO: open search screen */ },
+                ) { /* TODO: open dedicated search screen */ }
+                .testTag("home_search_field"),
         )
         Spacer(Modifier.width(8.dp))
-        // AI badge has been removed
+        // ✨ AI chip — placeholder; routes to AI Search screen (upcoming issue).
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(20.dp))
+                .background(
+                    Brush.linearGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                            MaterialTheme.colorScheme.tertiary.copy(alpha = 0.9f),
+                        ),
+                    ),
+                )
+                .clickable(onClick = onAiSearchClick)
+                .padding(horizontal = 10.dp, vertical = 5.dp)
+                .testTag("home_ai_search_button"),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_ai_sparkle),
+                contentDescription = "AI Search",
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(13.dp),
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "AI",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimary,
+                fontSize = 11.sp,
+            )
+        }
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
@@ -29,16 +29,18 @@ import androidx.compose.ui.unit.sp
 import must.kdroiders.hustlehub.R
 
 /**
- * Discovery screen search bar with an ✨ AI trigger chip.
+ * Non-editable search bar displayed on the Home/Discovery screen.
  *
- * The [onAiSearchClick] callback is a placeholder; the dedicated AI Search screen
- * will be wired up in a future issue when its bottom-tab is implemented.
+ * This is a styled button, not an actual text field. Tapping anywhere on the
+ * bar (except the AI chip) navigates to [SearchScreen] where real editing occurs.
+ * This mirrors the UX pattern used by Google Maps, Airbnb, and similar apps.
  */
 @Composable
 fun HomeSearchBar(
     query: String,
     onQueryChanged: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onSearchClick: () -> Unit = {},
     onAiSearchClick: () -> Unit = {},
 ) {
     Row(
@@ -69,7 +71,8 @@ fun HomeSearchBar(
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
-                ) { /* TODO: open dedicated search screen */ }
+                    onClick = onSearchClick,
+                )
                 .testTag("home_search_field"),
         )
         Spacer(Modifier.width(8.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/AiSearchScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/AiSearchScreen.kt
@@ -1,0 +1,250 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.view
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import must.kdroiders.hustlehub.R
+import must.kdroiders.hustlehub.data.remote.QueryUnderstanding
+import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleTextField
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.AiMatchCard
+import must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel.AiSearchViewModel
+
+/**
+ * AI Search screen — accepts a natural language query and displays ranked service matches.
+ *
+ * The Gemini call happens server-side. If the backend falls back to keyword search,
+ * a warning banner is shown above the results.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AiSearchScreen(
+    onBack: () -> Unit,
+    onNavigateToServiceDetail: (serviceId: String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AiSearchViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.error) {
+        state.error?.let { snackbarHostState.showSnackbar(it); viewModel.clearError() }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            TopAppBar(
+                title = { Text("AI Search", fontWeight = FontWeight.SemiBold) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                actions = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_ai_sparkle),
+                        contentDescription = "AI powered",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(end = 16.dp).size(20.dp),
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+                modifier = Modifier.statusBarsPadding(),
+            )
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // Query input + search button
+                item(key = "input") {
+                    Column {
+                        HustleTextField(
+                            value = state.query,
+                            onValueChange = viewModel::onQueryChanged,
+                            label = "What do you need?",
+                            placeholder = "e.g. braids near Hostel C under 500",
+                            singleLine = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("ai_search_input"),
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        HustleButton(
+                            text = "Find Match",
+                            onClick = { viewModel.onSearch() },
+                            enabled = state.query.isNotBlank(),
+                            loading = state.isLoading,
+                            icon = Icons.Default.Search,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("ai_search_button"),
+                        )
+                    }
+                }
+
+                // Loading indicator
+                if (state.isLoading) {
+                    item(key = "loading") {
+                        Box(modifier = Modifier.fillMaxWidth().padding(24.dp), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.testTag("ai_search_loading"),
+                            )
+                        }
+                    }
+                }
+
+                // Fallback warning banner
+                if (state.usedFallback && state.matches.isNotEmpty()) {
+                    item(key = "fallback_banner") {
+                        Card(
+                            shape = RoundedCornerShape(10.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                            ),
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(
+                            text = "AI is temporarily unavailable — showing keyword results instead.",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                modifier = Modifier.padding(12.dp),
+                            )
+                        }
+                    }
+                }
+
+                // Query understanding chips
+                state.queryUnderstanding?.let { understanding ->
+                    if (!state.isLoading && state.matches.isNotEmpty()) {
+                        item(key = "understanding") {
+                            QueryUnderstandingRow(understanding = understanding)
+                        }
+                    }
+                }
+
+                // Results header
+                if (!state.isLoading && state.matches.isNotEmpty()) {
+                    item(key = "results_header") {
+                        Text(
+                            text = "Best Matches",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+                }
+
+                // Match cards
+                if (!state.isLoading) {
+                    items(items = state.matches, key = { it.serviceId }) { match ->
+                        AiMatchCard(
+                            match = match,
+                            onViewClick = { onNavigateToServiceDetail(match.serviceId) },
+                        )
+                    }
+                }
+
+                // Empty state — shown after a search that returned nothing
+                if (!state.isLoading && state.matches.isEmpty() && state.query.isNotEmpty() && state.error == null) {
+                    item(key = "empty") {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "No matches found.\nTry a different query.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+
+                item { Spacer(Modifier.height(80.dp)) }
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun QueryUnderstandingRow(understanding: QueryUnderstanding) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(vertical = 4.dp),
+    ) {
+        understanding.service?.let {
+            item { InputChip(selected = false, onClick = {}, label = { Text("Service: $it") }) }
+        }
+        understanding.category?.let {
+            item { InputChip(selected = false, onClick = {}, label = { Text("Category: $it") }) }
+        }
+        understanding.location?.let {
+            item { InputChip(selected = false, onClick = {}, label = { Text("Near: $it") }) }
+        }
+        understanding.maxPrice?.let {
+            item { InputChip(selected = false, onClick = {}, label = { Text("≤ KES $it") }) }
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -30,36 +32,50 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.CategoryChipRow
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.EmptyServicesView
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.FeaturedServicesRow
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.HomeSearchBar
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.HomeTopBar
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCard
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCardShimmer
 import must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel.HomeViewModel
 
+/** Number of shimmer placeholders shown while the initial page loads. */
+private const val SHIMMER_COUNT = 6
+
+/**
+ * Discovery / Home screen — the primary browsing destination.
+ *
+ * NavKey: [BottomHome]
+ * Layout:
+ *  - Full-span header: TopBar → SearchBar (with AI chip) → CategoryChips → Featured row
+ *  - 2-column [LazyVerticalGrid] of service cards with shimmer loading
+ *  - Pagination trigger on scroll near the end
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
+    onNavigateToServiceDetail: (serviceId: String) -> Unit = {},
 ) {
     val state by viewModel.uiState.collectAsState()
-    val listState = rememberLazyListState()
+    val gridState = rememberLazyGridState()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // Detect end of list to trigger next page
+    // Detect when the user scrolls to 3 items before the end to trigger next page.
     val shouldLoadMore by remember {
         derivedStateOf {
-            val lastVisible = listState.layoutInfo.visibleItemsInfo
+            val lastVisible = gridState.layoutInfo.visibleItemsInfo
                 .lastOrNull()
                 ?.index ?: 0
-            val totalItems = listState.layoutInfo.totalItemsCount
-            // Gate loading more on common pagination conditions
+            val totalItems = gridState.layoutInfo.totalItemsCount
             lastVisible >= totalItems - 3 &&
                 !state.isLoadingServices &&
                 !state.isLoadingMore &&
@@ -68,15 +84,13 @@ fun HomeScreen(
         }
     }
 
-    LaunchedEffect(listState) {
+    LaunchedEffect(gridState) {
         snapshotFlow { shouldLoadMore }
             .distinctUntilChanged()
-            .collect { atEnd ->
-                if (atEnd) viewModel.loadNextPage()
-            }
+            .collect { atEnd -> if (atEnd) viewModel.loadNextPage() }
     }
 
-    // Show errors as snackbar
+    // Surface errors as snackbars so the grid stays visible (offline-first UX).
     LaunchedEffect(state.error) {
         state.error?.let {
             snackbarHostState.showSnackbar(it)
@@ -90,6 +104,7 @@ fun HomeScreen(
             .background(MaterialTheme.colorScheme.background),
     ) {
         val pullToRefreshState = rememberPullToRefreshState()
+
         PullToRefreshBox(
             isRefreshing = state.isRefreshing,
             onRefresh = viewModel::onRefresh,
@@ -105,89 +120,130 @@ fun HomeScreen(
                 )
             },
         ) {
-            LazyColumn(
-                state = listState,
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = gridState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .statusBarsPadding(),
-                contentPadding = PaddingValues(bottom = 100.dp),
+                    .statusBarsPadding()
+                    .testTag("home_service_grid"),
+                contentPadding = PaddingValues(
+                    start = 12.dp,
+                    end = 12.dp,
+                    bottom = 100.dp,
+                ),
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(12.dp),
+                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(12.dp),
             ) {
-                // Top app bar
-                item(key = "topbar") {
+                // Header items span both columns.
+
+                item(key = "topbar", span = { GridItemSpan(maxLineSpan) }) {
                     HomeTopBar(
                         initials = state.providerInitials,
                         notificationCount = state.notificationCount,
                     )
                 }
 
-                // Search bar
-                item(key = "search") {
-                    Spacer(Modifier.height(16.dp))
+                item(key = "searchbar", span = { GridItemSpan(maxLineSpan) }) {
                     HomeSearchBar(
                         query = state.searchQuery,
                         onQueryChanged = viewModel::onSearchQueryChanged,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
+                            .padding(horizontal = 4.dp),
                     )
                 }
 
-                // Category chips
-                item(key = "categories") {
-                    Spacer(Modifier.height(16.dp))
+                item(key = "categories", span = { GridItemSpan(maxLineSpan) }) {
+                    Spacer(Modifier.height(4.dp))
                     CategoryChipRow(
                         selected = state.selectedCategory,
                         onSelected = viewModel::onCategorySelected,
                     )
                 }
 
-                // Browse services section header
-                item(key = "browse_header") {
-                    Spacer(Modifier.height(16.dp))
+                // Featured section — top 5 rated services, conditionally shown.
+
+                if (state.featuredServices.isNotEmpty()) {
+                    item(key = "featured_header", span = { GridItemSpan(maxLineSpan) }) {
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = "⭐ Featured",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            modifier = Modifier.padding(start = 4.dp),
+                        )
+                        Spacer(Modifier.height(10.dp))
+                    }
+
+                    item(key = "featured_row", span = { GridItemSpan(maxLineSpan) }) {
+                        FeaturedServicesRow(
+                            services = state.featuredServices,
+                            onServiceClick = onNavigateToServiceDetail,
+                            // Negative horizontal padding to bleed past the grid's insets
+                            modifier = Modifier.padding(horizontal = (-12).dp),
+                        )
+                        Spacer(Modifier.height(4.dp))
+                    }
+                }
+
+                // Section label for the paginated service grid below.
+
+                item(key = "browse_header", span = { GridItemSpan(maxLineSpan) }) {
+                    Spacer(Modifier.height(4.dp))
                     Text(
                         text = "Browse Services",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onBackground,
-                        modifier = Modifier.padding(horizontal = 16.dp),
+                        modifier = Modifier.padding(start = 4.dp),
                     )
-                    Spacer(Modifier.height(12.dp))
+                    Spacer(Modifier.height(8.dp))
                 }
 
-                // Shimmer placeholders while initial load
+                // Show shimmer skeletons while the first page is in flight.
+
                 if (state.isLoadingServices) {
-                    items(count = 4, key = { "shimmer_$it" }) {
-                        ServiceCardShimmer(
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
-                        )
+                    items(
+                        count = SHIMMER_COUNT,
+                        key = { "shimmer_$it" },
+                        span = { GridItemSpan(1) },
+                    ) {
+                        ServiceCardShimmer()
                     }
                 }
 
-                // Empty state
+                // Empty state — shown only after a successful load returns no results.
+
                 if (!state.isLoadingServices && state.services.isEmpty()) {
-                    item(key = "empty") {
+                    item(key = "empty", span = { GridItemSpan(maxLineSpan) }) {
                         EmptyServicesView(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(top = 32.dp),
+                                .padding(top = 24.dp),
                         )
                     }
                 }
 
-                // Real service cards
-                itemsIndexed(
+                // Service cards rendered in the 2-column grid.
+
+                items(
                     items = state.services,
-                    key = { _, service -> service.id },
-                ) { _, service ->
+                    key = { it.id },
+                    span = { GridItemSpan(1) },
+                ) { service ->
                     ServiceCard(
                         service = service,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                        onClick = { onNavigateToServiceDetail(service.id) },
+                        modifier = Modifier.testTag("service_card_${service.id}"),
                     )
                 }
 
-                // Load-more spinner at the bottom
+                // Pagination progress indicator appended at the end of the list.
+
                 if (state.isLoadingMore) {
-                    item(key = "loading_more") {
+                    item(key = "loading_more", span = { GridItemSpan(maxLineSpan) }) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -211,3 +267,4 @@ fun HomeScreen(
         )
     }
 }
+

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -64,6 +64,8 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
     onNavigateToServiceDetail: (serviceId: String) -> Unit = {},
+    onNavigateToSearch: () -> Unit = {},
+    onNavigateToAiSearch: () -> Unit = {},
 ) {
     val state by viewModel.uiState.collectAsState()
     val gridState = rememberLazyGridState()
@@ -148,6 +150,8 @@ fun HomeScreen(
                     HomeSearchBar(
                         query = state.searchQuery,
                         onQueryChanged = viewModel::onSearchQueryChanged,
+                        onSearchClick = onNavigateToSearch,
+                        onAiSearchClick = onNavigateToAiSearch,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 4.dp),
@@ -168,7 +172,7 @@ fun HomeScreen(
                     item(key = "featured_header", span = { GridItemSpan(maxLineSpan) }) {
                         Spacer(Modifier.height(4.dp))
                         Text(
-                            text = "⭐ Featured",
+                            text = "Featured",
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onBackground,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/SearchScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/SearchScreen.kt
@@ -1,0 +1,483 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.view
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import must.kdroiders.hustlehub.data.model.ServiceAvailability
+import must.kdroiders.hustlehub.ui.features.home.domain.model.SearchFilters
+import must.kdroiders.hustlehub.ui.features.home.domain.model.SortOrder
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.EmptyServicesView
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.FilterBottomSheet
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCard
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCardShimmer
+import must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel.SearchViewModel
+
+private const val SEARCH_SHIMMER_COUNT = 6
+
+/**
+ * Full search screen with real-time text search, filter bottom sheet, active filter chips,
+ * recent search suggestions, and a paginated 2-column result grid.
+ *
+ * The search field is auto-focused on entry. Results update after a 300ms debounce
+ * in [SearchViewModel]. When the field is empty, recent search suggestions are shown.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchScreen(
+    onBack: () -> Unit,
+    onNavigateToServiceDetail: (serviceId: String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SearchViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val gridState = rememberLazyGridState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val focusRequester = remember { FocusRequester() }
+
+    // Auto-focus the search field when the screen opens.
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    // Pagination trigger.
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val lastVisible = gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            val total = gridState.layoutInfo.totalItemsCount
+            lastVisible >= total - 3 &&
+                !state.isLoading &&
+                !state.isLoadingMore &&
+                state.hasMorePages &&
+                state.services.isNotEmpty()
+        }
+    }
+    LaunchedEffect(gridState) {
+        snapshotFlow { shouldLoadMore }.distinctUntilChanged().collect { if (it) viewModel.loadNextPage() }
+    }
+
+    LaunchedEffect(state.error) {
+        state.error?.let { snackbarHostState.showSnackbar(it); viewModel.clearError() }
+    }
+
+    if (state.isFilterSheetOpen) {
+        FilterBottomSheet(
+            draft = state.draftFilters,
+            onDraftChanged = viewModel::onDraftFilterChanged,
+            onApply = viewModel::onFiltersApplied,
+            onReset = viewModel::onFiltersReset,
+            onDismiss = viewModel::onFilterSheetToggle,
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            state = gridState,
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .testTag("search_result_grid"),
+            contentPadding = PaddingValues(start = 12.dp, end = 12.dp, bottom = 100.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Top bar: back + search field + filter icon
+            item(key = "topbar", span = { GridItemSpan(maxLineSpan) }) {
+                SearchTopBar(
+                    query = state.query,
+                    onQueryChanged = viewModel::onQueryChanged,
+                    onBack = onBack,
+                    onFilterClick = viewModel::onFilterSheetToggle,
+                    focusRequester = focusRequester,
+                    hasActiveFilters = !state.filters.isDefault,
+                )
+            }
+
+            // Active filter chips — visible only when filters differ from defaults.
+            if (!state.filters.isDefault) {
+                item(key = "active_filters", span = { GridItemSpan(maxLineSpan) }) {
+                    ActiveFilterChipRow(
+                        filters = state.filters,
+                        onRemoveCategory = { cat ->
+                            viewModel.onFiltersApplied()
+                            viewModel.onDraftFilterChanged(
+                                state.filters.copy(categories = state.filters.categories - cat),
+                            )
+                            viewModel.onFiltersApplied()
+                        },
+                        onRemoveRating = {
+                            viewModel.onDraftFilterChanged(state.filters.copy(minRating = 0f))
+                            viewModel.onFiltersApplied()
+                        },
+                        onRemovePrice = {
+                            viewModel.onDraftFilterChanged(state.filters.copy(maxPrice = 5000))
+                            viewModel.onFiltersApplied()
+                        },
+                        onRemoveAvailability = {
+                            viewModel.onDraftFilterChanged(state.filters.copy(availability = null))
+                            viewModel.onFiltersApplied()
+                        },
+                        onRemoveSort = {
+                            viewModel.onDraftFilterChanged(state.filters.copy(sortOrder = SortOrder.NEWEST))
+                            viewModel.onFiltersApplied()
+                        },
+                        onClearAll = viewModel::onFiltersReset,
+                    )
+                }
+            }
+
+            // Recent searches — shown when query is empty and history exists.
+            if (state.query.isEmpty() && state.recentSearches.isNotEmpty()) {
+                item(key = "recent_header", span = { GridItemSpan(maxLineSpan) }) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "Recent",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        TextButton(onClick = { viewModel.clearRecentSearches() }) {
+                            Text("Clear", style = MaterialTheme.typography.labelMedium)
+                        }
+                    }
+                }
+                item(key = "recent_searches", span = { GridItemSpan(maxLineSpan) }) {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height((state.recentSearches.size * 48).dp.coerceAtMost(240.dp)),
+                        userScrollEnabled = false,
+                    ) {
+                        items(items = state.recentSearches, key = { it }) { term ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { viewModel.onQueryChanged(term) }
+                                    .padding(horizontal = 4.dp, vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.History,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                                Spacer(Modifier.width(12.dp))
+                                Text(
+                                    text = term,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Shimmer placeholders during initial load.
+            if (state.isLoading) {
+                items(count = SEARCH_SHIMMER_COUNT, key = { "shimmer_$it" }, span = { GridItemSpan(1) }) {
+                    ServiceCardShimmer()
+                }
+            }
+
+            // Empty state after successful load with no results.
+            if (!state.isLoading && state.services.isEmpty() && state.query.isNotEmpty()) {
+                item(key = "empty", span = { GridItemSpan(maxLineSpan) }) {
+                    EmptyServicesView(
+                        message = "No results for \"${state.query}\"",
+                        modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+                    )
+                }
+            }
+
+            // Result cards.
+            items(items = state.services, key = { it.id }, span = { GridItemSpan(1) }) { service ->
+                ServiceCard(
+                    service = service,
+                    onClick = { onNavigateToServiceDetail(service.id) },
+                    modifier = Modifier.testTag("search_card_${service.id}"),
+                )
+            }
+
+            // Pagination spinner.
+            if (state.isLoadingMore) {
+                item(key = "loading_more", span = { GridItemSpan(maxLineSpan) }) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.primary,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.padding(8.dp),
+                        )
+                    }
+                }
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun SearchTopBar(
+    query: String,
+    onQueryChanged: (String) -> Unit,
+    onBack: () -> Unit,
+    onFilterClick: () -> Unit,
+    focusRequester: FocusRequester,
+    hasActiveFilters: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        Spacer(Modifier.width(4.dp))
+        // Inline search text field styled as a capsule.
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .clip(RoundedCornerShape(24.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            BasicTextField(
+                value = query,
+                onValueChange = onQueryChanged,
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                ),
+                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { /* query fires on change */ }),
+                decorationBox = { inner ->
+                    if (query.isEmpty()) {
+                        Text(
+                            text = "Search services...",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    inner()
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester)
+                    .testTag("search_text_field"),
+            )
+            AnimatedVisibility(visible = query.isNotEmpty(), enter = fadeIn(), exit = fadeOut()) {
+                IconButton(onClick = { onQueryChanged("") }, modifier = Modifier.size(20.dp)) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Clear search",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.width(4.dp))
+        IconButton(
+            onClick = onFilterClick,
+            modifier = Modifier.testTag("filter_icon_button"),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Tune,
+                contentDescription = "Filters",
+                tint = if (hasActiveFilters) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActiveFilterChipRow(
+    filters: SearchFilters,
+    onRemoveCategory: (String) -> Unit,
+    onRemoveRating: () -> Unit,
+    onRemovePrice: () -> Unit,
+    onRemoveAvailability: () -> Unit,
+    onRemoveSort: () -> Unit,
+    onClearAll: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .testTag("active_filter_row"),
+        contentPadding = PaddingValues(horizontal = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Per-category chips
+        items(items = filters.categories.toList(), key = { "cat_$it" }) { cat ->
+            InputChip(
+                selected = true,
+                onClick = { onRemoveCategory(cat) },
+                label = { Text(cat) },
+                trailingIcon = {
+                    Icon(Icons.Default.Close, contentDescription = "Remove", modifier = Modifier.size(14.dp))
+                },
+            )
+        }
+        if (filters.minRating > 0f) {
+            item(key = "rating") {
+                InputChip(
+                    selected = true,
+                    onClick = onRemoveRating,
+                    label = { Text("%.1f+ stars".format(filters.minRating)) },
+                    trailingIcon = {
+                        Icon(Icons.Default.Close, contentDescription = "Remove", modifier = Modifier.size(14.dp))
+                    },
+                )
+            }
+        }
+        if (filters.maxPrice < 5000) {
+            item(key = "price") {
+                InputChip(
+                    selected = true,
+                    onClick = onRemovePrice,
+                    label = { Text("≤ KES ${filters.maxPrice}") },
+                    trailingIcon = {
+                        Icon(Icons.Default.Close, contentDescription = "Remove", modifier = Modifier.size(14.dp))
+                    },
+                )
+            }
+        }
+        filters.availability?.let { avail ->
+            item(key = "avail") {
+                InputChip(
+                    selected = true,
+                    onClick = onRemoveAvailability,
+                    label = { Text(if (avail == ServiceAvailability.AVAILABLE) "Available" else "Busy") },
+                    trailingIcon = {
+                        Icon(Icons.Default.Close, contentDescription = "Remove", modifier = Modifier.size(14.dp))
+                    },
+                )
+            }
+        }
+        if (filters.sortOrder != SortOrder.NEWEST) {
+            item(key = "sort") {
+                InputChip(
+                    selected = true,
+                    onClick = onRemoveSort,
+                    label = { Text(filters.sortOrder.label) },
+                    trailingIcon = {
+                        Icon(Icons.Default.Close, contentDescription = "Remove", modifier = Modifier.size(14.dp))
+                    },
+                )
+            }
+        }
+        item(key = "clear_all") {
+            TextButton(
+                onClick = onClearAll,
+                modifier = Modifier.testTag("clear_all_filters_button"),
+            ) {
+                Text(
+                    text = "Clear All",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/AiSearchViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/AiSearchViewModel.kt
@@ -1,0 +1,77 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.data.remote.AiSearchMatch
+import must.kdroiders.hustlehub.data.remote.AiSearchRequest
+import must.kdroiders.hustlehub.data.remote.QueryUnderstanding
+import must.kdroiders.hustlehub.ui.features.home.domain.usecase.AiSearchUseCase
+import javax.inject.Inject
+
+data class AiSearchUiState(
+    val query: String = "",
+    val matches: List<AiSearchMatch> = emptyList(),
+    val queryUnderstanding: QueryUnderstanding? = null,
+    val isLoading: Boolean = false,
+    /**
+     * True when the backend fell back to keyword search (Gemini unavailable).
+     * Derived heuristic: understanding has no category/location and service == raw query.
+     */
+    val usedFallback: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class AiSearchViewModel
+    @Inject
+    constructor(
+        private val aiSearchUseCase: AiSearchUseCase,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(AiSearchUiState())
+        val uiState: StateFlow<AiSearchUiState> = _uiState.asStateFlow()
+
+        fun onQueryChanged(query: String) {
+            _uiState.update { it.copy(query = query, error = null) }
+        }
+
+        fun onSearch(userLocation: AiSearchRequest.UserLocationDto? = null) {
+            val query = _uiState.value.query.trim()
+            if (query.isBlank()) return
+
+            _uiState.update { it.copy(isLoading = true, error = null) }
+
+            viewModelScope.launch {
+                aiSearchUseCase(query = query, userLocation = userLocation)
+                    .onSuccess { response ->
+                        val understanding = response.queryUnderstanding
+                        // Heuristic: if Gemini returned an understanding where service == raw
+                        // query and no category/location was parsed, the backend likely fell back.
+                        val likelyFallback = understanding.category == null &&
+                            understanding.location == null &&
+                            understanding.service?.equals(query, ignoreCase = true) == true
+
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                matches = response.matches,
+                                queryUnderstanding = understanding,
+                                usedFallback = likelyFallback,
+                            )
+                        }
+                    }
+                    .onFailure { error ->
+                        _uiState.update { it.copy(isLoading = false, error = error.message) }
+                    }
+            }
+        }
+
+        fun clearError() {
+            _uiState.update { it.copy(error = null) }
+        }
+    }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
@@ -27,6 +27,8 @@ data class HomeUiState(
     val notificationCount: Int = 0,
     // Paginated real services from backend
     val services: List<Service> = emptyList(),
+    /** Top 5 highest-rated services derived from the loaded list — powers the Featured row. */
+    val featuredServices: List<Service> = emptyList(),
     val isLoadingServices: Boolean = false,
     val isRefreshing: Boolean = false,
     val isLoadingMore: Boolean = false,
@@ -102,8 +104,16 @@ class HomeViewModel
                                 (current.services + pageResponse.content).distinctBy { it.id }
                             }
 
+                            // Derive top 5 rated services for the Featured row.
+                            // Only services with at least one review qualify.
+                            val featured = merged
+                                .filter { it.averageRating > 0f }
+                                .sortedByDescending { it.averageRating }
+                                .take(5)
+
                             current.copy(
                                 services = merged,
+                                featuredServices = featured,
                                 isLoadingServices = false,
                                 isRefreshing = false,
                                 isLoadingMore = false,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/SearchViewModel.kt
@@ -1,0 +1,168 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.data.model.Service
+import must.kdroiders.hustlehub.datastore.UserPreferences
+import must.kdroiders.hustlehub.ui.features.home.domain.model.SearchFilters
+import must.kdroiders.hustlehub.ui.features.home.domain.usecase.SearchServicesUseCase
+import javax.inject.Inject
+
+private const val PAGE_SIZE = 20
+private const val SEARCH_DEBOUNCE_MS = 300L
+
+data class SearchUiState(
+    val query: String = "",
+    /** Live applied filters — these drive the active filter chip row. */
+    val filters: SearchFilters = SearchFilters(),
+    /** Draft filters held in the bottom sheet before the user taps Apply. */
+    val draftFilters: SearchFilters = SearchFilters(),
+    val recentSearches: List<String> = emptyList(),
+    val services: List<Service> = emptyList(),
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val hasMorePages: Boolean = true,
+    val currentPage: Int = 0,
+    val isFilterSheetOpen: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class SearchViewModel
+    @Inject
+    constructor(
+        private val searchServicesUseCase: SearchServicesUseCase,
+        private val userPreferences: UserPreferences,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(SearchUiState())
+        val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
+
+        // Internal query flow to drive debounced search.
+        private val _queryFlow = MutableStateFlow("")
+
+        init {
+            observeRecentSearches()
+            observeQueryDebounced()
+        }
+
+        private fun observeRecentSearches() {
+            userPreferences.recentSearches
+                .onEach { searches -> _uiState.update { it.copy(recentSearches = searches) } }
+                .launchIn(viewModelScope)
+        }
+
+        @OptIn(FlowPreview::class)
+        private fun observeQueryDebounced() {
+            _queryFlow
+                .drop(1) // skip initial empty string
+                .debounce(SEARCH_DEBOUNCE_MS)
+                .distinctUntilChanged()
+                .onEach { query -> fetchPage(query = query, filters = _uiState.value.filters, reset = true) }
+                .launchIn(viewModelScope)
+        }
+
+        fun onQueryChanged(query: String) {
+            _uiState.update { it.copy(query = query) }
+            _queryFlow.value = query
+        }
+
+        fun onDraftFilterChanged(draft: SearchFilters) {
+            _uiState.update { it.copy(draftFilters = draft) }
+        }
+
+        fun onFilterSheetToggle() {
+            _uiState.update { current ->
+                val opening = !current.isFilterSheetOpen
+                // When opening: seed draft with the currently applied filters.
+                current.copy(
+                    isFilterSheetOpen = opening,
+                    draftFilters = if (opening) current.filters else current.draftFilters,
+                )
+            }
+        }
+
+        fun onFiltersApplied() {
+            val draft = _uiState.value.draftFilters
+            _uiState.update { it.copy(filters = draft, isFilterSheetOpen = false) }
+            fetchPage(query = _uiState.value.query, filters = draft, reset = true)
+        }
+
+        fun onFiltersReset() {
+            val empty = SearchFilters()
+            _uiState.update { it.copy(draftFilters = empty, filters = empty, isFilterSheetOpen = false) }
+            fetchPage(query = _uiState.value.query, filters = empty, reset = true)
+        }
+
+        fun clearRecentSearches() {
+            viewModelScope.launch {
+                userPreferences.clearRecentSearches()
+            }
+        }
+
+        fun loadNextPage() {
+            val state = _uiState.value
+            if (!state.hasMorePages || state.isLoadingMore || state.isLoading) return
+            fetchPage(query = state.query, filters = state.filters, reset = false, page = state.currentPage)
+        }
+
+        fun clearError() {
+            _uiState.update { it.copy(error = null) }
+        }
+
+        private fun fetchPage(
+            query: String,
+            filters: SearchFilters,
+            reset: Boolean,
+            page: Int = 0,
+        ) {
+            viewModelScope.launch {
+                val targetPage = if (reset) 0 else page
+                _uiState.update { current ->
+                    current.copy(
+                        isLoading = reset && targetPage == 0 && current.services.isEmpty(),
+                        isLoadingMore = !reset && targetPage > 0,
+                        error = null,
+                    )
+                }
+
+                searchServicesUseCase(query = query, filters = filters, page = targetPage, size = PAGE_SIZE)
+                    .onSuccess { pageResponse ->
+                        // Persist non-empty queries to recent search history.
+                        if (query.isNotBlank() && reset) {
+                            userPreferences.addRecentSearch(query.trim())
+                        }
+                        _uiState.update { current ->
+                            val merged = if (reset) {
+                                pageResponse.content
+                            } else {
+                                (current.services + pageResponse.content).distinctBy { it.id }
+                            }
+                            current.copy(
+                                services = merged,
+                                isLoading = false,
+                                isLoadingMore = false,
+                                currentPage = targetPage + 1,
+                                hasMorePages = pageResponse.content.size == PAGE_SIZE,
+                            )
+                        }
+                    }
+                    .onFailure { error ->
+                        _uiState.update { it.copy(isLoading = false, isLoadingMore = false, error = error.message) }
+                    }
+            }
+        }
+    }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStates.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStates.kt
@@ -1,93 +1,35 @@
 package must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import must.kdroiders.hustlehub.sharedComposables.HustleButton
-import must.kdroiders.hustlehub.sharedComposables.HustleButtonVariant
+import must.kdroiders.hustlehub.sharedComposables.ErrorView
 import must.kdroiders.hustlehub.sharedComposables.LoadingIndicator
 
-// Loading / Error states
-
+/**
+ * Profile-screen loading placeholder.
+ *
+ * Delegates to the shared [LoadingIndicator] from `sharedComposables/` — DRY principle.
+ */
 @Composable
-fun LoadingState() {
-    LoadingIndicator()
+fun LoadingState(modifier: Modifier = Modifier) {
+    LoadingIndicator(modifier = modifier)
 }
 
+/**
+ * Profile-screen error state with a retry action.
+ *
+ * Delegates to the shared [ErrorView] from `sharedComposables/` which renders
+ * the canonical HustleHub error UI (icon, title, message, retry button).
+ */
 @Composable
 fun ErrorState(
     message: String,
     onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(80.dp)
-                    .clip(RoundedCornerShape(24.dp))
-                    .background(MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f)),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Warning,
-                    contentDescription = "Error",
-                    tint = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.size(40.dp),
-                )
-            }
-
-            Spacer(Modifier.height(24.dp))
-
-            Text(
-                text = "Oops! Something went wrong",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-
-            Spacer(Modifier.height(8.dp))
-
-            Text(
-                text = message,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center,
-            )
-
-            Spacer(Modifier.height(32.dp))
-
-            HustleButton(
-                text = "Try Again",
-                onClick = onRetry,
-                variant = HustleButtonVariant.Outlined,
-            )
-        }
-    }
+    ErrorView(
+        message = message,
+        onRetry = onRetry,
+        modifier = modifier,
+    )
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
@@ -194,6 +194,13 @@ class ServiceRepositoryImpl(
         size: Int,
         category: ServiceCategory?,
         query: String?,
+        availability: ServiceAvailability?,
+        minRating: Double?,
+        maxPrice: Int?,
+        lat: Double?,
+        lng: Double?,
+        radiusKm: Double?,
+        sortBy: String?,
     ): Result<PageResponse<Service>> =
         withContext(Dispatchers.IO) {
             val now = System.currentTimeMillis()
@@ -206,11 +213,17 @@ class ServiceRepositoryImpl(
                     size = size,
                     category = categoryStr,
                     query = query,
+                    availability = availability?.name,
+                    minRating = minRating,
+                    maxPrice = maxPrice,
+                    lat = lat,
+                    lng = lng,
+                    radiusKm = radiusKm,
+                    sortBy = sortBy,
                 )
                 if (response.success && response.data != null) {
                     val pageData = response.data
                     val services = pageData.content.map { it.toDomainModel() }
-                    // Cache the discovered services (page 0 only to avoid stale pagination)
                     if (page == 0) serviceDao.upsertAll(services.map { it.toEntity(now) })
                     Result.success(
                         PageResponse(
@@ -225,7 +238,6 @@ class ServiceRepositoryImpl(
                     Result.failure(Exception(response.message))
                 }
             } catch (e: Exception) {
-                // Serve cache for first page only
                 Timber.w(e, "browseServices network miss, serving cache (page $page)")
                 if (page == 0) {
                     val cached = serviceDao.getAllServices()
@@ -246,6 +258,35 @@ class ServiceRepositoryImpl(
                 } else {
                     Result.failure(e)
                 }
+            }
+        }
+
+    override suspend fun searchServices(
+        query: String,
+        page: Int,
+        size: Int,
+    ): Result<PageResponse<Service>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val response = apiService.searchServices(query = query, page = page, size = size)
+                if (response.success && response.data != null) {
+                    val pageData = response.data
+                    val services = pageData.content.map { it.toDomainModel() }
+                    Result.success(
+                        PageResponse(
+                            content = services,
+                            page = pageData.page,
+                            size = pageData.size,
+                            totalElements = pageData.totalElements,
+                            totalPages = pageData.totalPages,
+                        ),
+                    )
+                } else {
+                    Result.failure(Exception(response.message))
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "searchServices failed for query='$query'")
+                Result.failure(e)
             }
         }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/repository/ServiceRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/repository/ServiceRepository.kt
@@ -55,14 +55,32 @@ interface ServiceRepository {
     suspend fun getMyServices(): Result<List<Service>>
 
     /**
-     * Returns a paginated page of browsable services, optionally filtered by
-     * [category] and/or a free-text [query].
-     * Falls back to the Room cache on the first page if the network is unavailable.
+     * Returns a paginated page of browsable services, optionally filtered by category,
+     * availability, rating, price, and location. Falls back to the Room cache on page 0
+     * if the network is unavailable.
      */
     suspend fun browseServices(
         page: Int = 0,
         size: Int = 20,
         category: ServiceCategory? = null,
         query: String? = null,
+        availability: ServiceAvailability? = null,
+        minRating: Double? = null,
+        maxPrice: Int? = null,
+        lat: Double? = null,
+        lng: Double? = null,
+        radiusKm: Double? = null,
+        sortBy: String? = null,
+    ): Result<PageResponse<Service>>
+
+    /**
+     * Full-text keyword search — hits GET /discovery/search?q=.
+     * Results sorted by avgRating descending on the server.
+     * No cache fallback (text search results are highly volatile).
+     */
+    suspend fun searchServices(
+        query: String,
+        page: Int = 0,
+        size: Int = 20,
     ): Result<PageResponse<Service>>
 }

--- a/app/src/main/res/drawable/ic_ai_sparkle.xml
+++ b/app/src/main/res/drawable/ic_ai_sparkle.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Main large sparkle star -->
+    <path
+        android:pathData="M12,2 L13.5,9.5 L21,11 L13.5,12.5 L12,20 L10.5,12.5 L3,11 L10.5,9.5 Z"
+        android:fillColor="#FFFFFF" />
+    <!-- Small top-right sparkle -->
+    <path
+        android:pathData="M19,2 L19.75,5.25 L23,6 L19.75,6.75 L19,10 L18.25,6.75 L15,6 L18.25,5.25 Z"
+        android:fillColor="#FFFFFF" />
+    <!-- Tiny bottom-left sparkle -->
+    <path
+        android:pathData="M5,15 L5.5,17.5 L8,18 L5.5,18.5 L5,21 L4.5,18.5 L2,18 L4.5,17.5 Z"
+        android:fillColor="#FFFFFF" />
+</vector>


### PR DESCRIPTION
## 📝 What does this PR do?
This PR overhauls the discovery experience by redesigning the Home feed into a responsive 2-column grid, implementing a robust advanced search screen with dynamic filtering, and introducing Gemini-powered AI natural language service matching.

---

## 🔄 Main Changes

### Added
- **AI Search (`AiSearchScreen`)**: Introduced natural language service discovery hitting the new `/api/v1/discovery/ai-search` endpoint. Includes relevance scoring badges, match reasoning cards, query understanding chips, and a graceful keyword fallback banner.
- **Advanced Search (`SearchScreen`)**: Added real-time debounced text search, active filter chip rows, and persistent recent search history using DataStore.
- **Filter Bottom Sheet**: Built a dynamic `FilterBottomSheet` supporting multi-select categories, rating sliders, price range sliders, and segmented buttons for availability and sorting.
- **Featured Services**: Added a horizontally scrolling `FeaturedServicesRow` displaying the top 5 highest-rated services directly on the Home screen.

### Changed
- **Home Screen Architecture**: Refactored the discovery feed from a single `LazyColumn` to a staggered 2-column `LazyVerticalGrid` using custom span logic for headers.
- **Search Bar UX**: Converted the `HomeSearchBar` into a non-editable button component that navigates to the dedicated `SearchScreen` upon tap (mirroring standard maps/booking app UX patterns).
- **Network Layer**: Extended `ServiceApiService` with full filtering parameters (`minRating`, `maxPrice`, `availability`, `sortBy`) and split full-text search into its own dedicated `searchServices` endpoint.
- **Navigation**: Registered `SearchScreen` and `AiSearchScreen` in the `Navigation 3` graph and wired callbacks all the way down through the `MainScaffold`.

### Refactored
- Removed legacy ASCII banner comments in favor of clean, professional inline documentation.
- Replaced duplicated loading and error states across the app with canonical `LoadingIndicator` and `ErrorView` delegates from `sharedComposables`.
- Replaced inline text fields and buttons with `HustleTextField` and `HustleButton` from the shared design system.

---

## ✅ Type of change
- [x] New feature
- [ ] Bug fix
- [x] UI update
- [x] Refactor / cleanup
- [ ] Documentation

---

## 🧪 I have tested that...
- [x] The app builds without errors
- [x] My feature/fix works as expected
- [x] I didn't break anything else

---

## 🔍 Code quality
- [x] Ktlint passed  (`./gradlew ktlintCheck`)
- [x] Detekt passed  (`./gradlew detekt`)
- [x] My commit message follows convention (`feat:`, `fix:`, `chore:` etc.)

---

## Closes #
Closes #27, Closes #28, Closes #29
