### PR TITLE
implement local message caching, unread badges, provider resolution, swipe-to-delete, and UI modernization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,6 +112,10 @@ dependencies {
     implementation(libs.krossbow.stomp.core)
     implementation(libs.krossbow.websocket.okhttp)
 
+    // Media3 / ExoPlayer — voice note playback, audio focus, speed control
+    implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.androidx.media3.session)
+
     // Coroutines & Serialization
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.coroutines.play.services)

--- a/app/src/main/java/must/kdroiders/hustlehub/activities/MainActivity.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/activities/MainActivity.kt
@@ -29,6 +29,7 @@ import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingExcept
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.R
+import must.kdroiders.hustlehub.core.notification.NotificationHelper
 import must.kdroiders.hustlehub.navigation.HustleHubNav
 import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.LoginViewModel
 import must.kdroiders.hustlehub.ui.theme.HustleHubTheme
@@ -45,6 +46,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // Register notification channel early — safe to call multiple times (OS is idempotent)
+        NotificationHelper.createChannel(this)
 
         // Always initialize legacy Google Sign-In as fallback
         initializeLegacyGoogleSignIn()
@@ -75,6 +79,12 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Clear all chat notifications and badge when user returns to the app
+        NotificationHelper.cancelAllNotifications(this)
     }
 
     private fun initializeLegacyGoogleSignIn() {

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/NotificationHelper.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/NotificationHelper.kt
@@ -1,0 +1,110 @@
+package must.kdroiders.hustlehub.core.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import must.kdroiders.hustlehub.R
+import must.kdroiders.hustlehub.activities.MainActivity
+import timber.log.Timber
+
+/**
+ * Manages local push notifications for incoming chat messages.
+ *
+ * Why this exists:
+ * On Android 8.0+ (API 26), the OS drives the app-icon badge entirely from active
+ * notifications. By posting a local notification each time a message arrives from
+ * another user, we get:
+ *   - App icon badge count (free, via OS)
+ *   - A visible notification in the drawer (ready for FCM to replace later)
+ *
+ * When FCM is integrated, FCM will trigger [postMessageNotification] from the
+ * FirebaseMessagingService instead of from the WebSocket listener, and this class
+ * requires zero changes.
+ */
+object NotificationHelper {
+
+    const val CHANNEL_ID = "hustlehub_messages"
+    private const val CHANNEL_NAME = "Messages"
+    private const val CHANNEL_DESCRIPTION = "Incoming chat message notifications"
+
+    /**
+     * Creates the notification channel on Android 8.0+.
+     * Safe to call multiple times — the OS is idempotent.
+     * Call once from [Application.onCreate] or [MainActivity.onCreate].
+     */
+    fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val importance = NotificationManager.IMPORTANCE_HIGH
+            val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, importance).apply {
+                description = CHANNEL_DESCRIPTION
+            }
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    /**
+     * Posts a heads-up notification for a new message.
+     * On Android 8+, this automatically increments the app icon badge.
+     *
+     * @param notificationId  stable ID — use a hash of conversationId so all
+     *                        messages from the same conversation update one slot.
+     * @param senderName      display name shown as the notification title.
+     * @param messagePreview  short preview of message content for the notification body.
+     */
+    fun postMessageNotification(
+        context: Context,
+        notificationId: Int,
+        senderName: String,
+        messagePreview: String,
+    ) {
+        try {
+            val intent = Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                notificationId,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+            val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle(senderName)
+                .setContentText(messagePreview)
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setContentIntent(pendingIntent)
+                .build()
+
+            NotificationManagerCompat.from(context).notify(notificationId, notification)
+        } catch (e: SecurityException) {
+            // POST_NOTIFICATIONS permission not granted (Android 13+). Silently ignore.
+            Timber.w(e, "POST_NOTIFICATIONS permission not granted; skipping notification")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to post message notification")
+        }
+    }
+
+    /**
+     * Cancels all notifications for a given conversation.
+     * Call when the user opens a conversation — clears the app icon badge slot for
+     * that conversation.
+     */
+    fun cancelConversationNotification(context: Context, conversationId: String) {
+        NotificationManagerCompat.from(context).cancel(conversationId.hashCode())
+    }
+
+    /**
+     * Cancels ALL chat notifications (e.g. when the user reads everything).
+     */
+    fun cancelAllNotifications(context: Context) {
+        NotificationManagerCompat.from(context).cancelAll()
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/NotificationHelper.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/NotificationHelper.kt
@@ -27,7 +27,6 @@ import timber.log.Timber
  * requires zero changes.
  */
 object NotificationHelper {
-
     const val CHANNEL_ID = "hustlehub_messages"
     private const val CHANNEL_NAME = "Messages"
     private const val CHANNEL_DESCRIPTION = "Incoming chat message notifications"
@@ -74,7 +73,8 @@ object NotificationHelper {
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
             )
 
-            val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            val notification = NotificationCompat
+                .Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_launcher_foreground)
                 .setContentTitle(senderName)
                 .setContentText(messagePreview)
@@ -97,7 +97,10 @@ object NotificationHelper {
      * Call when the user opens a conversation — clears the app icon badge slot for
      * that conversation.
      */
-    fun cancelConversationNotification(context: Context, conversationId: String) {
+    fun cancelConversationNotification(
+        context: Context,
+        conversationId: String,
+    ) {
         NotificationManagerCompat.from(context).cancel(conversationId.hashCode())
     }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/core/utils/ImageCompressor.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/utils/ImageCompressor.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.os.Build
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber

--- a/app/src/main/java/must/kdroiders/hustlehub/data/local/AppDatabase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/data/local/AppDatabase.kt
@@ -15,7 +15,7 @@ import must.kdroiders.hustlehub.ui.features.service.data.local.entity.ServiceEnt
         ConversationEntity::class,
         MessageEntity::class,
     ],
-    version = 2,
+    version = 3,
     exportSchema = false,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -131,6 +131,7 @@ object AppModule {
     @Provides
     @Singleton
     fun provideChatRepository(
+        @ApplicationContext context: Context,
         conversationApiService: ConversationApiService,
         chatWebSocketService: ChatWebSocketService,
         conversationDao: ConversationDao,
@@ -138,6 +139,7 @@ object AppModule {
         firebaseAuth: FirebaseAuth?,
     ): ChatRepository {
         return ChatRepositoryImpl(
+            context,
             conversationApiService,
             chatWebSocketService,
             conversationDao,

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/BottomNavigationBar.kt
@@ -9,6 +9,8 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material.icons.outlined.PersonOutline
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -78,6 +80,7 @@ private val bottomTabs = listOf(
 fun HustleBottomBar(
     currentKey: NavKey,
     onTabSelected: (NavKey) -> Unit,
+    totalUnreadCount: Int = 1,
     modifier: Modifier = Modifier,
 ) {
     NavigationBar(
@@ -92,10 +95,28 @@ fun HustleBottomBar(
                 selected = selected,
                 onClick = { onTabSelected(item.key) },
                 icon = {
-                    Icon(
-                        imageVector = if (selected) item.selectedIcon else item.unselectedIcon,
-                        contentDescription = item.label,
-                    )
+                    val isChatTab = item.key == BottomChat
+                    if (isChatTab && totalUnreadCount > 0) {
+                        BadgedBox(
+                            badge = {
+                                Badge {
+                                    Text(
+                                        text = if (totalUnreadCount > 99) "99+" else totalUnreadCount.toString(),
+                                    )
+                                }
+                            },
+                        ) {
+                            Icon(
+                                imageVector = if (selected) item.selectedIcon else item.unselectedIcon,
+                                contentDescription = item.label,
+                            )
+                        }
+                    } else {
+                        Icon(
+                            imageVector = if (selected) item.selectedIcon else item.unselectedIcon,
+                            contentDescription = item.label,
+                        )
+                    }
                 },
                 label = {
                     Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -251,6 +251,11 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
             entry<ChatDetail> { key ->
                 ChatDetailScreen(
                     conversationId = key.chatId,
+                    serviceId = key.serviceId,
+                    serviceTitle = key.serviceTitle,
+                    serviceCategory = key.serviceCategory,
+                    servicePriceRange = key.servicePriceRange,
+                    providerName = key.providerName,
                     onBackClick = { if (backstack.size > 1) backstack.remove(backstack.last()) },
                     onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
                 )
@@ -261,7 +266,18 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
                 ServiceDetailScreen(
                     serviceId = key.serviceId,
                     onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onNavigateToChat = { providerId -> backstack.add(ChatDetail(chatId = providerId)) },
+                    onNavigateToChat = { providerId, serviceId, title, category, priceRange, providerName ->
+                        backstack.add(
+                            ChatDetail(
+                                chatId = providerId,
+                                serviceId = serviceId,
+                                serviceTitle = title,
+                                serviceCategory = category,
+                                servicePriceRange = priceRange,
+                                providerName = providerName,
+                            ),
+                        )
+                    },
                     onNavigateToProviderProfile = { providerId -> backstack.add(ProviderProfile(providerId = providerId)) },
                     onNavigateToWriteReview = { serviceId, providerId ->
                         backstack.add(WriteReview(serviceId = serviceId, providerId = providerId))

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
@@ -70,10 +70,22 @@ data object ChangePassword : NavKey
 
 /**
  * Individual chat conversation.
- * Carries the [chatId] so the detail pane can load the correct thread.
+ *
+ * [chatId] is the conversation ID used to load the thread.
+ *
+ * The optional service fields are non-null only when the chat is opened directly
+ * from a service listing via "Message Provider". They are used to auto-generate
+ * a SERVICE_CARD message at the top of the conversation on first open.
  */
 @Serializable
-data class ChatDetail(val chatId: String) : NavKey
+data class ChatDetail(
+    val chatId: String,
+    val serviceId: String? = null,
+    val serviceTitle: String? = null,
+    val serviceCategory: String? = null,
+    val servicePriceRange: String? = null,
+    val providerName: String? = null,
+) : NavKey
 
 /** App settings screen — pushed from the Profile tab header. */
 @Serializable

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
@@ -6,7 +6,10 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
@@ -14,6 +17,7 @@ import must.kdroiders.hustlehub.navigation.AiSearchScreen
 import must.kdroiders.hustlehub.navigation.SearchScreen
 import must.kdroiders.hustlehub.navigation.ServiceDetail
 import must.kdroiders.hustlehub.ui.features.chat.presentation.view.ChatScreen
+import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.UnreadCountViewModel
 import must.kdroiders.hustlehub.ui.features.home.presentation.view.HomeScreen
 import must.kdroiders.hustlehub.ui.features.map.MapScreen
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.ProfileScreen
@@ -54,11 +58,16 @@ fun MainShellScreen(
     // The currently active tab key is always the last element.
     val currentKey = innerBackstack.lastOrNull() ?: BottomHome
 
+    // Observe the total unread count reactively — zero allocation per recomposition.
+    val unreadCountViewModel: UnreadCountViewModel = hiltViewModel()
+    val totalUnreadCount by unreadCountViewModel.totalUnreadCount.collectAsState(initial = 0)
+
     Scaffold(
         modifier = modifier,
         bottomBar = {
             HustleBottomBar(
                 currentKey = currentKey,
+                totalUnreadCount = totalUnreadCount,
                 onTabSelected = { destination ->
                     // Replace entire stack with the selected tab (no accumulation).
                     innerBackstack.clear()

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/dao/ConversationDao.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/dao/ConversationDao.kt
@@ -24,6 +24,9 @@ interface ConversationDao {
     @Upsert
     suspend fun upsertAll(entities: List<ConversationEntity>)
 
+    @Query("DELETE FROM conversations WHERE id = :id")
+    suspend fun deleteById(id: String)
+
     @Query("DELETE FROM conversations WHERE cachedAt < :threshold")
     suspend fun deleteStaleEntries(threshold: Long)
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/dao/ConversationDao.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/dao/ConversationDao.kt
@@ -14,6 +14,10 @@ interface ConversationDao {
     @Query("SELECT * FROM conversations WHERE id = :id")
     suspend fun getById(id: String): ConversationEntity?
 
+    /** Reactive sum of unread counts across all conversations — drives the bottom nav badge. */
+    @Query("SELECT COALESCE(SUM(unreadCount), 0) FROM conversations")
+    fun getTotalUnreadCount(): Flow<Int>
+
     @Upsert
     suspend fun upsert(entity: ConversationEntity)
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/entity/MessageEntity.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/entity/MessageEntity.kt
@@ -18,6 +18,10 @@ data class MessageEntity(
     val timestamp: String,
     val deliveredAt: String?,
     val readAt: String?,
+    /** false for optimistic messages waiting for server echo. */
+    val isSynced: Boolean = false,
+    /** true if the send permanently failed. */
+    val isFailed: Boolean = false,
     val cachedAt: Long = System.currentTimeMillis(),
 )
 
@@ -34,6 +38,8 @@ fun MessageEntity.toDomain(): Message =
         timestamp = timestamp,
         deliveredAt = deliveredAt,
         readAt = readAt,
+        isSynced = isSynced,
+        isFailed = isFailed,
     )
 
 fun Message.toEntity(cachedAt: Long = System.currentTimeMillis()): MessageEntity =
@@ -49,5 +55,7 @@ fun Message.toEntity(cachedAt: Long = System.currentTimeMillis()): MessageEntity
         timestamp = timestamp,
         deliveredAt = deliveredAt,
         readAt = readAt,
+        isSynced = isSynced,
+        isFailed = isFailed,
         cachedAt = cachedAt,
     )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/remote/ConversationApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/remote/ConversationApiService.kt
@@ -6,6 +6,7 @@ import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.ConversationRes
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.CreateConversationRequest
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.MessageResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -33,6 +34,11 @@ interface ConversationApiService {
 
     @PUT("conversations/{conversationId}/read")
     suspend fun markAsRead(
+        @Path("conversationId") conversationId: String,
+    ): ApiResponse<Unit>
+
+    @DELETE("conversations/{conversationId}")
+    suspend fun deleteConversation(
         @Path("conversationId") conversationId: String,
     ): ApiResponse<Unit>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
@@ -41,6 +41,13 @@ class ChatRepositoryImpl
         private val messageDao: MessageDao,
         private val firebaseAuth: FirebaseAuth?,
     ) : ChatRepository {
+        @Volatile
+        private var activeConversationId: String? = null
+
+        override fun setActiveConversation(conversationId: String?) {
+            this.activeConversationId = conversationId
+        }
+
         override fun getConversations(): Flow<List<Conversation>> {
             return conversationDao.getAll().map { entities ->
                 entities.map { it.toDomain() }
@@ -66,7 +73,7 @@ class ChatRepositoryImpl
 
         override suspend fun getOrCreateConversation(
             otherUserId: String,
-            serviceId: String,
+            serviceId: String?,
         ): Result<Conversation> =
             withContext(Dispatchers.IO) {
                 try {
@@ -107,6 +114,10 @@ class ChatRepositoryImpl
                     }
                 } catch (e: Exception) {
                     Timber.e(e, "Failed to load message history")
+                    if (e is retrofit2.HttpException && e.code() == 404) {
+                        conversationDao.deleteById(conversationId)
+                        messageDao.deleteByConversation(conversationId)
+                    }
                     Result.failure(e)
                 }
             }
@@ -190,6 +201,10 @@ class ChatRepositoryImpl
                     }
                 } catch (e: Exception) {
                     Timber.e(e, "Failed to mark conversation as read")
+                    if (e is retrofit2.HttpException && e.code() == 404) {
+                        conversationDao.deleteById(conversationId)
+                        messageDao.deleteByConversation(conversationId)
+                    }
                     Result.failure(e)
                 }
             }
@@ -229,22 +244,24 @@ class ChatRepositoryImpl
                         val cachedConv = conversationDao.getById(conversationId)
                         if (cachedConv != null) {
                             val isFromOtherUser = message.senderId != (firebaseAuth?.currentUser?.uid ?: "")
+                            val isActive = conversationId == activeConversationId
+
                             conversationDao.upsert(
                                 cachedConv.copy(
                                     lastMessage = message.content,
                                     lastMessageType = message.type.name,
                                     lastMessageAt = message.timestamp,
-                                    // Only increment badge for messages from others
-                                    unreadCount = if (isFromOtherUser) {
+                                    // Only increment badge for messages from others if the chat is NOT active
+                                    unreadCount = if (isFromOtherUser && !isActive) {
                                         cachedConv.unreadCount + 1
                                     } else {
-                                        cachedConv.unreadCount
+                                        0
                                     },
                                 ),
                             )
 
-                            
-                            if (isFromOtherUser) {
+                            // Post a local notification for incoming messages if the chat is not active.
+                            if (isFromOtherUser && !isActive) {
                                 val senderName = cachedConv.otherUserName
                                 val preview = when (message.type.name) {
                                     "VOICE" -> "Sent a voice note"
@@ -258,6 +275,10 @@ class ChatRepositoryImpl
                                     senderName = senderName,
                                     messagePreview = preview,
                                 )
+                            } else if (isFromOtherUser && isActive) {
+                                // If the conversation is currently active, mark the new message as read on the backend
+                                // since the user is actively viewing it.
+                                markAsRead(conversationId)
                             }
                         }
                     }
@@ -272,6 +293,26 @@ class ChatRepositoryImpl
 
         override suspend fun disconnectWebSocket() {
             chatWebSocketService.disconnect()
+        }
+
+        override suspend fun deleteConversation(conversationId: String): Result<Unit> {
+            return withContext(Dispatchers.IO) {
+                try {
+                    // 1. Delete from local database
+                    conversationDao.deleteById(conversationId)
+                    messageDao.deleteByConversation(conversationId)
+
+                    // 2. Perform the remote API delete call
+                    val response = conversationApiService.deleteConversation(conversationId)
+                    if (response.success) {
+                        Result.success(Unit)
+                    } else {
+                        Result.failure(Exception(response.message ?: "Failed to delete conversation on server"))
+                    }
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
@@ -1,13 +1,16 @@
 package must.kdroiders.hustlehub.ui.features.chat.data.repository
 
+import android.content.Context
 import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
+import must.kdroiders.hustlehub.core.notification.NotificationHelper
 import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.ConversationDao
 import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.MessageDao
 import must.kdroiders.hustlehub.ui.features.chat.data.local.entity.toDomain
@@ -31,6 +34,7 @@ import javax.inject.Singleton
 class ChatRepositoryImpl
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val conversationApiService: ConversationApiService,
         private val chatWebSocketService: ChatWebSocketService,
         private val conversationDao: ConversationDao,
@@ -150,6 +154,8 @@ class ChatRepositoryImpl
                         timestamp = currentTimestamp,
                         deliveredAt = null,
                         readAt = null,
+                        isSynced = false,
+                        isFailed = false,
                     )
 
                     messageDao.upsert(tempMessage.toEntity())
@@ -222,13 +228,37 @@ class ChatRepositoryImpl
                         messageDao.upsert(message.toEntity())
                         val cachedConv = conversationDao.getById(conversationId)
                         if (cachedConv != null) {
+                            val isFromOtherUser = message.senderId != (firebaseAuth?.currentUser?.uid ?: "")
                             conversationDao.upsert(
                                 cachedConv.copy(
                                     lastMessage = message.content,
                                     lastMessageType = message.type.name,
                                     lastMessageAt = message.timestamp,
+                                    // Only increment badge for messages from others
+                                    unreadCount = if (isFromOtherUser) {
+                                        cachedConv.unreadCount + 1
+                                    } else {
+                                        cachedConv.unreadCount
+                                    },
                                 ),
                             )
+
+                            
+                            if (isFromOtherUser) {
+                                val senderName = cachedConv.otherUserName
+                                val preview = when (message.type.name) {
+                                    "VOICE" -> "Sent a voice note"
+                                    "IMAGE" -> "Sent an image"
+                                    "LOCATION" -> "Shared a location"
+                                    else -> message.content.take(80)
+                                }
+                                NotificationHelper.postMessageNotification(
+                                    context = context,
+                                    notificationId = conversationId.hashCode(),
+                                    senderName = senderName,
+                                    messagePreview = preview,
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
@@ -7,8 +7,8 @@ import com.google.gson.JsonObject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 import must.kdroiders.hustlehub.core.notification.NotificationHelper
 import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.ConversationDao
@@ -106,6 +106,26 @@ class ChatRepositoryImpl
                 try {
                     val response = conversationApiService.getMessages(conversationId, page, 50)
                     if (response.success && response.data != null) {
+                        val gson = Gson()
+                        val localIdsToDelete = response.data.content.mapNotNull { msg ->
+                            try {
+                                if (msg.metadata != null) {
+                                    val metaObj = gson.fromJson(msg.metadata, JsonObject::class.java)
+                                    if (metaObj.has("localId")) {
+                                        metaObj.get("localId").asString
+                                    } else {
+                                        null
+                                    }
+                                } else {
+                                    null
+                                }
+                            } catch (e: Exception) {
+                                null
+                            }
+                        }
+                        if (localIdsToDelete.isNotEmpty()) {
+                            localIdsToDelete.forEach { messageDao.deleteById(it) }
+                        }
                         val entities = response.data.content.map { it.toEntity() }
                         messageDao.upsertAll(entities)
                         Result.success(Unit)
@@ -209,81 +229,86 @@ class ChatRepositoryImpl
                 }
             }
 
-        override suspend fun connectWebSocket(conversationId: String): Flow<Message> {
-            // Ensure WebSocket is connected
-            chatWebSocketService.connect()
+        override suspend fun connectWebSocket(conversationId: String): Flow<Message> =
+            flow {
+                try {
+                    // Ensure WebSocket is connected
+                    chatWebSocketService.connect()
 
-            // We connect the WebSocket session, subscribe to the conversation flow,
-            // and whenever a new message is received, we:
-            // 1. Map to domain model
-            // 2. Insert into the local database
-            // 3. Update the conversation unread count and last message in local database
-            return chatWebSocketService
-                .subscribeToConversation(conversationId)
-                .map { it.toDomainModel() }
-                .onEach { message ->
-                    withContext(Dispatchers.IO) {
-                        val gson = Gson()
+                    // Subscribe to conversation fresh on each collection
+                    chatWebSocketService
+                        .subscribeToConversation(conversationId)
+                        .map { it.toDomainModel() }
+                        .collect { message ->
+                            withContext(Dispatchers.IO) {
+                                val gson = Gson()
 
-                        // Remove optimistic message if this is the real one from the server
-                        if (message.senderId == firebaseAuth?.currentUser?.uid) {
-                            try {
-                                if (message.metadata != null) {
-                                    val metaObj = gson.fromJson(message.metadata, JsonObject::class.java)
-                                    if (metaObj.has("localId")) {
-                                        val localId = metaObj.get("localId").asString
-                                        messageDao.deleteById(localId)
+                                val cachedConv = conversationDao.getById(conversationId)
+                                val isFromOtherUser = cachedConv?.let { message.senderId == it.otherUserId } ?: false
+                                val isFromSelf = !isFromOtherUser
+
+                                // Remove optimistic message if this is the real one from the server
+                                if (isFromSelf) {
+                                    try {
+                                        if (message.metadata != null) {
+                                            val metaObj = gson.fromJson(message.metadata, JsonObject::class.java)
+                                            if (metaObj.has("localId")) {
+                                                val localId = metaObj.get("localId").asString
+                                                messageDao.deleteById(localId)
+                                            }
+                                        }
+                                    } catch (e: Exception) {
+                                        Timber.e(e, "Error processing localId from metadata")
                                     }
                                 }
-                            } catch (e: Exception) {
-                                Timber.e(e, "Error processing localId from metadata")
-                            }
-                        }
 
-                        messageDao.upsert(message.toEntity())
-                        val cachedConv = conversationDao.getById(conversationId)
-                        if (cachedConv != null) {
-                            val isFromOtherUser = message.senderId != (firebaseAuth?.currentUser?.uid ?: "")
-                            val isActive = conversationId == activeConversationId
+                                messageDao.upsert(message.toEntity())
+                                if (cachedConv != null) {
+                                    val isActive = conversationId == activeConversationId
 
-                            conversationDao.upsert(
-                                cachedConv.copy(
-                                    lastMessage = message.content,
-                                    lastMessageType = message.type.name,
-                                    lastMessageAt = message.timestamp,
-                                    // Only increment badge for messages from others if the chat is NOT active
-                                    unreadCount = if (isFromOtherUser && !isActive) {
-                                        cachedConv.unreadCount + 1
-                                    } else {
-                                        0
-                                    },
-                                ),
-                            )
+                                    conversationDao.upsert(
+                                        cachedConv.copy(
+                                            lastMessage = message.content,
+                                            lastMessageType = message.type.name,
+                                            lastMessageAt = message.timestamp,
+                                            // Only increment badge for messages from others if the chat is NOT active
+                                            unreadCount = if (isFromOtherUser && !isActive) {
+                                                cachedConv.unreadCount + 1
+                                            } else {
+                                                0
+                                            },
+                                        ),
+                                    )
 
-                            // Post a local notification for incoming messages if the chat is not active.
-                            if (isFromOtherUser && !isActive) {
-                                val senderName = cachedConv.otherUserName
-                                val preview = when (message.type.name) {
-                                    "VOICE" -> "Sent a voice note"
-                                    "IMAGE" -> "Sent an image"
-                                    "LOCATION" -> "Shared a location"
-                                    else -> message.content.take(80)
+                                    // Post a local notification for incoming messages if the chat is not active.
+                                    if (isFromOtherUser && !isActive) {
+                                        val senderName = cachedConv.otherUserName
+                                        val preview = when (message.type.name) {
+                                            "VOICE" -> "Sent a voice note"
+                                            "IMAGE" -> "Sent an image"
+                                            "LOCATION" -> "Shared a location"
+                                            else -> message.content.take(80)
+                                        }
+                                        NotificationHelper.postMessageNotification(
+                                            context = context,
+                                            notificationId = conversationId.hashCode(),
+                                            senderName = senderName,
+                                            messagePreview = preview,
+                                        )
+                                    } else if (isFromOtherUser && isActive) {
+                                        // If the conversation is currently active, mark the new message as read on the backend
+                                        // since the user is actively viewing it.
+                                        markAsRead(conversationId)
+                                    }
                                 }
-                                NotificationHelper.postMessageNotification(
-                                    context = context,
-                                    notificationId = conversationId.hashCode(),
-                                    senderName = senderName,
-                                    messagePreview = preview,
-                                )
-                            } else if (isFromOtherUser && isActive) {
-                                // If the conversation is currently active, mark the new message as read on the backend
-                                // since the user is actively viewing it.
-                                markAsRead(conversationId)
                             }
+                            emit(message)
                         }
-                    }
+                } catch (e: Exception) {
+                    chatWebSocketService.disconnect()
+                    throw e
                 }
-        }
+            }
 
         override suspend fun subscribeToPresence(
             otherUserId: String,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/model/Message.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/model/Message.kt
@@ -20,4 +20,8 @@ data class Message(
     val timestamp: String,
     val deliveredAt: String? = null,
     val readAt: String? = null,
+    /** true once the server has acknowledged this message (echoed back via WebSocket). */
+    val isSynced: Boolean = true,
+    /** true if the send permanently failed (e.g. no network and retries exhausted). */
+    val isFailed: Boolean = false,
 )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/repository/ChatRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/repository/ChatRepository.kt
@@ -12,7 +12,7 @@ interface ChatRepository {
 
     suspend fun getOrCreateConversation(
         otherUserId: String,
-        serviceId: String,
+        serviceId: String? = null,
     ): Result<Conversation>
 
     fun getMessages(conversationId: String): Flow<List<Message>>
@@ -37,4 +37,8 @@ interface ChatRepository {
     suspend fun subscribeToPresence(otherUserId: String): Flow<must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.UserPresence>
 
     suspend fun disconnectWebSocket()
+
+    fun setActiveConversation(conversationId: String?)
+
+    suspend fun deleteConversation(conversationId: String): Result<Unit>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/audio/VoicePlayer.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/audio/VoicePlayer.kt
@@ -1,6 +1,13 @@
 package must.kdroiders.hustlehub.ui.features.chat.presentation.audio
 
-import android.media.MediaPlayer
+import android.content.Context
+import android.net.Uri
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -10,82 +17,137 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.net.URL
 
 data class PlayerState(
     val isPlaying: Boolean = false,
+    val isBuffering: Boolean = false,
     val currentPositionMs: Int = 0,
     val durationMs: Int = 0,
     val playingUrl: String? = null,
+    val playbackSpeed: Float = 1.0f,
 )
 
-class VoicePlayer {
-    private var mediaPlayer: MediaPlayer? = null
-    private val _playerState = MutableStateFlow(PlayerState())
-    val playerState: StateFlow<PlayerState> = _playerState.asStateFlow()
+/**
+ * Manages a single ExoPlayer instance for voice-note playback.
+ *
+ * Features:
+ * - Downloads remote URLs to local cache before playback (idempotent — skips download if cached).
+ * - Automatic audio focus and AudioBecomingNoisy handling via [AudioAttributes] + handleAudioFocus.
+ * - Playback-speed cycling: 1.0x → 1.5x → 2.0x → 1.0x.
+ * - Singleton-safe: only one clip plays at a time; calling [play] with a different URL
+ *   stops the current clip first.
+ */
+class VoicePlayer(private val context: Context) {
 
     private val scope = CoroutineScope(Dispatchers.Main)
     private var updateJob: Job? = null
 
-    fun play(url: String) {
-        if (_playerState.value.playingUrl == url) {
-            if (_playerState.value.isPlaying) {
-                pause()
-            } else {
-                resume()
+    private val _playerState = MutableStateFlow(PlayerState())
+    val playerState: StateFlow<PlayerState> = _playerState.asStateFlow()
+
+    private val exoPlayer: ExoPlayer by lazy {
+        ExoPlayer.Builder(context)
+            .build()
+            .apply {
+                // Audio focus + BECOMING_NOISY — handled automatically by ExoPlayer
+                val audioAttributes = AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
+                    .build()
+                setAudioAttributes(audioAttributes, /* handleAudioFocus = */ true)
+
+                addListener(object : Player.Listener {
+                    override fun onIsPlayingChanged(isPlaying: Boolean) {
+                        _playerState.update { it.copy(isPlaying = isPlaying) }
+                        if (isPlaying) startProgressUpdates() else stopProgressUpdates()
+                    }
+
+                    override fun onPlaybackStateChanged(state: Int) {
+                        val buffering = state == Player.STATE_BUFFERING
+                        val ready = state == Player.STATE_READY
+                        _playerState.update { it.copy(isBuffering = buffering) }
+                        if (ready) {
+                            // Capture total duration once the player is prepared
+                            val dur = duration.takeIf { it > 0L }?.toInt() ?: 0
+                            _playerState.update { it.copy(durationMs = dur) }
+                        }
+                        if (state == Player.STATE_ENDED) {
+                            stop()
+                        }
+                    }
+                })
             }
+    }
+
+    private val speedCycle = listOf(1.0f, 1.5f, 2.0f)
+
+    /** Toggle the current playback speed through the cycle [1.0x, 1.5x, 2.0x]. */
+    fun toggleSpeed() {
+        val current = _playerState.value.playbackSpeed
+        val idx = speedCycle.indexOf(current)
+        val next = speedCycle[(idx + 1) % speedCycle.size]
+        exoPlayer.playbackParameters = PlaybackParameters(next)
+        _playerState.update { it.copy(playbackSpeed = next) }
+    }
+
+    /**
+     * Play or pause a voice note at [url].
+     *
+     * - If the same URL is already playing → pauses.
+     * - If the same URL is paused → resumes.
+     * - Otherwise → downloads (if needed), caches, and plays from scratch.
+     */
+    fun play(url: String) {
+        val current = _playerState.value
+        if (current.playingUrl == url) {
+            if (current.isPlaying) pause() else resume()
             return
         }
 
-        stop()
+        // Stop any clip currently playing
+        stopPlayback()
 
-        mediaPlayer = MediaPlayer().apply {
-            setDataSource(url)
-            setOnPreparedListener { mp ->
-                mp.start()
-                _playerState.update {
-                    it.copy(
-                        isPlaying = true,
-                        durationMs = mp.duration,
-                        playingUrl = url,
-                    )
+        _playerState.update { it.copy(playingUrl = url, isBuffering = true) }
+
+        scope.launch {
+            try {
+                val localUri = getOrDownload(url)
+                exoPlayer.apply {
+                    // Preserve current speed when switching tracks
+                    val speed = _playerState.value.playbackSpeed
+                    playbackParameters = PlaybackParameters(speed)
+                    setMediaItem(MediaItem.fromUri(localUri))
+                    prepare()
+                    play()
                 }
-                startUpdatingProgress()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to play voice note: $url")
+                _playerState.update { it.copy(isBuffering = false, playingUrl = null) }
             }
-            setOnCompletionListener {
-                stop()
-            }
-            prepareAsync()
         }
-    }
-
-    private fun resume() {
-        mediaPlayer?.start()
-        _playerState.update { it.copy(isPlaying = true) }
-        startUpdatingProgress()
     }
 
     fun pause() {
-        mediaPlayer?.pause()
+        exoPlayer.pause()
         _playerState.update { it.copy(isPlaying = false) }
-        stopUpdatingProgress()
+        stopProgressUpdates()
+    }
+
+    private fun resume() {
+        exoPlayer.play()
+        _playerState.update { it.copy(isPlaying = true) }
     }
 
     fun stop() {
-        stopUpdatingProgress()
-        mediaPlayer?.apply {
-            try {
-                if (isPlaying) {
-                    stop()
-                }
-            } catch (e: Exception) {
-                // Ignore state errors on stop
-            }
-            release()
-        }
-        mediaPlayer = null
+        stopPlayback()
         _playerState.update {
             it.copy(
                 isPlaying = false,
+                isBuffering = false,
                 currentPositionMs = 0,
                 durationMs = 0,
                 playingUrl = null,
@@ -93,19 +155,61 @@ class VoicePlayer {
         }
     }
 
-    private fun startUpdatingProgress() {
-        stopUpdatingProgress()
+    fun release() {
+        stopProgressUpdates()
+        exoPlayer.release()
+    }
+
+    // Private helpers
+
+    private fun stopPlayback() {
+        stopProgressUpdates()
+        try {
+            exoPlayer.stop()
+            exoPlayer.clearMediaItems()
+        } catch (e: Exception) {
+            Timber.w(e, "Error stopping ExoPlayer")
+        }
+    }
+
+    /**
+     * Returns a local [Uri] for [url]. Downloads and caches the file on first call;
+     * returns the cached file URI on subsequent calls (even across app restarts).
+     */
+    private suspend fun getOrDownload(url: String): Uri = withContext(Dispatchers.IO) {
+        val cacheDir = File(context.cacheDir, "voice_cache").also { it.mkdirs() }
+        val fileName = "voice_${url.hashCode().toUInt()}.m4a"
+        val cacheFile = File(cacheDir, fileName)
+
+        if (!cacheFile.exists()) {
+            URL(url).openStream().use { input ->
+                cacheFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+        Uri.fromFile(cacheFile)
+    }
+
+    private fun startProgressUpdates() {
+        stopProgressUpdates()
         updateJob = scope.launch {
             while (true) {
-                val current = mediaPlayer?.currentPosition ?: 0
-                _playerState.update { it.copy(currentPositionMs = current) }
-                delay(200)
+                val pos = exoPlayer.currentPosition.coerceAtLeast(0L).toInt()
+                val dur = exoPlayer.duration.takeIf { it > 0L }?.toInt() ?: _playerState.value.durationMs
+                _playerState.update { it.copy(currentPositionMs = pos, durationMs = dur) }
+                delay(PROGRESS_UPDATE_INTERVAL_MS)
             }
         }
     }
 
-    private fun stopUpdatingProgress() {
+    private fun stopProgressUpdates() {
         updateJob?.cancel()
         updateJob = null
+    }
+
+    private companion object {
+        /** How often (ms) to poll ExoPlayer's current position for the progress bar. */
+        const val PROGRESS_UPDATE_INTERVAL_MS = 150L
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/audio/VoicePlayer.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/audio/VoicePlayer.kt
@@ -77,7 +77,13 @@ class VoicePlayer(private val context: Context) {
                             _playerState.update { it.copy(durationMs = dur) }
                         }
                         if (state == Player.STATE_ENDED) {
-                            stop()
+                            exoPlayer.seekTo(0)
+                            exoPlayer.pause()
+                            _playerState.update {
+                                it.copy(
+                                    currentPositionMs = 0,
+                                )
+                            }
                         }
                     }
                 })

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/audio/VoicePlayer.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/audio/VoicePlayer.kt
@@ -42,7 +42,6 @@ data class PlayerState(
  *   stops the current clip first.
  */
 class VoicePlayer(private val context: Context) {
-
     private val scope = CoroutineScope(Dispatchers.Main)
     private var updateJob: Job? = null
 
@@ -50,11 +49,13 @@ class VoicePlayer(private val context: Context) {
     val playerState: StateFlow<PlayerState> = _playerState.asStateFlow()
 
     private val exoPlayer: ExoPlayer by lazy {
-        ExoPlayer.Builder(context)
+        ExoPlayer
+            .Builder(context)
             .build()
             .apply {
                 // Audio focus + BECOMING_NOISY — handled automatically by ExoPlayer
-                val audioAttributes = AudioAttributes.Builder()
+                val audioAttributes = AudioAttributes
+                    .Builder()
                     .setUsage(C.USAGE_MEDIA)
                     .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
                     .build()
@@ -176,20 +177,21 @@ class VoicePlayer(private val context: Context) {
      * Returns a local [Uri] for [url]. Downloads and caches the file on first call;
      * returns the cached file URI on subsequent calls (even across app restarts).
      */
-    private suspend fun getOrDownload(url: String): Uri = withContext(Dispatchers.IO) {
-        val cacheDir = File(context.cacheDir, "voice_cache").also { it.mkdirs() }
-        val fileName = "voice_${url.hashCode().toUInt()}.m4a"
-        val cacheFile = File(cacheDir, fileName)
+    private suspend fun getOrDownload(url: String): Uri =
+        withContext(Dispatchers.IO) {
+            val cacheDir = File(context.cacheDir, "voice_cache").also { it.mkdirs() }
+            val fileName = "voice_${url.hashCode().toUInt()}.m4a"
+            val cacheFile = File(cacheDir, fileName)
 
-        if (!cacheFile.exists()) {
-            URL(url).openStream().use { input ->
-                cacheFile.outputStream().use { output ->
-                    input.copyTo(output)
+            if (!cacheFile.exists()) {
+                URL(url).openStream().use { input ->
+                    cacheFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
                 }
             }
+            Uri.fromFile(cacheFile)
         }
-        Uri.fromFile(cacheFile)
-    }
 
     private fun startProgressUpdates() {
         stopProgressUpdates()

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -156,6 +156,8 @@ fun MessageBubble(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 // Time and read receipt
+                // States: pending (clock) -> sent (single check) -> delivered (double check, dim)
+                //         -> read (double check, highlighted)
                 Row(
                     modifier = Modifier.align(Alignment.End),
                     verticalAlignment = Alignment.CenterVertically,
@@ -169,20 +171,29 @@ fun MessageBubble(
                     if (isCurrentUser) {
                         Spacer(modifier = Modifier.width(4.dp))
                         val isPending = message.id.startsWith("temp_")
+                        val isRead = message.readAt != null
+                        val isDelivered = message.deliveredAt != null
                         val receiptIcon = when {
-                            isPending -> androidx.compose.material.icons.Icons.Default.Schedule
-                            message.readAt != null -> Icons.Default.DoneAll
+                            isPending -> Icons.Default.Schedule
+                            isRead || isDelivered -> Icons.Default.DoneAll
                             else -> Icons.Default.Done
+                        }
+                        // Blue accent only when read; dim tint for sent/delivered
+                        val receiptTint = when {
+                            isRead -> MaterialTheme.colorScheme.tertiary
+                            else -> textColor.copy(alpha = 0.6f)
+                        }
+                        val receiptDescription = when {
+                            isPending -> "Sending"
+                            isRead -> "Read"
+                            isDelivered -> "Delivered"
+                            else -> "Sent"
                         }
                         Icon(
                             imageVector = receiptIcon,
-                            contentDescription = null,
+                            contentDescription = receiptDescription,
                             modifier = Modifier.size(12.dp),
-                            tint = if (message.readAt != null) {
-                                MaterialTheme.colorScheme.onPrimary
-                            } else {
-                                MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.6f)
-                            },
+                            tint = receiptTint,
                         )
                     }
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -1,5 +1,8 @@
 package must.kdroiders.hustlehub.ui.features.chat.presentation.components
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -8,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,23 +29,27 @@ import androidx.compose.material.icons.filled.Work
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -56,6 +64,7 @@ fun MessageBubble(
     isCurrentUser: Boolean,
     playerState: PlayerState,
     onVoicePlayClick: (String) -> Unit,
+    onVoiceSpeedToggle: () -> Unit,
     onLocationClick: (Double, Double, String) -> Unit,
     onServiceCardClick: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -138,6 +147,7 @@ fun MessageBubble(
                             textColor = textColor,
                             playerState = playerState,
                             onPlayClick = onVoicePlayClick,
+                            onSpeedToggle = onVoiceSpeedToggle,
                         )
                     }
 
@@ -206,75 +216,167 @@ fun MessageBubble(
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun VoiceMessageContent(
     message: Message,
-    textColor: androidx.compose.ui.graphics.Color,
+    textColor: Color,
     playerState: PlayerState,
     onPlayClick: (String) -> Unit,
+    onSpeedToggle: () -> Unit,
 ) {
     val voiceUrl = message.mediaUrl ?: ""
     val isPlayingThis = playerState.isPlaying && playerState.playingUrl == voiceUrl
-    val progress = if (isPlayingThis && playerState.durationMs > 0) {
+    val isBufferingThis = playerState.isBuffering && playerState.playingUrl == voiceUrl
+    val progress = if (playerState.playingUrl == voiceUrl && playerState.durationMs > 0) {
         playerState.currentPositionMs.toFloat() / playerState.durationMs
     } else {
         0f
+    }
+
+    // Stable pseudo-random waveform bars seeded from the URL hash
+    val waveformBars = remember(voiceUrl) {
+        val seed = voiceUrl.hashCode().toLong()
+        val rng = java.util.Random(seed)
+        List(WAVEFORM_BAR_COUNT) { 0.2f + rng.nextFloat() * 0.8f }
     }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.width(240.dp),
     ) {
-        IconButton(
-            onClick = { onPlayClick(voiceUrl) },
-            colors = IconButtonDefaults.iconButtonColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            ),
-            modifier = Modifier.size(36.dp),
+        // Play/Pause or Buffering spinner
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.size(38.dp),
         ) {
-            Icon(
-                imageVector = if (isPlayingThis) Icons.Default.Pause else Icons.Default.PlayArrow,
-                contentDescription = if (isPlayingThis) "Pause" else "Play",
-            )
+            if (isBufferingThis) {
+                CircularWavyProgressIndicator(
+                    modifier = Modifier.size(28.dp),
+                    color = textColor.copy(alpha = 0.8f),
+                    trackColor = textColor.copy(alpha = 0.15f),
+                )
+            } else {
+                IconButton(
+                    onClick = { onPlayClick(voiceUrl) },
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = textColor.copy(alpha = 0.15f),
+                        contentColor = textColor,
+                    ),
+                    modifier = Modifier.size(38.dp),
+                ) {
+                    Icon(
+                        imageVector = if (isPlayingThis) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (isPlayingThis) "Pause" else "Play",
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
         }
 
         Spacer(modifier = Modifier.width(8.dp))
 
         Column(modifier = Modifier.weight(1f)) {
-            Slider(
-                value = progress,
-                onValueChange = {},
-                valueRange = 0f..1f,
-                colors = SliderDefaults.colors(
-                    thumbColor = textColor,
-                    activeTrackColor = textColor,
-                    inactiveTrackColor = textColor.copy(alpha = 0.3f),
-                ),
-                modifier = Modifier.height(16.dp),
+            // Waveform visualization
+            WaveformProgress(
+                bars = waveformBars,
+                progress = progress,
+                activeColor = textColor,
+                inactiveColor = textColor.copy(alpha = 0.3f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(32.dp),
             )
+
+            // Position / Total duration + speed toggle
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                val durationText = formatDuration(
-                    if (isPlayingThis) playerState.currentPositionMs else 0,
+                val posText = formatDuration(
+                    if (playerState.playingUrl == voiceUrl) playerState.currentPositionMs else 0,
                 )
-                val totalDurationText = parseVoiceDurationFromMetadata(message.metadata)
+                val totalText = if (playerState.playingUrl == voiceUrl && playerState.durationMs > 0) {
+                    formatDuration(playerState.durationMs)
+                } else {
+                    parseVoiceDurationFromMetadata(message.metadata)
+                }
                 Text(
-                    text = durationText,
+                    text = "$posText / $totalText",
                     fontSize = 10.sp,
                     color = textColor.copy(alpha = 0.7f),
                 )
-                Text(
-                    text = totalDurationText,
-                    fontSize = 10.sp,
-                    color = textColor.copy(alpha = 0.7f),
-                )
+
+                // Speed toggle — only shown while something is loaded
+                if (playerState.playingUrl == voiceUrl) {
+                    val speedLabel = when (playerState.playbackSpeed) {
+                        1.5f -> "1.5x"
+                        2.0f -> "2x"
+                        else -> "1x"
+                    }
+                    Text(
+                        text = speedLabel,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = textColor.copy(alpha = 0.85f),
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(4.dp))
+                            .clickable { onSpeedToggle() }
+                            .padding(horizontal = 4.dp, vertical = 2.dp),
+                    )
+                }
             }
         }
     }
 }
+
+/**
+ * Renders a horizontal row of vertical bars whose fill level reflects [progress].
+ * Bars to the left of the playhead use [activeColor]; bars to the right use [inactiveColor].
+ */
+@Composable
+private fun WaveformProgress(
+    bars: List<Float>,
+    progress: Float,
+    activeColor: Color,
+    inactiveColor: Color,
+    modifier: Modifier = Modifier,
+    barWidthDp: Dp = 3.dp,
+    gapDp: Dp = 2.dp,
+) {
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress,
+        animationSpec = tween(durationMillis = 150),
+        label = "waveformProgress",
+    )
+
+    Canvas(modifier = modifier) {
+        val totalBars = bars.size
+        val barWidth = barWidthDp.toPx()
+        val gap = gapDp.toPx()
+        val totalWidth = totalBars * (barWidth + gap) - gap
+        val startX = (size.width - totalWidth) / 2f
+        val midY = size.height / 2f
+        val playheadX = startX + totalWidth * animatedProgress
+
+        bars.forEachIndexed { i, amplitude ->
+            val barX = startX + i * (barWidth + gap)
+            val barHeight = amplitude * size.height
+            val color = if (barX <= playheadX) activeColor else inactiveColor
+
+            drawLine(
+                color = color,
+                start = Offset(barX + barWidth / 2f, midY - barHeight / 2f),
+                end = Offset(barX + barWidth / 2f, midY + barHeight / 2f),
+                strokeWidth = barWidth,
+                cap = androidx.compose.ui.graphics.StrokeCap.Round,
+            )
+        }
+    }
+}
+
+private const val WAVEFORM_BAR_COUNT = 40
 
 @Composable
 private fun LocationMessageContent(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -525,7 +524,8 @@ private fun ServiceCardMessageContent(
                     ),
                     shape = RoundedCornerShape(8.dp),
                     contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                        horizontal = 12.dp, vertical = 6.dp,
+                        horizontal = 12.dp,
+                        vertical = 6.dp,
                     ),
                 ) {
                     Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -1,6 +1,7 @@
 package must.kdroiders.hustlehub.ui.features.chat.presentation.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,12 +22,15 @@ import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Work
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
@@ -337,45 +341,97 @@ private fun ServiceCardMessageContent(
     if (serviceData != null) {
         Card(
             modifier = Modifier
-                .width(240.dp)
-                .clickable { onClick(serviceData.serviceId) },
+                .width(260.dp)
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
+                    shape = RoundedCornerShape(12.dp),
+                ),
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface,
             ),
             shape = RoundedCornerShape(12.dp),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
         ) {
-            Column(modifier = Modifier.padding(12.dp)) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                // Header label
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         imageVector = Icons.Default.Work,
-                        contentDescription = "Service",
+                        contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp),
+                        modifier = Modifier.size(14.dp),
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
-                        text = serviceData.title,
-                        style = MaterialTheme.typography.titleSmall,
+                        text = "SERVICE REQUEST",
+                        style = MaterialTheme.typography.labelSmall,
                         fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colorScheme.primary,
+                        letterSpacing = 0.8.sp,
                     )
                 }
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = serviceData.priceRange,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.primary,
+
+                Spacer(modifier = Modifier.height(8.dp))
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                    thickness = 0.8.dp,
                 )
-                Spacer(modifier = Modifier.height(6.dp))
+                Spacer(modifier = Modifier.height(10.dp))
+
+                // Service title
                 Text(
-                    text = "Tap to view service detail",
-                    fontSize = 11.sp,
+                    text = serviceData.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Category · Price range
+                Text(
+                    text = buildString {
+                        if (!serviceData.category.isNullOrBlank()) append("${serviceData.category} · ")
+                        append(serviceData.priceRange)
+                    },
+                    style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+
+                // Provider name
+                if (!serviceData.providerName.isNullOrBlank()) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = serviceData.providerName,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // "View Service" CTA
+                OutlinedButton(
+                    onClick = { onClick(serviceData.serviceId) },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary,
+                    ),
+                    shape = RoundedCornerShape(8.dp),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                        horizontal = 12.dp, vertical = 6.dp,
+                    ),
+                ) {
+                    Text(
+                        text = "View Service",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
             }
         }
     } else {
@@ -420,4 +476,10 @@ private fun parseVoiceDurationFromMetadata(metadata: String?): String {
 // Metadata structures
 private data class VoiceMetadata(val durationSeconds: Int)
 private data class LocationMetadata(val lat: Double, val lng: Double, val label: String?)
-private data class ServiceMetadata(val serviceId: String, val title: String, val priceRange: String)
+private data class ServiceMetadata(
+    val serviceId: String,
+    val title: String,
+    val priceRange: String,
+    val category: String? = null,
+    val providerName: String? = null,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -324,7 +324,7 @@ fun ChatDetailScreen(
                         items = reversedMessages,
                         key = { _, msg -> msg.id },
                     ) { index, message ->
-                        val isSelf = message.senderId == state.currentUserId
+                        val isSelf = message.senderId != state.otherUserId || message.id.startsWith("temp_")
 
                         // Because messages are reversed (newest first, index 0),
                         // the previous message chronologically is at index + 1

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,7 +29,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -45,8 +45,8 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularWavyProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -51,6 +53,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -98,6 +102,11 @@ fun ChatDetailScreen(
     onBackClick: () -> Unit,
     onNavigateToServiceDetail: (String) -> Unit,
     modifier: Modifier = Modifier,
+    serviceId: String? = null,
+    serviceTitle: String? = null,
+    serviceCategory: String? = null,
+    servicePriceRange: String? = null,
+    providerName: String? = null,
     viewModel: ChatDetailViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -117,7 +126,14 @@ fun ChatDetailScreen(
 
     // Initialize the conversation when screen loads or ID changes
     LaunchedEffect(conversationId) {
-        viewModel.initialize(conversationId)
+        viewModel.initialize(
+            conversationId = conversationId,
+            serviceId = serviceId,
+            serviceTitle = serviceTitle,
+            serviceCategory = serviceCategory,
+            servicePriceRange = servicePriceRange,
+            providerName = providerName,
+        )
     }
 
     // Show errors in snackbar
@@ -413,6 +429,45 @@ fun ChatDetailScreen(
                             showAttachmentMenu = false
                         },
                     )
+                }
+            }
+
+            // Quick Reply Templates — visible only to the provider of this conversation
+            AnimatedVisibility(visible = state.isCurrentUserProvider) {
+                val quickReplies = listOf(
+                    "Hi! I'm available",
+                    "Can we schedule a time?",
+                    "What style do you prefer?",
+                    "I'm currently busy, back later",
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 12.dp, vertical = 6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    quickReplies.forEach { reply ->
+                        SuggestionChip(
+                            onClick = {
+                                viewModel.sendTextMessage(reply)
+                            },
+                            label = {
+                                Text(
+                                    text = reply,
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            },
+                            colors = SuggestionChipDefaults.suggestionChipColors(
+                                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f),
+                                labelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            ),
+                            border = SuggestionChipDefaults.suggestionChipBorder(
+                                enabled = true,
+                                borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
+                            ),
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -86,6 +86,7 @@ import must.kdroiders.hustlehub.ui.features.chat.presentation.components.DateSep
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.MessageBubble
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ChatDetailViewModel
 import java.io.File
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
@@ -134,14 +135,8 @@ fun ChatDetailScreen(
         }
     }
 
-    // Typing indicator ticker
-    LaunchedEffect(textInput) {
-        if (textInput.isNotBlank()) {
-            viewModel.sendTypingIndicator(true)
-            delay(3000)
-            viewModel.sendTypingIndicator(false)
-        }
-    }
+    // Typing indicator: delegate to ViewModel which owns debounce + auto-clear logic
+    // (no LaunchedEffect needed — the screen just forwards raw onChange events)
 
     // Image picker launcher
     val imagePicker = rememberLauncherForActivityResult(
@@ -242,7 +237,7 @@ fun ChatDetailScreen(
 
                         Spacer(modifier = Modifier.width(12.dp))
 
-                        // Name and typing status
+                        // Name and typing/presence status line
                         Column {
                             Text(
                                 text = state.otherUserName,
@@ -251,9 +246,12 @@ fun ChatDetailScreen(
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )
+                            val lastSeenAt = state.otherUserLastSeenAt
                             val subtitle = when {
                                 state.isTyping -> "typing..."
                                 state.isOtherUserOnline -> "online"
+                                lastSeenAt != null ->
+                                    "Last seen ${formatLastSeen(lastSeenAt)}"
                                 else -> "offline"
                             }
                             Text(
@@ -501,7 +499,10 @@ fun ChatDetailScreen(
 
                     TextField(
                         value = textInput,
-                        onValueChange = { textInput = it },
+                        onValueChange = { newText ->
+                            textInput = newText
+                            viewModel.onTypingChanged(newText)
+                        },
                         placeholder = { Text("Type a message...") },
                         modifier = Modifier
                             .weight(1f)
@@ -671,4 +672,23 @@ private fun formatSeconds(totalSeconds: Int): String {
     val minutes = totalSeconds / 60
     val seconds = totalSeconds % 60
     return String.format("%02d:%02d", minutes, seconds)
+}
+
+/**
+ * Converts an ISO-8601 last-seen timestamp into a human-readable relative string.
+ * Examples: "just now", "5 min ago", "2 hours ago", "3 days ago".
+ */
+private fun formatLastSeen(isoString: String): String {
+    return try {
+        val then = Instant.parse(isoString)
+        val duration = Duration.between(then, Instant.now())
+        when {
+            duration.toMinutes() < 1L -> "just now"
+            duration.toMinutes() < 60L -> "${duration.toMinutes()} min ago"
+            duration.toHours() < 24L -> "${duration.toHours()} hour${if (duration.toHours() > 1L) "s" else ""} ago"
+            else -> "${duration.toDays()} day${if (duration.toDays() > 1L) "s" else ""} ago"
+        }
+    } catch (e: Exception) {
+        "a while ago"
+    }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -44,7 +44,8 @@ import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -95,7 +96,7 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ChatDetailScreen(
     conversationId: String,
@@ -356,6 +357,7 @@ fun ChatDetailScreen(
                             isCurrentUser = isSelf,
                             playerState = state.playerState,
                             onVoicePlayClick = viewModel::playVoice,
+                            onVoiceSpeedToggle = viewModel::toggleVoicePlaybackSpeed,
                             onLocationClick = { lat, lng, label ->
                                 // Custom maps action or toast
                                 val mapUri = Uri.parse("geo:$lat,$lng?q=$lat,$lng($label)")
@@ -372,10 +374,12 @@ fun ChatDetailScreen(
                 }
 
                 if (state.isLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.TopCenter).padding(8.dp),
+                    CircularWavyProgressIndicator(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .padding(8.dp),
                         color = MaterialTheme.colorScheme.primary,
-                        strokeWidth = 2.dp,
+                        trackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
                     )
                 }
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -46,6 +46,11 @@ import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.sharedComposables.EmptyStateView
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Conversation
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ConversationListViewModel
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.filled.Delete
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -122,9 +127,48 @@ fun ChatScreen(
                                 items = state.conversations,
                                 key = { it.id },
                             ) { conversation ->
-                                ConversationItem(
-                                    conversation = conversation,
-                                    onClick = { onNavigateToChatDetail(conversation.id) },
+                                val dismissState = rememberSwipeToDismissBoxState(
+                                    confirmValueChange = { dismissValue ->
+                                        if (dismissValue == SwipeToDismissBoxValue.EndToStart) {
+                                            viewModel.deleteConversation(conversation.id)
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    }
+                                )
+
+                                SwipeToDismissBox(
+                                    state = dismissState,
+                                    enableDismissFromStartToEnd = false,
+                                    enableDismissFromEndToStart = true,
+                                    backgroundContent = {
+                                        val color = when (dismissState.dismissDirection) {
+                                            SwipeToDismissBoxValue.EndToStart -> MaterialTheme.colorScheme.errorContainer
+                                            else -> androidx.compose.ui.graphics.Color.Transparent
+                                        }
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .background(color)
+                                                .padding(horizontal = 24.dp),
+                                            contentAlignment = Alignment.CenterEnd
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Delete,
+                                                contentDescription = "Delete Conversation",
+                                                tint = MaterialTheme.colorScheme.onErrorContainer
+                                            )
+                                        }
+                                    },
+                                    content = {
+                                        Box(modifier = Modifier.background(MaterialTheme.colorScheme.background)) {
+                                            ConversationItem(
+                                                conversation = conversation,
+                                                onClick = { onNavigateToChatDetail(conversation.id) },
+                                            )
+                                        }
+                                    }
                                 )
                                 HorizontalDivider(
                                     modifier = Modifier.padding(horizontal = 16.dp),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -19,17 +19,26 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Work
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -46,11 +55,6 @@ import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.sharedComposables.EmptyStateView
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Conversation
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ConversationListViewModel
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.rememberSwipeToDismissBoxState
-import androidx.compose.material3.SwipeToDismissBoxValue
-import androidx.compose.material3.Icon
-import androidx.compose.material.icons.filled.Delete
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -135,7 +139,7 @@ fun ChatScreen(
                                         } else {
                                             false
                                         }
-                                    }
+                                    },
                                 )
 
                                 SwipeToDismissBox(
@@ -152,12 +156,12 @@ fun ChatScreen(
                                                 .fillMaxSize()
                                                 .background(color)
                                                 .padding(horizontal = 24.dp),
-                                            contentAlignment = Alignment.CenterEnd
+                                            contentAlignment = Alignment.CenterEnd,
                                         ) {
                                             Icon(
                                                 imageVector = Icons.Default.Delete,
                                                 contentDescription = "Delete Conversation",
-                                                tint = MaterialTheme.colorScheme.onErrorContainer
+                                                tint = MaterialTheme.colorScheme.onErrorContainer,
                                             )
                                         }
                                     },
@@ -168,7 +172,7 @@ fun ChatScreen(
                                                 onClick = { onNavigateToChatDetail(conversation.id) },
                                             )
                                         }
-                                    }
+                                    },
                                 )
                                 HorizontalDivider(
                                     modifier = Modifier.padding(horizontal = 16.dp),
@@ -242,24 +246,49 @@ private fun ConversationItem(
             )
             Spacer(modifier = Modifier.height(4.dp))
             val messageText = when (conversation.lastMessageType) {
-                "VOICE" -> "🎤 Voice note"
-                "IMAGE" -> "📷 Photo"
-                "LOCATION" -> "📍 Location"
-                "SERVICE_CARD" -> "💼 Service shared"
+                "VOICE" -> "Voice note"
+                "IMAGE" -> "Photo"
+                "LOCATION" -> "Location"
+                "SERVICE_CARD" -> "Service shared"
                 else -> conversation.lastMessage ?: "No messages yet"
             }
-            Text(
-                text = messageText,
-                style = MaterialTheme.typography.bodyMedium,
-                color = if (conversation.unreadCount > 0) {
-                    MaterialTheme.colorScheme.onBackground
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-                fontWeight = if (conversation.unreadCount > 0) FontWeight.Bold else FontWeight.Normal,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            val icon = when (conversation.lastMessageType) {
+                "VOICE" -> Icons.Default.Mic
+                "IMAGE" -> Icons.Default.Image
+                "LOCATION" -> Icons.Default.Place
+                "SERVICE_CARD" -> Icons.Default.Work
+                else -> null
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start,
+            ) {
+                if (icon != null) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = if (conversation.unreadCount > 0) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                }
+                Text(
+                    text = messageText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (conversation.unreadCount > 0) {
+                        MaterialTheme.colorScheme.onBackground
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    fontWeight = if (conversation.unreadCount > 0) FontWeight.Bold else FontWeight.Normal,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
 
         Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -7,7 +7,6 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import must.kdroiders.hustlehub.core.notification.NotificationHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -23,6 +22,7 @@ import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import must.kdroiders.hustlehub.core.notification.NotificationHelper
 import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.ConversationDao
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.ChatWebSocketService
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Message
@@ -136,7 +136,7 @@ class ChatDetailViewModel
                 } else {
                     val result = chatRepository.getOrCreateConversation(
                         otherUserId = conversationId,
-                        serviceId = serviceId
+                        serviceId = serviceId,
                     )
                     result.fold(
                         onSuccess = { conversation ->
@@ -146,7 +146,7 @@ class ChatDetailViewModel
                         onFailure = { e ->
                             Timber.e(e, "Failed to resolve conversation, using original ID")
                             conversationId
-                        }
+                        },
                     )
                 }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -47,6 +47,10 @@ data class ChatDetailUiState(
     val isLoading: Boolean = false,
     val playerState: PlayerState = PlayerState(),
     val error: String? = null,
+    /** True when the signed-in user is the service provider of this conversation. */
+    val isCurrentUserProvider: Boolean = false,
+    /** Prevents the auto-generated service card from being re-sent on every re-open. */
+    val serviceCardSent: Boolean = false,
 )
 
 @HiltViewModel
@@ -89,20 +93,40 @@ class ChatDetailViewModel
                 .launchIn(viewModelScope)
         }
 
-        fun initialize(conversationId: String) {
+        /**
+         * Initialises the chat conversation.
+         *
+         * The optional [serviceId] / [serviceTitle] / [serviceCategory] / [servicePriceRange] /
+         * [providerName] fields are non-null only when the screen is opened from a service listing.
+         * When present and the conversation is brand new (empty history), a SERVICE_CARD message
+         * is auto-sent once so the provider sees the request context at a glance.
+         */
+        fun initialize(
+            conversationId: String,
+            serviceId: String? = null,
+            serviceTitle: String? = null,
+            serviceCategory: String? = null,
+            servicePriceRange: String? = null,
+            providerName: String? = null,
+        ) {
             if (this.conversationId == conversationId) return
             this.conversationId = conversationId
 
-            _uiState.update { it.copy(currentUserId = firebaseAuth?.currentUser?.uid ?: "") }
+            val currentUid = firebaseAuth?.currentUser?.uid ?: ""
+            _uiState.update { it.copy(currentUserId = currentUid) }
 
             // Load cached conversation details to show other user's info in header instantly
             viewModelScope.launch(Dispatchers.IO) {
                 val cached = conversationDao.getById(conversationId)
                 if (cached != null) {
+                    // Determine if the current user is the provider:
+                    // The conversation's otherUserId is the customer, so if it isn't us, we are the provider.
+                    val isProvider = cached.otherUserId != currentUid
                     _uiState.update {
                         it.copy(
                             otherUserName = cached.otherUserName,
                             otherUserAvatar = cached.otherUserAvatar,
+                            isCurrentUserProvider = isProvider,
                         )
                     }
                 }
@@ -162,14 +186,26 @@ class ChatDetailViewModel
                 }
             }
 
-            // Load REST history page 0
-            loadHistory()
+            // Load REST history page 0, then auto-send service card if this is a brand-new thread
+            loadHistoryAndAutoCard(
+                serviceId = serviceId,
+                serviceTitle = serviceTitle,
+                serviceCategory = serviceCategory,
+                servicePriceRange = servicePriceRange,
+                providerName = providerName,
+            )
 
             // Mark as read on entry
             markAsRead()
         }
 
-        fun loadHistory() {
+        private fun loadHistoryAndAutoCard(
+            serviceId: String? = null,
+            serviceTitle: String? = null,
+            serviceCategory: String? = null,
+            servicePriceRange: String? = null,
+            providerName: String? = null,
+        ) {
             val id = conversationId ?: return
             viewModelScope.launch {
                 _uiState.update { it.copy(isLoading = true, error = null) }
@@ -177,10 +213,29 @@ class ChatDetailViewModel
                     .loadMessageHistory(id, 0)
                     .onSuccess {
                         _uiState.update { it.copy(isLoading = false) }
+                        // Auto-send service card only on the very first open of a brand-new thread
+                        val noMessages = _uiState.value.messages.isEmpty()
+                        val hasServiceContext = !serviceId.isNullOrBlank() && !serviceTitle.isNullOrBlank()
+                        val cardNotYetSent = !_uiState.value.serviceCardSent
+                        if (noMessages && hasServiceContext && cardNotYetSent) {
+                            _uiState.update { it.copy(serviceCardSent = true) }
+                            sendServiceCardMessage(
+                                serviceId = serviceId!!,
+                                title = serviceTitle!!,
+                                priceRange = "KES ${servicePriceRange ?: ""}",
+                                providerName = providerName ?: "",
+                                category = serviceCategory ?: "",
+                            )
+                        }
                     }.onFailure { error ->
                         _uiState.update { it.copy(isLoading = false, error = error.message) }
                     }
             }
+        }
+
+        /** Public entry-point used by the pull-to-refresh or retry actions. */
+        fun loadHistory() {
+            loadHistoryAndAutoCard()
         }
 
         private fun markAsRead() {
@@ -284,10 +339,20 @@ class ChatDetailViewModel
             serviceId: String,
             title: String,
             priceRange: String,
+            category: String = "",
+            providerName: String = "",
         ) {
             val id = conversationId ?: return
             viewModelScope.launch {
-                val metadata = gson.toJson(mapOf("serviceId" to serviceId, "title" to title, "priceRange" to priceRange))
+                val metadata = gson.toJson(
+                    mapOf(
+                        "serviceId" to serviceId,
+                        "title" to title,
+                        "priceRange" to priceRange,
+                        "category" to category,
+                        "providerName" to providerName,
+                    ),
+                )
                 chatRepository.sendMessage(
                     conversationId = id,
                     type = MessageType.SERVICE_CARD,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,8 +19,8 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import must.kdroiders.hustlehub.core.notification.NotificationHelper
@@ -41,6 +42,7 @@ import javax.inject.Inject
 data class ChatDetailUiState(
     val messages: List<Message> = emptyList(),
     val currentUserId: String = "",
+    val otherUserId: String = "",
     val otherUserName: String = "",
     val otherUserAvatar: String? = null,
     val isTyping: Boolean = false,
@@ -158,6 +160,7 @@ class ChatDetailViewModel
                     val isProvider = finalCached.otherUserId != currentUid
                     _uiState.update {
                         it.copy(
+                            otherUserId = finalCached.otherUserId,
                             otherUserName = finalCached.otherUserName,
                             otherUserAvatar = finalCached.otherUserAvatar,
                             isCurrentUserProvider = isProvider,
@@ -167,6 +170,7 @@ class ChatDetailViewModel
                     // Fallback to providerName if conversation isn't cached yet
                     _uiState.update {
                         it.copy(
+                            otherUserId = conversationId,
                             otherUserName = providerName ?: "User",
                             otherUserAvatar = null,
                             isCurrentUserProvider = false,
@@ -186,48 +190,53 @@ class ChatDetailViewModel
                     }
                 }
 
-                // 5. Connect WebSocket and collect incoming messages
+                // 5. Connect WebSocket and collect incoming messages with structured auto-reconnection
                 webSocketJob = launch {
-                    try {
-                        chatRepository
-                            .connectWebSocket(resolvedId)
-                            .retryWhen { cause, attempt ->
-                                Timber.e(cause, "WebSocket disconnected, retrying (attempt $attempt)...")
-                                kotlinx.coroutines.delay(kotlin.math.min(2000L * (attempt + 1), 10000L))
-                                true
-                            }.catch { e -> Timber.e(e, "Error in WebSocket messages flow") }
-                            .launchIn(this)
+                    var attempt = 0
+                    while (isActive) {
+                        try {
+                            chatWebSocketService.connect()
+                            attempt = 0 // Reset attempt count on successful connection
 
-                        // Also subscribe to typing indicators
-                        chatWebSocketService
-                            .subscribeToTyping(resolvedId)
-                            .onEach { typingIndicator ->
-                                if (typingIndicator.senderId != null) {
-                                    val isOtherUser = typingIndicator.isTyping
-                                    _uiState.update { it.copy(isTyping = isOtherUser) }
+                            coroutineScope {
+                                chatRepository
+                                    .connectWebSocket(resolvedId)
+                                    .catch { e -> Timber.e(e, "Error in WebSocket messages flow") }
+                                    .launchIn(this)
+
+                                chatWebSocketService
+                                    .subscribeToTyping(resolvedId)
+                                    .onEach { typingIndicator ->
+                                        if (typingIndicator.senderId != null) {
+                                            val isOtherUser = typingIndicator.isTyping
+                                            _uiState.update { it.copy(isTyping = isOtherUser) }
+                                        }
+                                    }.catch { e -> Timber.e(e, "Error in WebSocket typing flow") }
+                                    .launchIn(this)
+
+                                val otherUid = finalCached?.otherUserId
+                                    ?: if (resolvedId != conversationId) conversationId else null
+
+                                if (otherUid != null) {
+                                    chatRepository
+                                        .subscribeToPresence(otherUid)
+                                        .onEach { presence ->
+                                            _uiState.update {
+                                                it.copy(
+                                                    isOtherUserOnline = presence.online,
+                                                    otherUserLastSeenAt = if (presence.online) null else presence.lastSeenAt,
+                                                )
+                                            }
+                                        }.catch { e -> Timber.e(e, "Error in WebSocket presence flow") }
+                                        .launchIn(this)
                                 }
-                            }.catch { e -> Timber.e(e, "Error in WebSocket typing flow") }
-                            .launchIn(this)
-
-                        // Subscribe to other user's presence if we know who they are
-                        val otherUid = finalCached?.otherUserId
-                            ?: if (resolvedId != conversationId) conversationId else null
-
-                        if (otherUid != null) {
-                            chatRepository
-                                .subscribeToPresence(otherUid)
-                                .onEach { presence ->
-                                    _uiState.update {
-                                        it.copy(
-                                            isOtherUserOnline = presence.online,
-                                            otherUserLastSeenAt = if (presence.online) null else presence.lastSeenAt,
-                                        )
-                                    }
-                                }.catch { e -> Timber.e(e, "Error in WebSocket presence flow") }
-                                .launchIn(this)
+                            }
+                        } catch (e: Exception) {
+                            Timber.e(e, "WebSocket connection failed or disconnected, retrying...")
+                            chatWebSocketService.disconnect()
+                            attempt++
+                            kotlinx.coroutines.delay(kotlin.math.min(2000L * attempt, 10000L))
                         }
-                    } catch (e: Exception) {
-                        Timber.e(e, "Failed to initialize WebSocket")
                     }
                 }
 
@@ -322,7 +331,7 @@ class ChatDetailViewModel
                 _uiState.update { it.copy(isLoading = true) }
                 try {
                     val response = withContext(Dispatchers.IO) {
-                        val requestFile = file.readBytes().toRequestBody("audio/mp4".toMediaTypeOrNull())
+                        val requestFile = file.readBytes().toRequestBody("audio/m4a".toMediaTypeOrNull())
                         val body = MultipartBody.Part.createFormData("file", file.name, requestFile)
                         val convIdBody = MultipartBody.Part.createFormData("conversationId", id)
                         mediaApiService.uploadVoiceNote(body, convIdBody)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -80,6 +80,10 @@ class ChatDetailViewModel
         // Cancels the auto-clear job when a new typing event arrives
         private var typingClearJob: Job? = null
 
+        private var messagesJob: Job? = null
+        private var webSocketJob: Job? = null
+        private var presenceJob: Job? = null
+
         init {
             // Observe voice player state changes
             viewModelScope.launch {
@@ -115,94 +119,143 @@ class ChatDetailViewModel
             if (this.conversationId == conversationId) return
             this.conversationId = conversationId
 
-            val currentUid = firebaseAuth?.currentUser?.uid ?: ""
-            _uiState.update { it.copy(currentUserId = currentUid) }
+            messagesJob?.cancel()
+            webSocketJob?.cancel()
+            presenceJob?.cancel()
 
-            // Load cached conversation details to show other user's info in header instantly
-            viewModelScope.launch(Dispatchers.IO) {
-                val cached = conversationDao.getById(conversationId)
-                if (cached != null) {
-                    // Determine if the current user is the provider:
-                    // The conversation's otherUserId is the customer, so if it isn't us, we are the provider.
-                    val isProvider = cached.otherUserId != currentUid
+            val currentUid = firebaseAuth?.currentUser?.uid ?: ""
+            _uiState.update { it.copy(currentUserId = currentUid, messages = emptyList()) }
+
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+
+                // 1. Resolve conversation ID (the input could be a conversation ID or a provider/user ID)
+                val cached = withContext(Dispatchers.IO) { conversationDao.getById(conversationId) }
+                val resolvedId = if (cached != null) {
+                    conversationId
+                } else {
+                    val result = chatRepository.getOrCreateConversation(
+                        otherUserId = conversationId,
+                        serviceId = serviceId
+                    )
+                    result.fold(
+                        onSuccess = { conversation ->
+                            this@ChatDetailViewModel.conversationId = conversation.id
+                            conversation.id
+                        },
+                        onFailure = { e ->
+                            Timber.e(e, "Failed to resolve conversation, using original ID")
+                            conversationId
+                        }
+                    )
+                }
+
+                chatRepository.setActiveConversation(resolvedId)
+
+                // 2. Load cached conversation details to show other user's info in header instantly
+                val finalCached = withContext(Dispatchers.IO) { conversationDao.getById(resolvedId) }
+                if (finalCached != null) {
+                    val isProvider = finalCached.otherUserId != currentUid
                     _uiState.update {
                         it.copy(
-                            otherUserName = cached.otherUserName,
-                            otherUserAvatar = cached.otherUserAvatar,
+                            otherUserName = finalCached.otherUserName,
+                            otherUserAvatar = finalCached.otherUserAvatar,
                             isCurrentUserProvider = isProvider,
+                        )
+                    }
+                } else {
+                    // Fallback to providerName if conversation isn't cached yet
+                    _uiState.update {
+                        it.copy(
+                            otherUserName = providerName ?: "User",
+                            otherUserAvatar = null,
+                            isCurrentUserProvider = false,
                         )
                     }
                 }
 
-                // Cancel the notification for this conversation immediately — clears the badge slot.
-                NotificationHelper.cancelConversationNotification(context, conversationId)
-            }
-
-            // Observe local database messages (Room is single source of truth)
-            viewModelScope.launch {
-                chatRepository.getMessages(conversationId).collect { messageList ->
-                    _uiState.update { it.copy(messages = messageList) }
+                // 3. Cancel the notification for this conversation
+                withContext(Dispatchers.IO) {
+                    NotificationHelper.cancelConversationNotification(context, resolvedId)
                 }
-            }
 
-            // Connect WebSocket and collect incoming messages
-            viewModelScope.launch {
-                try {
-                    chatRepository
-                        .connectWebSocket(conversationId)
-                        .retryWhen { cause, attempt ->
-                            Timber.e(cause, "WebSocket disconnected, retrying (attempt $attempt)...")
-                            kotlinx.coroutines.delay(kotlin.math.min(2000L * (attempt + 1), 10000L))
-                            true // Always retry
-                        }.catch { e -> Timber.e(e, "Error in WebSocket messages flow") }
-                        .launchIn(viewModelScope)
+                // 4. Observe local database messages
+                messagesJob = launch {
+                    chatRepository.getMessages(resolvedId).collect { messageList ->
+                        _uiState.update { it.copy(messages = messageList) }
+                    }
+                }
 
-                    // Also subscribe to typing indicators for this conversation
-                    chatWebSocketService
-                        .subscribeToTyping(conversationId)
-                        .onEach { typingIndicator ->
-                            if (typingIndicator.senderId != null) {
-                                // Only show typing if it's the other user typing
-                                val isOtherUser = typingIndicator.isTyping
-                                _uiState.update { it.copy(isTyping = isOtherUser) }
-                            }
-                        }.catch { e -> Timber.e(e, "Error in WebSocket typing flow") }
-                        .launchIn(viewModelScope)
+                // 5. Connect WebSocket and collect incoming messages
+                webSocketJob = launch {
+                    try {
+                        chatRepository
+                            .connectWebSocket(resolvedId)
+                            .retryWhen { cause, attempt ->
+                                Timber.e(cause, "WebSocket disconnected, retrying (attempt $attempt)...")
+                                kotlinx.coroutines.delay(kotlin.math.min(2000L * (attempt + 1), 10000L))
+                                true
+                            }.catch { e -> Timber.e(e, "Error in WebSocket messages flow") }
+                            .launchIn(this)
 
-                    // Subscribe to other user's presence if we know who they are
-                    viewModelScope.launch(Dispatchers.IO) {
-                        val cached = conversationDao.getById(conversationId)
-                        cached?.otherUserId?.let { uid ->
+                        // Also subscribe to typing indicators
+                        chatWebSocketService
+                            .subscribeToTyping(resolvedId)
+                            .onEach { typingIndicator ->
+                                if (typingIndicator.senderId != null) {
+                                    val isOtherUser = typingIndicator.isTyping
+                                    _uiState.update { it.copy(isTyping = isOtherUser) }
+                                }
+                            }.catch { e -> Timber.e(e, "Error in WebSocket typing flow") }
+                            .launchIn(this)
+
+                        // Subscribe to other user's presence if we know who they are
+                        val otherUid = finalCached?.otherUserId
+                            ?: if (resolvedId != conversationId) conversationId else null
+
+                        if (otherUid != null) {
                             chatRepository
-                                .subscribeToPresence(uid)
+                                .subscribeToPresence(otherUid)
                                 .onEach { presence ->
                                     _uiState.update {
                                         it.copy(
                                             isOtherUserOnline = presence.online,
-                                            // Clear lastSeen when online; populate it when offline
                                             otherUserLastSeenAt = if (presence.online) null else presence.lastSeenAt,
                                         )
                                     }
                                 }.catch { e -> Timber.e(e, "Error in WebSocket presence flow") }
-                                .launchIn(viewModelScope)
+                                .launchIn(this)
                         }
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to initialize WebSocket")
                     }
-                } catch (e: Exception) {
-                    Timber.e(e, "Failed to initialize WebSocket")
                 }
+
+                // 6. Load REST history page 0, then auto-send service card if this is a brand-new thread
+                chatRepository
+                    .loadMessageHistory(resolvedId, 0)
+                    .onSuccess {
+                        _uiState.update { it.copy(isLoading = false) }
+                        val noMessages = _uiState.value.messages.isEmpty()
+                        val hasServiceContext = !serviceId.isNullOrBlank() && !serviceTitle.isNullOrBlank()
+                        val cardNotYetSent = !_uiState.value.serviceCardSent
+                        if (noMessages && hasServiceContext && cardNotYetSent) {
+                            _uiState.update { it.copy(serviceCardSent = true) }
+                            sendServiceCardMessage(
+                                serviceId = serviceId!!,
+                                title = serviceTitle!!,
+                                priceRange = "KES ${servicePriceRange ?: ""}",
+                                providerName = providerName ?: "",
+                                category = serviceCategory ?: "",
+                            )
+                        }
+                    }.onFailure { error ->
+                        _uiState.update { it.copy(isLoading = false, error = error.message) }
+                    }
+
+                // 7. Mark as read on entry
+                chatRepository.markAsRead(resolvedId)
             }
-
-            // Load REST history page 0, then auto-send service card if this is a brand-new thread
-            loadHistoryAndAutoCard(
-                serviceId = serviceId,
-                serviceTitle = serviceTitle,
-                serviceCategory = serviceCategory,
-                servicePriceRange = servicePriceRange,
-                providerName = providerName,
-            )
-
-            // Mark as read on entry
-            markAsRead()
         }
 
         private fun loadHistoryAndAutoCard(
@@ -219,7 +272,6 @@ class ChatDetailViewModel
                     .loadMessageHistory(id, 0)
                     .onSuccess {
                         _uiState.update { it.copy(isLoading = false) }
-                        // Auto-send service card only on the very first open of a brand-new thread
                         val noMessages = _uiState.value.messages.isEmpty()
                         val hasServiceContext = !serviceId.isNullOrBlank() && !serviceTitle.isNullOrBlank()
                         val cardNotYetSent = !_uiState.value.serviceCardSent
@@ -239,7 +291,6 @@ class ChatDetailViewModel
             }
         }
 
-        /** Public entry-point used by the pull-to-refresh or retry actions. */
         fun loadHistory() {
             loadHistoryAndAutoCard()
         }
@@ -420,6 +471,7 @@ class ChatDetailViewModel
 
         override fun onCleared() {
             super.onCleared()
+            chatRepository.setActiveConversation(null)
             voicePlayer.release()
             viewModelScope.launch {
                 chatRepository.disconnectWebSocket()

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -1,10 +1,12 @@
 package must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -57,6 +59,7 @@ data class ChatDetailUiState(
 class ChatDetailViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val chatRepository: ChatRepository,
         private val chatWebSocketService: ChatWebSocketService,
         private val mediaApiService: MediaApiService,
@@ -67,7 +70,7 @@ class ChatDetailViewModel
         val uiState: StateFlow<ChatDetailUiState> = _uiState.asStateFlow()
 
         private var conversationId: String? = null
-        private val voicePlayer = VoicePlayer()
+        private val voicePlayer = VoicePlayer(context)
         private val gson = Gson()
 
         // Raw typing events from the keyboard — debounced before sending over WebSocket
@@ -403,13 +406,18 @@ class ChatDetailViewModel
             voicePlayer.play(url)
         }
 
+        /** Cycles the playback speed: 1.0x → 1.5x → 2.0x → 1.0x. */
+        fun toggleVoicePlaybackSpeed() {
+            voicePlayer.toggleSpeed()
+        }
+
         fun clearError() {
             _uiState.update { it.copy(error = null) }
         }
 
         override fun onCleared() {
             super.onCleared()
-            voicePlayer.stop()
+            voicePlayer.release()
             viewModelScope.launch {
                 chatRepository.disconnectWebSocket()
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -92,8 +92,7 @@ class ChatDetailViewModel
                 .debounce(TYPING_DEBOUNCE_MS)
                 .onEach { isTyping ->
                     sendTypingIndicator(isTyping)
-                }
-                .launchIn(viewModelScope)
+                }.launchIn(viewModelScope)
         }
 
         /**

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -7,6 +7,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import must.kdroiders.hustlehub.core.notification.NotificationHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -132,6 +133,9 @@ class ChatDetailViewModel
                         )
                     }
                 }
+
+                // Cancel the notification for this conversation immediately — clears the badge slot.
+                NotificationHelper.cancelConversationNotification(context, conversationId)
             }
 
             // Observe local database messages (Room is single source of truth)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -6,10 +6,14 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
@@ -38,6 +42,8 @@ data class ChatDetailUiState(
     val otherUserAvatar: String? = null,
     val isTyping: Boolean = false,
     val isOtherUserOnline: Boolean = false,
+    /** ISO-8601 string; null when user is currently online. */
+    val otherUserLastSeenAt: String? = null,
     val isLoading: Boolean = false,
     val playerState: PlayerState = PlayerState(),
     val error: String? = null,
@@ -60,6 +66,12 @@ class ChatDetailViewModel
         private val voicePlayer = VoicePlayer()
         private val gson = Gson()
 
+        // Raw typing events from the keyboard — debounced before sending over WebSocket
+        private val typingEvents = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
+
+        // Cancels the auto-clear job when a new typing event arrives
+        private var typingClearJob: Job? = null
+
         init {
             // Observe voice player state changes
             viewModelScope.launch {
@@ -67,6 +79,14 @@ class ChatDetailViewModel
                     _uiState.update { it.copy(playerState = pState) }
                 }
             }
+
+            // Debounce raw typing events before sending over WebSocket
+            typingEvents
+                .debounce(TYPING_DEBOUNCE_MS)
+                .onEach { isTyping ->
+                    sendTypingIndicator(isTyping)
+                }
+                .launchIn(viewModelScope)
         }
 
         fun initialize(conversationId: String) {
@@ -126,7 +146,13 @@ class ChatDetailViewModel
                             chatRepository
                                 .subscribeToPresence(uid)
                                 .onEach { presence ->
-                                    _uiState.update { it.copy(isOtherUserOnline = presence.online) }
+                                    _uiState.update {
+                                        it.copy(
+                                            isOtherUserOnline = presence.online,
+                                            // Clear lastSeen when online; populate it when offline
+                                            otherUserLastSeenAt = if (presence.online) null else presence.lastSeenAt,
+                                        )
+                                    }
                                 }.catch { e -> Timber.e(e, "Error in WebSocket presence flow") }
                                 .launchIn(viewModelScope)
                         }
@@ -168,6 +194,9 @@ class ChatDetailViewModel
             val id = conversationId ?: return
             if (content.isBlank()) return
             viewModelScope.launch {
+                // Clear the typing indicator immediately when the message is sent
+                sendTypingIndicator(false)
+                typingClearJob?.cancel()
                 chatRepository.sendMessage(id, MessageType.TEXT, content)
             }
         }
@@ -269,6 +298,25 @@ class ChatDetailViewModel
             }
         }
 
+        /**
+         * Called from the screen whenever the text input changes.
+         * Emits to the debounce pipeline — 500ms after the last keystroke it sends
+         * isTyping=true. A 3-second auto-clear is also scheduled.
+         */
+        fun onTypingChanged(text: String) {
+            val isTyping = text.isNotBlank()
+            typingClearJob?.cancel()
+            viewModelScope.launch {
+                typingEvents.emit(isTyping)
+            }
+            if (isTyping) {
+                typingClearJob = viewModelScope.launch {
+                    delay(TYPING_CLEAR_TIMEOUT_MS)
+                    sendTypingIndicator(false)
+                }
+            }
+        }
+
         fun sendTypingIndicator(isTyping: Boolean) {
             val id = conversationId ?: return
             viewModelScope.launch {
@@ -300,5 +348,13 @@ class ChatDetailViewModel
             viewModelScope.launch {
                 chatRepository.disconnectWebSocket()
             }
+        }
+
+        private companion object {
+            /** Minimum quiet period before a typing=true event is sent to the server. */
+            const val TYPING_DEBOUNCE_MS = 500L
+
+            /** How long after the last keystroke the typing indicator is auto-cleared. */
+            const val TYPING_CLEAR_TIMEOUT_MS = 3_000L
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ConversationListViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ConversationListViewModel.kt
@@ -54,4 +54,14 @@ class ConversationListViewModel
                     }
             }
         }
+
+        fun deleteConversation(conversationId: String) {
+            viewModelScope.launch {
+                chatRepository.deleteConversation(conversationId)
+                    .onFailure { error ->
+                        _uiState.update { it.copy(error = error.message ?: "Failed to delete conversation") }
+                    }
+            }
+        }
     }
+

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ConversationListViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ConversationListViewModel.kt
@@ -57,11 +57,11 @@ class ConversationListViewModel
 
         fun deleteConversation(conversationId: String) {
             viewModelScope.launch {
-                chatRepository.deleteConversation(conversationId)
+                chatRepository
+                    .deleteConversation(conversationId)
                     .onFailure { error ->
                         _uiState.update { it.copy(error = error.message ?: "Failed to delete conversation") }
                     }
             }
         }
     }
-

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModel.kt
@@ -1,0 +1,34 @@
+package must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.ConversationDao
+import javax.inject.Inject
+
+/**
+ * Lightweight ViewModel scoped to the main shell that exposes the total
+ * unread message count across all conversations.
+ *
+ * Consumed by [MainShellScreen] to drive the bottom navigation badge.
+ * Using a dedicated ViewModel (rather than collecting directly in the
+ * composable) ensures the Flow survives recomposition and tab switches.
+ */
+@HiltViewModel
+class UnreadCountViewModel
+    @Inject
+    constructor(
+        conversationDao: ConversationDao,
+    ) : ViewModel() {
+        val totalUnreadCount: StateFlow<Int> =
+            conversationDao
+                .getTotalUnreadCount()
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                    initialValue = 0,
+                )
+    }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FeaturedServicesRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FeaturedServicesRow.kt
@@ -161,11 +161,10 @@ private fun FeaturedServiceCard(
                         colors = listOf(
                             Color.Transparent,
                             Color.Black.copy(alpha = 0.6f),
-                            Color.Black.copy(alpha = 0.9f)
-                        )
-                    )
-                )
-                .padding(start = 12.dp, end = 12.dp, bottom = 12.dp, top = 32.dp),
+                            Color.Black.copy(alpha = 0.9f),
+                        ),
+                    ),
+                ).padding(start = 12.dp, end = 12.dp, bottom = 12.dp, top = 32.dp),
         ) {
             Text(
                 text = service.category.label,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/ServiceCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/ServiceCard.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.Icon
@@ -34,8 +34,6 @@ import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Service
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceAvailability
 import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
-import must.kdroiders.hustlehub.ui.theme.HustleOfflineGray
-import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
 
 @Composable
 fun ServiceCard(
@@ -148,7 +146,7 @@ private fun AvailabilityBadge(
                 modifier = Modifier
                     .size(6.dp)
                     .clip(CircleShape)
-                    .background(HustleActiveGreen)
+                    .background(HustleActiveGreen),
             )
             Spacer(Modifier.width(4.dp))
             Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -3,17 +3,21 @@ package must.kdroiders.hustlehub.ui.features.home.presentation.view
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -34,15 +38,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.ui.draw.clip
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
@@ -189,7 +189,7 @@ fun HomeScreen(
                                 .fillMaxWidth()
                                 .padding(horizontal = 4.dp),
                             horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Text(
                                 text = "Top Hustlers",
@@ -203,7 +203,7 @@ fun HomeScreen(
                                         snackbarHostState.showSnackbar("Coming soon")
                                     }
                                 },
-                                contentPadding = PaddingValues(0.dp)
+                                contentPadding = PaddingValues(0.dp),
                             ) {
                                 Text(
                                     text = "View All",
@@ -232,13 +232,13 @@ fun HomeScreen(
                     Spacer(Modifier.height(8.dp))
                     Row(
                         modifier = Modifier.padding(start = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Box(
                             modifier = Modifier
                                 .size(6.dp)
                                 .clip(CircleShape)
-                                .background(HustleActiveGreen)
+                                .background(HustleActiveGreen),
                         )
                         Spacer(Modifier.width(6.dp))
                         Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/media/data/remote/MediaApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/media/data/remote/MediaApiService.kt
@@ -3,7 +3,6 @@ package must.kdroiders.hustlehub.ui.features.media.data.remote
 import must.kdroiders.hustlehub.core.api.ApiResponse
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.VoiceUploadResponse
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package must.kdroiders.hustlehub.ui.features.profile.data.repository
 import android.content.Context
 import android.net.Uri
 import dagger.hilt.android.qualifiers.ApplicationContext
+import must.kdroiders.hustlehub.core.utils.ImageCompressor
 import must.kdroiders.hustlehub.ui.features.auth.data.remote.AuthApiService
 import must.kdroiders.hustlehub.ui.features.auth.data.remote.RegisterRequest
 import must.kdroiders.hustlehub.ui.features.auth.data.remote.UserResponseDto
@@ -23,7 +24,6 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
-import must.kdroiders.hustlehub.core.utils.ImageCompressor
 
 /**
  * Concrete implementation of [UserRepository].

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/util/HustleScoreCalculator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/util/HustleScoreCalculator.kt
@@ -18,8 +18,8 @@ object HustleScoreCalculator {
         val avgRating = services.map { it.averageRating }.average().toFloat()
 
         // Bayesian Average Formula
-        val bayesianRating = ( (totalReviews / (totalReviews + MIN_REVIEWS_TO_ESTABLISH)) * avgRating ) +
-                             ( (MIN_REVIEWS_TO_ESTABLISH / (totalReviews + MIN_REVIEWS_TO_ESTABLISH)) * PLATFORM_AVERAGE_RATING )
+        val bayesianRating = ((totalReviews / (totalReviews + MIN_REVIEWS_TO_ESTABLISH)) * avgRating) +
+            ((MIN_REVIEWS_TO_ESTABLISH / (totalReviews + MIN_REVIEWS_TO_ESTABLISH)) * PLATFORM_AVERAGE_RATING)
 
         // Convert the 1.0 - 5.0 Bayesian rating to a percentage out of 100
         val finalPercentage = (bayesianRating / 5f) * 100f
@@ -38,8 +38,8 @@ object HustleScoreCalculator {
 
         val avgRating = service.averageRating.toFloat()
 
-        val bayesianRating = ( (totalReviews / (totalReviews + MIN_REVIEWS_TO_ESTABLISH)) * avgRating ) +
-                             ( (MIN_REVIEWS_TO_ESTABLISH / (totalReviews + MIN_REVIEWS_TO_ESTABLISH)) * PLATFORM_AVERAGE_RATING )
+        val bayesianRating = ((totalReviews / (totalReviews + MIN_REVIEWS_TO_ESTABLISH)) * avgRating) +
+            ((MIN_REVIEWS_TO_ESTABLISH / (totalReviews + MIN_REVIEWS_TO_ESTABLISH)) * PLATFORM_AVERAGE_RATING)
 
         val finalPercentage = (bayesianRating / 5f) * 100f
         return kotlin.math.round(finalPercentage * 10f) / 10f

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -51,7 +51,7 @@ class ProfileViewModel
                         val services = servicesResult.getOrElse { emptyList() }
                         val calculatedReviewCount = services.sumOf { it.reviewCount }
                         val calculatedScore = HustleScoreCalculator.calculate(services)
-                        
+
                         _uiState.update {
                             it.copy(
                                 user = user,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/model/Service.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/model/Service.kt
@@ -1,8 +1,8 @@
 package must.kdroiders.hustlehub.ui.features.service.domain.model
 
+import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.LocationDto
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceAvailability
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceCategory
-import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.LocationDto
 
 data class Service(
     val id: String = "",

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/MyServicesScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/MyServicesScreen.kt
@@ -153,11 +153,11 @@ fun MyServicesScreen(
                     if (state.isGallerySaving) {
                         Box(
                             modifier = Modifier.fillMaxWidth().height(48.dp),
-                            contentAlignment = Alignment.Center
+                            contentAlignment = Alignment.Center,
                         ) {
                             CircularWavyProgressIndicator(
                                 color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(24.dp)
+                                modifier = Modifier.size(24.dp),
                             )
                         }
                     } else {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
@@ -80,7 +80,14 @@ fun ServiceDetailScreen(
     serviceId: String,
     serviceDetailViewModel: ServiceDetailViewModel = hiltViewModel(),
     onBack: () -> Unit = {},
-    onNavigateToChat: (providerId: String) -> Unit = {},
+    onNavigateToChat: (
+        providerId: String,
+        serviceId: String,
+        serviceTitle: String,
+        serviceCategory: String,
+        servicePriceRange: String,
+        providerName: String,
+    ) -> Unit = { _, _, _, _, _, _ -> },
     onNavigateToProviderProfile: (providerId: String) -> Unit = {},
     onNavigateToWriteReview: (serviceId: String, providerId: String) -> Unit = { _, _ -> },
 ) {
@@ -127,7 +134,19 @@ fun ServiceDetailScreen(
 
                         HustleButton(
                             text = "Message Provider",
-                            onClick = { state.service?.providerId?.let { onNavigateToChat(it) } },
+                            onClick = {
+                                val svc = state.service
+                                if (svc != null) {
+                                    onNavigateToChat(
+                                        svc.providerId,
+                                        svc.id,
+                                        svc.title,
+                                        svc.category.name,
+                                        svc.priceRange,
+                                        state.provider?.name ?: "",
+                                    )
+                                }
+                            },
                             modifier = Modifier.width(200.dp),
                         )
                     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
@@ -53,7 +53,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -157,7 +156,7 @@ fun ServiceDetailScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+                .background(MaterialTheme.colorScheme.background),
         ) {
             when {
                 state.isLoading -> LoadingIndicator(modifier = Modifier.fillMaxSize())
@@ -264,7 +263,7 @@ private fun ServiceDetailContent(
 
                     HorizontalPager(
                         state = pagerState,
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.fillMaxSize(),
                     ) { page ->
                         AsyncImage(
                             model = service.portfolio[page],
@@ -282,21 +281,27 @@ private fun ServiceDetailContent(
                             modifier = Modifier
                                 .align(Alignment.BottomCenter)
                                 .padding(bottom = 32.dp), // Padding to keep above the curved bottom
-                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
                         ) {
                             repeat(service.portfolio.size) { iteration ->
-                                val color = if (pagerState.currentPage == iteration) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.5f)
+                                val color = if (pagerState.currentPage ==
+                                    iteration
+                                ) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    Color.White.copy(alpha = 0.5f)
+                                }
                                 Box(
                                     modifier = Modifier
                                         .clip(CircleShape)
                                         .background(color)
-                                        .size(if (pagerState.currentPage == iteration) 8.dp else 6.dp)
+                                        .size(if (pagerState.currentPage == iteration) 8.dp else 6.dp),
                                 )
                             }
                         }
                     }
                 } else if (service.iconUrl.isNotBlank()) {
-                     AsyncImage(
+                    AsyncImage(
                         model = service.iconUrl,
                         contentDescription = "Service Hero Image",
                         contentScale = ContentScale.Crop,
@@ -311,7 +316,7 @@ private fun ServiceDetailContent(
                         .height(32.dp)
                         .align(Alignment.BottomCenter)
                         .clip(RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp))
-                        .background(MaterialTheme.colorScheme.background)
+                        .background(MaterialTheme.colorScheme.background),
                 )
             }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
@@ -132,7 +132,8 @@ fun ServiceDetailScreen(
                         }
 
                         HustleButton(
-                            text = "Message Provider",
+                            text = if (state.isOwnService) "Your Service" else "DM Provider",
+                            enabled = !state.isOwnService,
                             onClick = {
                                 val svc = state.service
                                 if (svc != null) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/FullScreenImageViewer.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/FullScreenImageViewer.kt
@@ -8,7 +8,11 @@ import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -27,10 +31,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil.compose.AsyncImage
@@ -51,7 +51,7 @@ fun FullScreenImageViewer(
 ) {
     val pagerState = rememberPagerState(
         initialPage = initialIndex,
-        pageCount = { imageUrls.size }
+        pageCount = { imageUrls.size },
     )
     val coroutineScope = androidx.compose.runtime.rememberCoroutineScope()
 
@@ -65,7 +65,7 @@ fun FullScreenImageViewer(
                 .background(Color.Black)
                 .pointerInput(Unit) {
                     detectTapGestures(
-                        onTap = { onDismiss() }
+                        onTap = { onDismiss() },
                     )
                 },
         ) {
@@ -75,7 +75,7 @@ fun FullScreenImageViewer(
             ) { page ->
                 ZoomableImage(
                     imageUrl = imageUrls[page],
-                    onDismiss = onDismiss
+                    onDismiss = onDismiss,
                 )
             }
 
@@ -139,7 +139,7 @@ fun FullScreenImageViewer(
 @Composable
 private fun ZoomableImage(
     imageUrl: String,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
     var scale by remember { mutableFloatStateOf(1f) }
     var offset by remember { mutableStateOf(Offset.Zero) }
@@ -154,7 +154,7 @@ private fun ZoomableImage(
             .fillMaxSize()
             .pointerInput(Unit) {
                 detectTapGestures(
-                    onTap = { onDismiss() }
+                    onTap = { onDismiss() },
                 )
             },
     ) {
@@ -169,8 +169,7 @@ private fun ZoomableImage(
                     scaleY = scale,
                     translationX = offset.x,
                     translationY = offset.y,
-                )
-                .transformable(state = transformState)
+                ).transformable(state = transformState)
                 .pointerInput(scale > 1f) {
                     if (scale > 1f) {
                         detectDragGestures { change, dragAmount ->
@@ -178,8 +177,7 @@ private fun ZoomableImage(
                             offset += dragAmount
                         }
                     }
-                }
-                .pointerInput(Unit) {
+                }.pointerInput(Unit) {
                     detectTapGestures(
                         onDoubleTap = {
                             if (scale > 1f) {
@@ -189,9 +187,9 @@ private fun ZoomableImage(
                                 scale = 2.5f
                             }
                         },
-                        onTap = { 
+                        onTap = {
                             // Consume single tap on the image so it doesn't dismiss the viewer
-                        }
+                        },
                     )
                 },
         )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
@@ -1,9 +1,13 @@
 package must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel
 
+import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -12,16 +16,12 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import must.kdroiders.hustlehub.core.utils.ImageCompressor
 import must.kdroiders.hustlehub.ui.features.media.domain.repository.StorageRepository
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceAvailability
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceCategory
 import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceByIdUseCase
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -266,7 +266,7 @@ class CreateServiceViewModel
                 result
                     .onSuccess { savedService ->
                         val targetId = if (state.isEditMode && snapshot != null) snapshot else savedService.id
-                        
+
                         // Handle Portfolio Uploads if there are new images
                         val newUrls = mutableListOf<String>()
                         if (state.portfolioUris.isNotEmpty()) {
@@ -283,16 +283,18 @@ class CreateServiceViewModel
                                                 }
                                             }
                                             url
-                                        } else null
+                                        } else {
+                                            null
+                                        }
                                     }
                                 }
                                 newUrls.addAll(uploadDeferreds.awaitAll().filterNotNull())
-                                
+
                                 // Now update the service with the final combined portfolio URLs
                                 val combinedUrls = state.existingPortfolioUrls + newUrls
                                 serviceRepository.updateService(
                                     serviceId = targetId,
-                                    portfolioUrls = combinedUrls
+                                    portfolioUrls = combinedUrls,
                                 )
                             } catch (e: Exception) {
                                 Timber.e(e, "Failed to upload portfolio images")

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/MyServicesViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/MyServicesViewModel.kt
@@ -1,24 +1,24 @@
 package must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel
 
+import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.core.utils.ImageCompressor
+import must.kdroiders.hustlehub.ui.features.media.domain.repository.StorageRepository
+import must.kdroiders.hustlehub.ui.features.media.domain.repository.UploadResult
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceAvailability
+import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.DeleteServiceUseCase
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetMyServicesUseCase
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.UpdateAvailabilityUseCase
-import must.kdroiders.hustlehub.ui.features.media.domain.repository.UploadResult
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
-import must.kdroiders.hustlehub.core.utils.ImageCompressor
-import must.kdroiders.hustlehub.ui.features.media.domain.repository.StorageRepository
-import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -177,17 +177,16 @@ class MyServicesViewModel
             }
         }
 
-
         fun saveGallery() {
             val serviceId = _uiState.value.selectedServiceForGallery ?: return
             val state = _uiState.value
-            
+
             _uiState.update { it.copy(isGallerySaving = true, error = null) }
-            
+
             viewModelScope.launch {
                 try {
                     val uploadedUrls = mutableListOf<String>()
-                    
+
                     // 1. Compress and upload new images
                     for (uri in state.portfolioUris) {
                         val compressedBytes = ImageCompressor.compressImage(context, uri)
@@ -203,16 +202,16 @@ class MyServicesViewModel
                             finalUrl?.let { uploadedUrls.add(it) }
                         }
                     }
-                    
+
                     // 2. Combine surviving existing URLs and newly uploaded URLs
                     val finalPortfolioUrls = state.existingPortfolioUrls + uploadedUrls
-                    
+
                     // 3. Update the service in backend
-                    serviceRepository.updateService(
-                        serviceId = serviceId,
-                        portfolioUrls = finalPortfolioUrls
-                    )
-                        .onSuccess { updatedService ->
+                    serviceRepository
+                        .updateService(
+                            serviceId = serviceId,
+                            portfolioUrls = finalPortfolioUrls,
+                        ).onSuccess { updatedService ->
                             // 4. Update the local cache
                             _uiState.update { current ->
                                 val updatedServices = current.services.map { service ->
@@ -223,15 +222,13 @@ class MyServicesViewModel
                                     selectedServiceForGallery = null,
                                     existingPortfolioUrls = emptyList(),
                                     portfolioUris = emptyList(),
-                                    isGallerySaving = false
+                                    isGallerySaving = false,
                                 )
                             }
-                        }
-                        .onFailure { e ->
+                        }.onFailure { e ->
                             Timber.e(e, "Failed to update service portfolio")
                             _uiState.update { it.copy(isGallerySaving = false, error = e.message ?: "Failed to update portfolio") }
                         }
-                        
                 } catch (e: Exception) {
                     Timber.e(e, "Error saving gallery")
                     _uiState.update { it.copy(isGallerySaving = false, error = e.message ?: "Error saving gallery") }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/ServiceDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/ServiceDetailViewModel.kt
@@ -50,20 +50,19 @@ class ServiceDetailViewModel
                 val serviceResult = serviceDeferred.await()
                 val reviewsResult = reviewsDeferred.await()
 
-                serviceResult
-                    .onSuccess { service ->
-                        val providerResult = getProviderProfileUseCase(service.providerId)
-
-                        val reviews = reviewsResult.getOrElse { emptyList<Review>().let { it } }
-                        val reviewPage = reviewsResult.getOrNull()
+                serviceResult.onSuccess { service ->
+                    val providerResult = getProviderProfileUseCase(service.providerId)
+                    val provider = providerResult.getOrNull()
+                    val reviews = reviewsResult.getOrElse { emptyList<Review>().let { it } }
+                    val reviewPage = reviewsResult.getOrNull()
 
                         _uiState.update {
                             it.copy(
                                 service = service,
-                                provider = providerResult.getOrNull(),
+                                provider = provider,
                                 reviews = reviewPage?.content ?: emptyList(),
                                 totalReviewCount = reviewPage?.totalElements?.toInt() ?: service.reviewCount,
-                                isOwnService = currentUid != null && currentUid == service.providerId,
+                                isOwnService = currentUid != null && provider != null && currentUid == provider.id,
                                 isLoading = false,
                                 error = null,
                             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ credentials = "1.6.0"
 playServicesAuth = "21.6.0"
 googleid = "1.2.0"
 krossbow = "7.0.0"
+media3 = "1.2.0"
 
 # expressive
 material3 = "1.5.0-alpha22"
@@ -139,6 +140,10 @@ googleid = { group = "com.google.android.libraries.identity.googleid", name = "g
 # Krossbow STOMP WebSocket
 krossbow-stomp-core = { group = "org.hildan.krossbow", name = "krossbow-stomp-core", version.ref = "krossbow" }
 krossbow-websocket-okhttp = { group = "org.hildan.krossbow", name = "krossbow-websocket-okhttp", version.ref = "krossbow" }
+
+# Media3 (ExoPlayer)
+androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3" }
 
 # Detekt formatting rules
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }


### PR DESCRIPTION
## 📝 What does this PR do?
This PR introduces offline-first local message caching with Room, unread message badges across the app, dynamic user-to-conversation ID resolution (resolving chat HTTP 404s and empty headers), a swipe-to-delete conversation feature with backend sync, and replaces preview emojis with polished Material Design vector icons.

---

## 🔄 Main Changes

### Added
- **Room Offline Caching**: Added `MessageEntity` and `MessageDao` to cache messages locally. Integrated database upserts for offline readability.
- **Unread Message Badges**: Implemented unread message count badges on the Bottom Navigation Chat icon, chat list conversation rows, and total unread count on the app launcher icon (Android 8+).
- **Backend DELETE Endpoint**: Added `DELETE /api/v1/conversations/{id}` to `ChatController.kt` and `ChatRestService.kt` to support complete conversation deletions.
- **Client DELETE API**: Added Retrofit mappings and repository hooks for deleting conversations locally and on the server.
- **UI Icons**: Added Material vector icons (`Mic`, `Image`, `Place`, `Work`) in the last message previews inside the chat list.

### Changed
- **Dynamic ID Resolution**: Modified `ChatDetailViewModel.kt` to dynamically resolve User/Provider IDs to a Conversation UUID on opening the screen. This resolves empty user headers and HTTP 404 errors.
- **Swipe-to-Dismiss UI**: Integrated Compose's `SwipeToDismissBox` in `ChatScreen.kt` for a clean swipe-to-delete gesture.
- **Badging Lifecycle**: Suppressed notification popups and auto-cleared unread badges when entering an active conversation.
- **Service Reviews bypass**: Temporarily bypassed `getServiceReviews` in `ServiceRepositoryImpl.kt` to return an empty response directly instead of failing with HTTP 500/404 since backend reviews are not implemented yet.

### Fixed
- **HTTP 404 & Empty Headers**: Fixed crashes and missing header names when clicking "Message Provider" on `ServiceDetailScreen` by resolving IDs on startup.
- **Stale Cache Cleanup**: Automatically purge stale conversation and message records from local Room storage when encountering a server HTTP 404 during synchronization.

### Removed
- Legacy emojis (`🎤`, `📷`, `📍`, `💼`) from the chat list rows, replacing them with professional vector icons.

---

## ✅ Type of change
- [x] New feature
- [x] Bug fix
- [x] UI update
- [x] Refactor / cleanup
- [ ] Documentation

---

## 🧪 I have tested that...
- [x] The app builds without errors
- [x] My feature/fix works as expected
- [x] I didn't break anything else

---

## 🔍 Code quality
- [x] Ktlint passed  (`./gradlew ktlintCheck`)
- [x] Detekt passed  (`./gradlew detekt`)
- [x] My commit message follows convention (`feat:`, `fix:`, `chore:` etc.)

---

## 📸 Screenshots
<!-- If you changed the UI, paste before/after screenshots here. Otherwise delete this section. -->

---

## Closes #
Closes #39, Closes #40, Closes #42
