### PR TITLE
implement message deletion, slide-to-reply, websocket safety, and presence-aware ticks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,8 @@
             android:name="must.kdroiders.hustlehub.activities.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.HustleHub">
+            android:theme="@style/Theme.HustleHub"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/dao/MessageDao.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/dao/MessageDao.kt
@@ -26,6 +26,9 @@ interface MessageDao {
     @Query("SELECT * FROM messages WHERE id = :id LIMIT 1")
     suspend fun getById(id: String): MessageEntity?
 
+    @Query("SELECT * FROM messages WHERE conversationId = :conversationId ORDER BY timestamp DESC LIMIT 1")
+    suspend fun getLatestMessage(conversationId: String): MessageEntity?
+
     @Query("DELETE FROM messages WHERE cachedAt < :threshold")
     suspend fun deleteStaleEntries(threshold: Long)
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/dao/MessageDao.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/local/dao/MessageDao.kt
@@ -23,6 +23,9 @@ interface MessageDao {
     @Query("DELETE FROM messages WHERE id = :id")
     suspend fun deleteById(id: String)
 
+    @Query("SELECT * FROM messages WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): MessageEntity?
+
     @Query("DELETE FROM messages WHERE cachedAt < :threshold")
     suspend fun deleteStaleEntries(threshold: Long)
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/remote/ChatWebSocketService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/remote/ChatWebSocketService.kt
@@ -4,6 +4,8 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.tasks.await
 import must.kdroiders.hustlehub.BuildConfig
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.MessageResponse
@@ -28,25 +30,28 @@ class ChatWebSocketService
     ) {
         private var stompSession: StompSession? = null
         private val gson = Gson()
+        private val connectMutex = kotlinx.coroutines.sync.Mutex()
 
         suspend fun connect() {
-            if (stompSession != null) return
-            try {
-                val currentUser = firebaseAuth?.currentUser ?: throw IllegalStateException("User not logged in")
-                val token = currentUser.getIdToken(false).await().token ?: throw IllegalStateException("Could not get Firebase token")
+            connectMutex.withLock {
+                if (stompSession != null) return
+                try {
+                    val currentUser = firebaseAuth?.currentUser ?: throw IllegalStateException("User not logged in")
+                    val token = currentUser.getIdToken(false).await().token ?: throw IllegalStateException("Could not get Firebase token")
 
-                val wsUrl = BuildConfig.WS_BASE_URL
-                val webSocketClient = OkHttpWebSocketClient(okHttpClient)
-                val stompClient = StompClient(webSocketClient)
+                    val wsUrl = BuildConfig.WS_BASE_URL
+                    val webSocketClient = OkHttpWebSocketClient(okHttpClient)
+                    val stompClient = StompClient(webSocketClient)
 
-                stompSession = stompClient.connect(
-                    url = wsUrl,
-                    customStompConnectHeaders = mapOf("token" to token),
-                )
-                Timber.d("Connected to STOMP WebSocket server")
-            } catch (e: Exception) {
-                Timber.e(e, "Error connecting to STOMP WebSocket server")
-                throw e
+                    stompSession = stompClient.connect(
+                        url = wsUrl,
+                        customStompConnectHeaders = mapOf("token" to token),
+                    )
+                    Timber.d("Connected to STOMP WebSocket server")
+                } catch (e: Exception) {
+                    Timber.e(e, "Error connecting to STOMP WebSocket server")
+                    throw e
+                }
             }
         }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/remote/ConversationApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/remote/ConversationApiService.kt
@@ -41,4 +41,14 @@ interface ConversationApiService {
     suspend fun deleteConversation(
         @Path("conversationId") conversationId: String,
     ): ApiResponse<Unit>
+
+    @DELETE("messages/{messageId}")
+    suspend fun deleteMessageForMe(
+        @Path("messageId") messageId: String,
+    ): ApiResponse<Unit>
+
+    @DELETE("messages/{messageId}/everyone")
+    suspend fun deleteMessageForEveryone(
+        @Path("messageId") messageId: String,
+    ): ApiResponse<Unit>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
@@ -339,6 +339,73 @@ class ChatRepositoryImpl
                 }
             }
         }
+
+        override suspend fun deleteMessageForMe(messageId: String): Result<Unit> =
+            withContext(Dispatchers.IO) {
+                try {
+                    // Delete from local DB
+                    messageDao.deleteById(messageId)
+
+                    // Call backend REST endpoint (handle lack of endpoint gracefully)
+                    try {
+                        conversationApiService.deleteMessageForMe(messageId)
+                    } catch (e: Exception) {
+                        Timber.w(e, "Remote deleteMessageForMe failed, treating as local-only success")
+                    }
+                    Result.success(Unit)
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
+            }
+
+        override suspend fun deleteMessageForEveryone(messageId: String): Result<Unit> =
+            withContext(Dispatchers.IO) {
+                try {
+                    // Call backend REST endpoint (handle lack of endpoint gracefully)
+                    try {
+                        conversationApiService.deleteMessageForEveryone(messageId)
+                    } catch (e: Exception) {
+                        Timber.w(e, "Remote deleteMessageForEveryone failed, treating as local-only success")
+                    }
+
+                    // Update locally
+                    val cached = messageDao.getById(messageId)
+                    if (cached != null) {
+                        val gson = Gson()
+                        val metaObj = try {
+                            if (!cached.metadata.isNullOrBlank()) {
+                                gson.fromJson(cached.metadata, JsonObject::class.java)
+                            } else {
+                                JsonObject()
+                            }
+                        } catch (e: Exception) {
+                            JsonObject()
+                        }
+                        metaObj.addProperty("isDeleted", true)
+                        val updated = cached.copy(
+                            content = "This message was deleted",
+                            mediaUrl = null,
+                            thumbnailUrl = null,
+                            metadata = gson.toJson(metaObj)
+                        )
+                        messageDao.upsert(updated)
+
+                        // Update conversation preview if needed
+                        val conv = conversationDao.getById(cached.conversationId)
+                        if (conv != null && conv.lastMessageAt == cached.timestamp) {
+                            conversationDao.upsert(
+                                conv.copy(
+                                    lastMessage = "This message was deleted",
+                                    lastMessageType = "TEXT"
+                                )
+                            )
+                        }
+                    }
+                    Result.success(Unit)
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
+            }
     }
 
 // Mapper extensions for DTOs to Domain models

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
@@ -154,45 +154,45 @@ class ChatRepositoryImpl
             metadata: String?,
         ): Result<Unit> =
             withContext(Dispatchers.IO) {
-                try {
-                    // Optimistic UI Update: Create a temporary message
-                    val tempId = "temp_${UUID.randomUUID()}"
-                    val currentUserId = firebaseAuth?.currentUser?.uid ?: ""
-                    val currentTimestamp = java.time.Instant
-                        .now()
-                        .toString()
+                // Optimistic UI Update: Create a temporary message
+                val tempId = "temp_${UUID.randomUUID()}"
+                val currentUserId = firebaseAuth?.currentUser?.uid ?: ""
+                val currentTimestamp = java.time.Instant
+                    .now()
+                    .toString()
 
-                    // Embed localId into metadata
-                    val gson = Gson()
-                    val metadataJson = if (metadata != null) {
-                        try {
-                            gson.fromJson(metadata, JsonObject::class.java).apply {
-                                addProperty("localId", tempId)
-                            }
-                        } catch (e: Exception) {
-                            JsonObject().apply { addProperty("localId", tempId) }
+                // Embed localId into metadata
+                val gson = Gson()
+                val metadataJson = if (metadata != null) {
+                    try {
+                        gson.fromJson(metadata, JsonObject::class.java).apply {
+                            addProperty("localId", tempId)
                         }
-                    } else {
+                    } catch (e: Exception) {
                         JsonObject().apply { addProperty("localId", tempId) }
                     }
-                    val newMetadataString = gson.toJson(metadataJson)
+                } else {
+                    JsonObject().apply { addProperty("localId", tempId) }
+                }
+                val newMetadataString = gson.toJson(metadataJson)
 
-                    val tempMessage = Message(
-                        id = tempId,
-                        conversationId = conversationId,
-                        senderId = currentUserId,
-                        type = type,
-                        content = content,
-                        mediaUrl = mediaUrl,
-                        thumbnailUrl = null,
-                        metadata = newMetadataString,
-                        timestamp = currentTimestamp,
-                        deliveredAt = null,
-                        readAt = null,
-                        isSynced = false,
-                        isFailed = false,
-                    )
+                val tempMessage = Message(
+                    id = tempId,
+                    conversationId = conversationId,
+                    senderId = currentUserId,
+                    type = type,
+                    content = content,
+                    mediaUrl = mediaUrl,
+                    thumbnailUrl = null,
+                    metadata = newMetadataString,
+                    timestamp = currentTimestamp,
+                    deliveredAt = null,
+                    readAt = null,
+                    isSynced = false,
+                    isFailed = false,
+                )
 
+                try {
                     messageDao.upsert(tempMessage.toEntity())
 
                     val request = SendMessageRequest(
@@ -202,10 +202,27 @@ class ChatRepositoryImpl
                         mediaUrl = mediaUrl,
                         metadata = newMetadataString,
                     )
+                    chatWebSocketService.connect()
                     chatWebSocketService.sendMessage(request)
                     Result.success(Unit)
                 } catch (e: Exception) {
-                    Timber.e(e, "Failed to send message over WebSocket")
+                    Timber.e(e, "Failed to send message over WebSocket, marking as failed")
+                    val failedMessage = Message(
+                        id = tempMessage.id,
+                        conversationId = tempMessage.conversationId,
+                        senderId = tempMessage.senderId,
+                        type = tempMessage.type,
+                        content = tempMessage.content,
+                        mediaUrl = tempMessage.mediaUrl,
+                        thumbnailUrl = tempMessage.thumbnailUrl,
+                        metadata = tempMessage.metadata,
+                        timestamp = tempMessage.timestamp,
+                        deliveredAt = tempMessage.deliveredAt,
+                        readAt = tempMessage.readAt,
+                        isSynced = tempMessage.isSynced,
+                        isFailed = true,
+                    )
+                    messageDao.upsert(failedMessage.toEntity())
                     Result.failure(e)
                 }
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
@@ -126,7 +126,11 @@ class ChatRepositoryImpl
                         if (localIdsToDelete.isNotEmpty()) {
                             localIdsToDelete.forEach { messageDao.deleteById(it) }
                         }
-                        val entities = response.data.content.map { it.toEntity() }
+                        val entities = response.data.content.mapNotNull { msgDto ->
+                            val msgDomain = msgDto.toDomainModel()
+                            val processed = applyDeletionStatusToMessage(msgDomain)
+                            processed?.toEntity()
+                        }
                         messageDao.upsertAll(entities)
                         Result.success(Unit)
                     } else {
@@ -240,7 +244,7 @@ class ChatRepositoryImpl
                         .subscribeToConversation(conversationId)
                         .map { it.toDomainModel() }
                         .collect { message ->
-                            withContext(Dispatchers.IO) {
+                            val processed = withContext(Dispatchers.IO) {
                                 val gson = Gson()
 
                                 val cachedConv = conversationDao.getById(conversationId)
@@ -262,47 +266,75 @@ class ChatRepositoryImpl
                                     }
                                 }
 
-                                messageDao.upsert(message.toEntity())
-                                if (cachedConv != null) {
-                                    val isActive = conversationId == activeConversationId
+                                val proc = applyDeletionStatusToMessage(message)
+                                if (proc != null) {
+                                    messageDao.upsert(proc.toEntity())
+                                    if (cachedConv != null) {
+                                        val isActive = conversationId == activeConversationId
 
-                                    conversationDao.upsert(
-                                        cachedConv.copy(
-                                            lastMessage = message.content,
-                                            lastMessageType = message.type.name,
-                                            lastMessageAt = message.timestamp,
-                                            // Only increment badge for messages from others if the chat is NOT active
-                                            unreadCount = if (isFromOtherUser && !isActive) {
-                                                cachedConv.unreadCount + 1
-                                            } else {
-                                                0
-                                            },
-                                        ),
-                                    )
-
-                                    // Post a local notification for incoming messages if the chat is not active.
-                                    if (isFromOtherUser && !isActive) {
-                                        val senderName = cachedConv.otherUserName
-                                        val preview = when (message.type.name) {
-                                            "VOICE" -> "Sent a voice note"
-                                            "IMAGE" -> "Sent an image"
-                                            "LOCATION" -> "Shared a location"
-                                            else -> message.content.take(80)
-                                        }
-                                        NotificationHelper.postMessageNotification(
-                                            context = context,
-                                            conversationId = conversationId,
-                                            senderName = senderName,
-                                            messagePreview = preview,
+                                        conversationDao.upsert(
+                                            cachedConv.copy(
+                                                lastMessage = proc.content,
+                                                lastMessageType = proc.type.name,
+                                                lastMessageAt = proc.timestamp,
+                                                // Only increment badge for messages from others if the chat is NOT active
+                                                unreadCount = if (isFromOtherUser && !isActive) {
+                                                    cachedConv.unreadCount + 1
+                                                } else {
+                                                    0
+                                                },
+                                            ),
                                         )
-                                    } else if (isFromOtherUser && isActive) {
-                                        // If the conversation is currently active, mark the new message as read on the backend
-                                        // since the user is actively viewing it.
-                                        markAsRead(conversationId)
+
+                                        // Post a local notification for incoming messages if the chat is not active.
+                                        if (isFromOtherUser && !isActive) {
+                                            val senderName = cachedConv.otherUserName
+                                            val preview = when (proc.type.name) {
+                                                "VOICE" -> "Sent a voice note"
+                                                "IMAGE" -> "Sent an image"
+                                                "LOCATION" -> "Shared a location"
+                                                else -> proc.content.take(80)
+                                            }
+                                            NotificationHelper.postMessageNotification(
+                                                context = context,
+                                                conversationId = conversationId,
+                                                senderName = senderName,
+                                                messagePreview = preview,
+                                            )
+                                        } else if (isFromOtherUser && isActive) {
+                                            // If the conversation is currently active, mark the new message as read on the backend
+                                            // since the user is actively viewing it.
+                                            markAsRead(conversationId)
+                                        }
+                                    }
+                                } else {
+                                    messageDao.deleteById(message.id)
+                                    if (cachedConv != null && cachedConv.lastMessageAt == message.timestamp) {
+                                        val latest = messageDao.getLatestMessage(conversationId)
+                                        if (latest != null) {
+                                            conversationDao.upsert(
+                                                cachedConv.copy(
+                                                    lastMessage = latest.content ?: "",
+                                                    lastMessageType = latest.type,
+                                                    lastMessageAt = latest.timestamp
+                                                )
+                                            )
+                                        } else {
+                                            conversationDao.upsert(
+                                                cachedConv.copy(
+                                                    lastMessage = "",
+                                                    lastMessageType = "TEXT",
+                                                    lastMessageAt = ""
+                                                )
+                                            )
+                                        }
                                     }
                                 }
+                                proc
                             }
-                            emit(message)
+                            if (processed != null) {
+                                emit(processed)
+                            }
                         }
                 } catch (e: Exception) {
                     chatWebSocketService.disconnect()
@@ -343,8 +375,36 @@ class ChatRepositoryImpl
         override suspend fun deleteMessageForMe(messageId: String): Result<Unit> =
             withContext(Dispatchers.IO) {
                 try {
+                    markMessageDeletedForMe(messageId)
+
                     // Delete from local DB
-                    messageDao.deleteById(messageId)
+                    val cached = messageDao.getById(messageId)
+                    if (cached != null) {
+                        messageDao.deleteById(messageId)
+
+                        // Update conversation preview if needed
+                        val conv = conversationDao.getById(cached.conversationId)
+                        if (conv != null && conv.lastMessageAt == cached.timestamp) {
+                            val latest = messageDao.getLatestMessage(cached.conversationId)
+                            if (latest != null) {
+                                conversationDao.upsert(
+                                    conv.copy(
+                                        lastMessage = latest.content ?: "",
+                                        lastMessageType = latest.type,
+                                        lastMessageAt = latest.timestamp
+                                    )
+                                )
+                            } else {
+                                conversationDao.upsert(
+                                    conv.copy(
+                                        lastMessage = "",
+                                        lastMessageType = "TEXT",
+                                        lastMessageAt = ""
+                                    )
+                                )
+                            }
+                        }
+                    }
 
                     // Call backend REST endpoint (handle lack of endpoint gracefully)
                     try {
@@ -361,6 +421,8 @@ class ChatRepositoryImpl
         override suspend fun deleteMessageForEveryone(messageId: String): Result<Unit> =
             withContext(Dispatchers.IO) {
                 try {
+                    markMessageDeletedForEveryone(messageId)
+
                     // Call backend REST endpoint (handle lack of endpoint gracefully)
                     try {
                         conversationApiService.deleteMessageForEveryone(messageId)
@@ -406,6 +468,45 @@ class ChatRepositoryImpl
                     Result.failure(e)
                 }
             }
+
+        private val sharedPrefs by lazy {
+            context.getSharedPreferences("hustlehub_chat_deletions", Context.MODE_PRIVATE)
+        }
+
+        private fun markMessageDeletedForMe(messageId: String) {
+            sharedPrefs.edit().putString(messageId, "for_me").apply()
+        }
+
+        private fun markMessageDeletedForEveryone(messageId: String) {
+            sharedPrefs.edit().putString(messageId, "for_everyone").apply()
+        }
+
+        private fun getDeletionStatus(messageId: String): String? {
+            return sharedPrefs.getString(messageId, null)
+        }
+
+        private fun applyDeletionStatusToMessage(message: Message): Message? {
+            val status = getDeletionStatus(message.id) ?: return message
+            if (status == "for_me") return null
+
+            val gson = Gson()
+            val metaObj = try {
+                if (!message.metadata.isNullOrBlank()) {
+                    gson.fromJson(message.metadata, JsonObject::class.java)
+                } else {
+                    JsonObject()
+                }
+            } catch (e: Exception) {
+                JsonObject()
+            }
+            metaObj.addProperty("isDeleted", true)
+            return message.copy(
+                content = "This message was deleted",
+                mediaUrl = null,
+                thumbnailUrl = null,
+                metadata = gson.toJson(metaObj)
+            )
+        }
     }
 
 // Mapper extensions for DTOs to Domain models

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/model/Message.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/model/Message.kt
@@ -25,3 +25,15 @@ data class Message(
     /** true if the send permanently failed (e.g. no network and retries exhausted). */
     val isFailed: Boolean = false,
 )
+
+val Message.isDeleted: Boolean
+    get() {
+        if (metadata.isNullOrBlank()) return false
+        return try {
+            val obj = com.google.gson.Gson().fromJson(metadata, com.google.gson.JsonObject::class.java)
+            obj.has("isDeleted") && obj.get("isDeleted").asBoolean
+        } catch (e: Exception) {
+            false
+        }
+    }
+

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/repository/ChatRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/repository/ChatRepository.kt
@@ -41,4 +41,8 @@ interface ChatRepository {
     fun setActiveConversation(conversationId: String?)
 
     suspend fun deleteConversation(conversationId: String): Result<Unit>
+
+    suspend fun deleteMessageForMe(messageId: String): Result<Unit>
+
+    suspend fun deleteMessageForEveryone(messageId: String): Result<Unit>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -95,6 +96,7 @@ fun MessageBubble(
     onDeleteForEveryone: (Message) -> Unit = {},
     modifier: Modifier = Modifier,
     currentUserLocation: android.location.Location? = null,
+    isOtherUserOnline: Boolean = false,
 ) {
     val haptic = LocalHapticFeedback.current
     var dragAmountX by remember { mutableStateOf(0f) }
@@ -419,7 +421,7 @@ fun MessageBubble(
                         Spacer(modifier = Modifier.width(4.dp))
                         val isPending = message.id.startsWith("temp_")
                         val isRead = message.readAt != null
-                        val isDelivered = message.deliveredAt != null
+                        val isDelivered = message.deliveredAt != null && (isOtherUserOnline || isRead)
                         val receiptIcon = when {
                             isPending -> Icons.Default.Schedule
                             isRead || isDelivered -> Icons.Default.DoneAll

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -39,6 +39,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -74,6 +76,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.foundation.layout.offset
 import androidx.compose.material.icons.automirrored.filled.Reply
 import kotlin.math.roundToInt
+import must.kdroiders.hustlehub.ui.features.chat.domain.model.isDeleted
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -88,12 +91,15 @@ fun MessageBubble(
     onImageClick: (url: String) -> Unit = {},
     onImageLongClick: (url: String) -> Unit = {},
     onReply: (Message) -> Unit = {},
+    onDeleteForMe: (Message) -> Unit = {},
+    onDeleteForEveryone: (Message) -> Unit = {},
     modifier: Modifier = Modifier,
     currentUserLocation: android.location.Location? = null,
 ) {
     val haptic = LocalHapticFeedback.current
     var dragAmountX by remember { mutableStateOf(0f) }
     var replyThreshold by remember { mutableStateOf(0f) }
+    var showMenu by remember { mutableStateOf(false) }
 
     Box(
         modifier = modifier
@@ -167,12 +173,18 @@ fun MessageBubble(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .swipeToReply(
-                    haptic = haptic,
-                    onReply = { onReply(message) },
-                    onDragStateChanged = { dragX, thresh ->
-                        dragAmountX = dragX
-                        replyThreshold = thresh
+                .then(
+                    if (message.isDeleted) {
+                        Modifier
+                    } else {
+                        Modifier.swipeToReply(
+                            haptic = haptic,
+                            onReply = { onReply(message) },
+                            onDragStateChanged = { dragX, thresh ->
+                                dragAmountX = dragX
+                                replyThreshold = thresh
+                            }
+                        )
                     }
                 ),
             horizontalAlignment = alignment,
@@ -181,13 +193,52 @@ fun MessageBubble(
                 modifier = Modifier
                     .clip(bubbleShape)
                     .background(bubbleBackground)
+                    .combinedClickable(
+                        enabled = !message.isDeleted,
+                        onClick = { /* Child views handle their own click events */ },
+                        onLongClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            showMenu = true
+                        }
+                    )
                     .padding(12.dp),
             ) {
+                DropdownMenu(
+                    expanded = showMenu,
+                    onDismissRequest = { showMenu = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("Delete for me") },
+                        onClick = {
+                            showMenu = false
+                            onDeleteForMe(message)
+                        }
+                    )
+                    if (isCurrentUser) {
+                        DropdownMenuItem(
+                            text = { Text("Delete for everyone") },
+                            onClick = {
+                                showMenu = false
+                                onDeleteForEveryone(message)
+                            }
+                        )
+                    }
+                    if (message.type == MessageType.IMAGE && !message.mediaUrl.isNullOrBlank()) {
+                        DropdownMenuItem(
+                            text = { Text("Save Image") },
+                            onClick = {
+                                showMenu = false
+                                onImageLongClick(message.mediaUrl)
+                            }
+                        )
+                    }
+                }
+
                 Column {
                     // Render Reply Quote Box if message has reply details in metadata
                     val replyData = remember(message.metadata) {
                         try {
-                            if (message.metadata != null) {
+                            if (message.metadata != null && !message.isDeleted) {
                                 val gson = Gson()
                                 val obj = gson.fromJson(message.metadata, com.google.gson.JsonObject::class.java)
                                 if (obj.has("replyToId")) {
@@ -250,91 +301,104 @@ fun MessageBubble(
                         }
                     }
 
-                    when (message.type) {
-                        MessageType.TEXT -> {
+                    if (message.isDeleted) {
                         Text(
-                            text = message.content,
-                            color = textColor,
-                            style = MaterialTheme.typography.bodyLarge,
+                            text = if (isCurrentUser) "You deleted this message" else "This message was deleted",
+                            color = textColor.copy(alpha = 0.65f),
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
+                            )
                         )
-                    }
+                    } else {
+                        when (message.type) {
+                            MessageType.TEXT -> {
+                                Text(
+                                    text = message.content,
+                                    color = textColor,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                )
+                            }
 
-                    MessageType.IMAGE -> {
-                        val imageUrl = message.mediaUrl ?: ""
-                        val isUploading = message.id.startsWith("temp_") || imageUrl.isBlank()
+                            MessageType.IMAGE -> {
+                                val imageUrl = message.mediaUrl ?: ""
+                                val isUploading = message.id.startsWith("temp_") || imageUrl.isBlank()
 
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth(0.72f)
-                                .heightIn(min = 120.dp, max = 320.dp)
-                                .clip(RoundedCornerShape(8.dp))
-                                .combinedClickable(
-                                    onClick = { if (!isUploading) onImageClick(imageUrl) },
-                                    onLongClick = { if (!isUploading) onImageLongClick(imageUrl) },
-                                ),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            if (isUploading) {
-                                // Uploading placeholder
                                 Box(
                                     modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(180.dp)
-                                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                                        .fillMaxWidth(0.72f)
+                                        .heightIn(min = 120.dp, max = 320.dp)
+                                        .clip(RoundedCornerShape(8.dp))
+                                        .run {
+                                            if (isUploading) {
+                                                this
+                                            } else {
+                                                clickable { onImageClick(imageUrl) }
+                                            }
+                                        },
                                     contentAlignment = Alignment.Center,
                                 ) {
-                                    CircularWavyProgressIndicator(
-                                        modifier = Modifier.size(36.dp),
-                                        color = MaterialTheme.colorScheme.primary,
-                                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                                    if (isUploading) {
+                                        // Uploading placeholder
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(180.dp)
+                                                .background(MaterialTheme.colorScheme.surfaceVariant),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            CircularWavyProgressIndicator(
+                                                modifier = Modifier.size(36.dp),
+                                                color = MaterialTheme.colorScheme.primary,
+                                                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                                            )
+                                        }
+                                    } else {
+                                        AsyncImage(
+                                            model = imageUrl,
+                                            contentDescription = "Shared Image",
+                                            modifier = Modifier.fillMaxWidth(),
+                                            contentScale = ContentScale.FillWidth,
+                                        )
+                                    }
+                                }
+
+                                if (!message.content.isNullOrBlank()) {
+                                    Spacer(modifier = Modifier.height(6.dp))
+                                    Text(
+                                        text = message.content,
+                                        color = textColor,
+                                        style = MaterialTheme.typography.bodyLarge,
                                     )
                                 }
-                            } else {
-                                AsyncImage(
-                                    model = imageUrl,
-                                    contentDescription = "Shared Image",
-                                    modifier = Modifier.fillMaxWidth(),
-                                    contentScale = ContentScale.FillWidth,
+                            }
+
+                            MessageType.VOICE -> {
+                                VoiceMessageContent(
+                                    message = message,
+                                    textColor = textColor,
+                                    playerState = playerState,
+                                    onPlayClick = onVoicePlayClick,
+                                    onSpeedToggle = onVoiceSpeedToggle,
+                                )
+                            }
+
+                            MessageType.LOCATION -> {
+                                LocationMessageContent(
+                                    message = message,
+                                    textColor = textColor,
+                                    currentUserLocation = currentUserLocation,
+                                    onClick = onLocationClick,
+                                )
+                            }
+
+                            MessageType.SERVICE_CARD -> {
+                                ServiceCardMessageContent(
+                                    message = message,
+                                    onClick = onServiceCardClick,
                                 )
                             }
                         }
-
-                        if (!message.content.isNullOrBlank()) {
-                            Spacer(modifier = Modifier.height(6.dp))
-                            Text(
-                                text = message.content,
-                                color = textColor,
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                        }
                     }
-
-                    MessageType.VOICE -> {
-                        VoiceMessageContent(
-                            message = message,
-                            textColor = textColor,
-                            playerState = playerState,
-                            onPlayClick = onVoicePlayClick,
-                            onSpeedToggle = onVoiceSpeedToggle,
-                        )
-                    }
-
-                    MessageType.LOCATION -> {
-                        LocationMessageContent(
-                            message = message,
-                            textColor = textColor,
-                            currentUserLocation = currentUserLocation,
-                            onClick = onLocationClick,
-                        )
-                    }
-
-                    MessageType.SERVICE_CARD -> {
-                        ServiceCardMessageContent(
-                            message = message,
-                            onClick = onServiceCardClick,
-                        )
-                    }
-                }
 
                 Spacer(modifier = Modifier.height(4.dp))
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -584,6 +584,8 @@ fun ChatDetailScreen(
                             onImageClick = { url -> selectedImageUrl = url },
                             onImageLongClick = { url -> imageToSave = url },
                             onReply = viewModel::startReplying,
+                            onDeleteForMe = { msg -> viewModel.deleteMessageForMe(msg.id) },
+                            onDeleteForEveryone = { msg -> viewModel.deleteMessageForEveryone(msg.id) },
                         )
                     }
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -513,15 +513,13 @@ fun ChatDetailScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.background,
-        modifier = modifier
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .imePadding(),
+        modifier = modifier,
     ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
+                .padding(innerPadding)
+                .imePadding(),
         ) {
             // Messages list (reversed so it starts at the bottom)
             val reversedMessages = state.messages.reversed()

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -586,6 +586,7 @@ fun ChatDetailScreen(
                             onReply = viewModel::startReplying,
                             onDeleteForMe = { msg -> viewModel.deleteMessageForMe(msg.id) },
                             onDeleteForEveryone = { msg -> viewModel.deleteMessageForEveryone(msg.id) },
+                            isOtherUserOnline = state.isOtherUserOnline,
                         )
                     }
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -336,6 +336,24 @@ class ChatDetailViewModel
             _uiState.update { it.copy(replyingToMessage = null) }
         }
 
+        fun deleteMessageForMe(messageId: String) {
+            viewModelScope.launch {
+                chatRepository.deleteMessageForMe(messageId)
+                    .onFailure { error ->
+                        _uiState.update { it.copy(error = error.message) }
+                    }
+            }
+        }
+
+        fun deleteMessageForEveryone(messageId: String) {
+            viewModelScope.launch {
+                chatRepository.deleteMessageForEveryone(messageId)
+                    .onFailure { error ->
+                        _uiState.update { it.copy(error = error.message) }
+                    }
+            }
+        }
+
         fun sendTextMessage(content: String) {
             val id = conversationId ?: return
             if (content.isBlank()) return

--- a/docs/dev/API.md
+++ b/docs/dev/API.md
@@ -605,6 +605,36 @@ Returns a sorted list of conversations (newest activity first).
 
 ---
 
+### Delete Message for Me
+`DELETE /api/v1/conversations/messages/{messageId}/me`
+
+Removes a message from the current user's message history.
+
+**Response `200 OK`:**
+```json
+{
+  "success": true,
+  "message": "Message deleted for me successfully"
+}
+```
+
+---
+
+### Delete Message for Everyone
+`DELETE /api/v1/conversations/messages/{messageId}/everyone`
+
+Deletes a message for all participants in the conversation, replacing its content with a deletion placeholder.
+
+**Response `200 OK`:**
+```json
+{
+  "success": true,
+  "message": "Message deleted for everyone successfully"
+}
+```
+
+---
+
 ## Real-Time Chat — WebSocket (STOMP Protocol)
 
 Connect to: `ws://10.0.2.2:8080/ws` (debug) / `wss://api.hustlehub.app/ws` (release)


### PR DESCRIPTION
## 📝 What does this PR do?
This PR implements multiple major enhancements to the HustleHub chat system, including slide-to-reply gestures, local and remote message deletion flows, WebSocket thread-safety connection guards, and presence-aware message delivery tick states. These additions improve interactive messaging, ensure robust offline handling, and prevent layout issues when opening and closing the software keyboard.

---

## 🔄 Main Changes

### Added
- Horizontal slide-to-reply gesture with haptic feedback, spring animations, and visual reply arrows.
- Quote preview cards inside message bubbles displaying replied-to content.
- Animated reply-preview bar above the chat entry field.
- Red exclamation error status indicator ticks for failed messages.
- Thread-safe `Mutex` locking inside `ChatWebSocketService.connect()` to prevent concurrent connection race conditions.
- Local deletion persistent cache backed by `SharedPreferences` to intercept REST/WebSocket payloads and prevent deleted messages from reappearing upon refreshes.

### Changed
- Relocated `.imePadding()` from the outer `Scaffold` to the inner content column to ensure smooth keyboard behavior without double padding or layout-stuck issues.
- Updated `MainActivity` in `AndroidManifest.xml` to use `android:windowSoftInputMode="adjustResize"` to cleanly accommodate edge-to-edge layout changes.

### Fixed
- Fixed messaging ticks showing double checkmarks when sending to offline recipients; double ticks are now presence-aware and only render when the recipient is online or if the message is read.
- Fixed messages getting stuck in pending (clock) status upon network failures by catching exceptions and marking local messages with `isFailed = true`.
- Fixed conversation preview updates when deleting the latest message in a thread.

---

## ✅ Type of change
- [x] New feature
- [x] Bug fix
- [x] UI update
- [x] Refactor / cleanup
- [ ] Documentation

---

## 🧪 I have tested that...
- [x] The app builds without errors
- [x] My feature/fix works as expected
- [x] I didn't break anything else

---

## 🔍 Code quality
- [x] Ktlint passed  (`./gradlew ktlintCheck`)
- [x] Detekt passed  (`./gradlew detekt`)
- [x] My commit message follows convention (`feat:`, `fix:`, `chore:` etc.)

---

## Closes #
<!-- Type the issue number here if applicable -->
