### PR TITLE
feat(map,chat,data): production map clustering, WhatsApp location picker, runCatching error handling & UI refinements

### DIFF
--- a/app/src/main/java/must/kdroiders/hustlehub/core/utils/ImageUtils.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/utils/ImageUtils.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import android.widget.Toast
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -21,7 +22,7 @@ suspend fun saveImageToGallery(
     context: Context,
     imageUrl: String,
 ) = withContext(Dispatchers.IO) {
-    try {
+    runCatching {
         val url = java.net.URL(imageUrl)
         val bytes = url.openStream().use { it.readBytes() }
 
@@ -36,7 +37,7 @@ suspend fun saveImageToGallery(
 
         val resolver = context.contentResolver
         val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
-            ?: throw IllegalStateException("MediaStore insert returned null URI")
+            ?: checkNotNull(null) { "MediaStore insert returned null URI" }
 
         resolver.openOutputStream(uri)?.use { out -> out.write(bytes) }
 
@@ -49,7 +50,8 @@ suspend fun saveImageToGallery(
         withContext(Dispatchers.Main) {
             Toast.makeText(context, "Image saved to gallery", Toast.LENGTH_SHORT).show()
         }
-    } catch (e: Exception) {
+    }.onFailure { e ->
+        if (e is CancellationException) throw e
         Timber.e(e, "ImageUtils: failed to save image to gallery url=$imageUrl")
         withContext(Dispatchers.Main) {
             Toast.makeText(context, "Failed to save image", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/must/kdroiders/hustlehub/datastore/UserPreferences.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/datastore/UserPreferences.kt
@@ -52,8 +52,8 @@ class UserPreferences
             val USER_UUID = stringPreferencesKey("user_uuid")
             val RECENT_SEARCHES = stringSetPreferencesKey("recent_searches")
             val LAST_SELECTED_CATEGORY = stringPreferencesKey("last_selected_category")
+            val PROVIDER_BANNER_DISMISSED = booleanPreferencesKey("provider_banner_dismissed")
 
-            /** Maximum number of recent searches to persist. Oldest entry is evicted when full. */
             const val MAX_RECENT_SEARCHES = 10
         }
 
@@ -147,10 +147,29 @@ class UserPreferences
                     prefs.remove(USER_EMAIL)
                     prefs.remove(USER_ROLE)
                     prefs.remove(USER_AVATAR_URL)
+                    prefs.remove(PROVIDER_BANNER_DISMISSED)
                 }
                 Timber.d("User cleared from DataStore")
             } catch (e: IOException) {
                 Timber.e(e, "Error clearing user from DataStore")
+            }
+        }
+
+        val isProviderBannerDismissed: Flow<Boolean> = dataStore.data
+            .catch { e ->
+                if (e is IOException) {
+                    Timber.e(e, "Error reading provider banner state")
+                    emit(emptyPreferences())
+                } else {
+                    throw e
+                }
+            }.map { prefs -> prefs[PROVIDER_BANNER_DISMISSED] ?: false }
+
+        suspend fun dismissProviderBanner() {
+            try {
+                dataStore.edit { prefs -> prefs[PROVIDER_BANNER_DISMISSED] = true }
+            } catch (e: IOException) {
+                Timber.e(e, "Error saving provider banner dismiss state")
             }
         }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -146,9 +146,9 @@ object AppModule {
         return ChatRepositoryImpl(
             context,
             conversationApiService,
-            chatWebSocketService,
             conversationDao,
             messageDao,
+            chatWebSocketService,
             firebaseAuth,
         )
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -213,6 +213,7 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
                     onSignUpSuccess = { email ->
                         backstack.add(EmailVerification(email = email))
                     },
+                    onGoogleSignInClick = onGoogleSignInClick,
                 )
             }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -35,11 +36,14 @@ enum class HustleCardVariant {
     /** Slightly elevated card with a soft shadow */
     Elevated,
 
-    /** Outlined card — no elevation, defined by a border */
+    /** Outlined translucent glass card — 30% alpha fill + 20% alpha border */
     Outlined,
 
-    /** Filled with surfaceVariant — useful for secondary sections */
+    /** Tonal translucent section card */
     Tonal,
+
+    /** Translucent glass card — matches StatCard style */
+    Glass,
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -49,6 +53,7 @@ fun HustleCard(
     variant: HustleCardVariant = HustleCardVariant.Elevated,
     onClick: (() -> Unit)? = null,
     contentPadding: PaddingValues = PaddingValues(20.dp),
+    containerColor: Color? = null,
     content: @Composable () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -68,6 +73,12 @@ fun HustleCard(
             scaleY = scale
         }
 
+    val glassBackground = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)
+    val glassBorder = BorderStroke(
+        width = 1.dp,
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+    )
+
     when (variant) {
         HustleCardVariant.Surface -> {
             Card(
@@ -77,7 +88,7 @@ fun HustleCard(
                 shape = CardShape,
                 interactionSource = interactionSource,
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
+                    containerColor = containerColor ?: MaterialTheme.colorScheme.surface,
                     contentColor = MaterialTheme.colorScheme.onSurface,
                 ),
                 elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
@@ -94,7 +105,7 @@ fun HustleCard(
                 shape = CardShape,
                 interactionSource = interactionSource,
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
+                    containerColor = containerColor ?: MaterialTheme.colorScheme.surface,
                     contentColor = MaterialTheme.colorScheme.onSurface,
                 ),
                 elevation = CardDefaults.cardElevation(
@@ -116,10 +127,10 @@ fun HustleCard(
                 interactionSource = interactionSource,
                 border = BorderStroke(
                     width = 1.dp,
-                    color = MaterialTheme.colorScheme.outlineVariant,
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f),
                 ),
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
+                    containerColor = containerColor ?: MaterialTheme.colorScheme.surface,
                     contentColor = MaterialTheme.colorScheme.onSurface,
                 ),
                 elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
@@ -128,16 +139,17 @@ fun HustleCard(
             }
         }
 
-        HustleCardVariant.Tonal -> {
+        HustleCardVariant.Tonal, HustleCardVariant.Glass -> {
             Card(
                 onClick = onClick ?: {},
                 enabled = onClick != null,
                 modifier = cardModifier,
                 shape = CardShape,
                 interactionSource = interactionSource,
+                border = glassBorder,
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    containerColor = containerColor ?: glassBackground,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
                 ),
                 elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import must.kdroiders.hustlehub.ui.theme.HustleHubTheme
 import must.kdroiders.hustlehub.ui.theme.LocalDimensions
 
-
 enum class HustleCardVariant {
     /** Default surface card — subtle, clean */
     Surface,

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import must.kdroiders.hustlehub.ui.theme.HustleHubTheme
+import must.kdroiders.hustlehub.ui.theme.LocalDimensions
 
-private val CardShape = RoundedCornerShape(12.dp)
 
 enum class HustleCardVariant {
     /** Default surface card — subtle, clean */
@@ -52,10 +52,13 @@ fun HustleCard(
     modifier: Modifier = Modifier,
     variant: HustleCardVariant = HustleCardVariant.Elevated,
     onClick: (() -> Unit)? = null,
-    contentPadding: PaddingValues = PaddingValues(20.dp),
+    contentPadding: PaddingValues? = null,
     containerColor: Color? = null,
     content: @Composable () -> Unit,
 ) {
+    val dimensions = LocalDimensions.current
+    val effectivePadding = contentPadding ?: PaddingValues(dimensions.cardContentPadding)
+    val cardShape = RoundedCornerShape(dimensions.cardCornerRadius)
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val motionScheme = MaterialTheme.motionScheme
@@ -85,7 +88,7 @@ fun HustleCard(
                 onClick = onClick ?: {},
                 enabled = onClick != null,
                 modifier = cardModifier,
-                shape = CardShape,
+                shape = cardShape,
                 interactionSource = interactionSource,
                 colors = CardDefaults.cardColors(
                     containerColor = containerColor ?: MaterialTheme.colorScheme.surface,
@@ -93,7 +96,7 @@ fun HustleCard(
                 ),
                 elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             ) {
-                Box(Modifier.padding(contentPadding)) { content() }
+                Box(Modifier.padding(effectivePadding)) { content() }
             }
         }
 
@@ -102,7 +105,7 @@ fun HustleCard(
                 onClick = onClick ?: {},
                 enabled = onClick != null,
                 modifier = cardModifier,
-                shape = CardShape,
+                shape = cardShape,
                 interactionSource = interactionSource,
                 colors = CardDefaults.cardColors(
                     containerColor = containerColor ?: MaterialTheme.colorScheme.surface,
@@ -114,7 +117,7 @@ fun HustleCard(
                     hoveredElevation = 4.dp,
                 ),
             ) {
-                Box(Modifier.padding(contentPadding)) { content() }
+                Box(Modifier.padding(effectivePadding)) { content() }
             }
         }
 
@@ -123,7 +126,7 @@ fun HustleCard(
                 onClick = onClick ?: {},
                 enabled = onClick != null,
                 modifier = cardModifier,
-                shape = CardShape,
+                shape = cardShape,
                 interactionSource = interactionSource,
                 border = BorderStroke(
                     width = 1.dp,
@@ -135,7 +138,7 @@ fun HustleCard(
                 ),
                 elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             ) {
-                Box(Modifier.padding(contentPadding)) { content() }
+                Box(Modifier.padding(effectivePadding)) { content() }
             }
         }
 
@@ -144,7 +147,7 @@ fun HustleCard(
                 onClick = onClick ?: {},
                 enabled = onClick != null,
                 modifier = cardModifier,
-                shape = CardShape,
+                shape = cardShape,
                 interactionSource = interactionSource,
                 border = glassBorder,
                 colors = CardDefaults.cardColors(
@@ -153,7 +156,7 @@ fun HustleCard(
                 ),
                 elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             ) {
-                Box(Modifier.padding(contentPadding)) { content() }
+                Box(Modifier.padding(effectivePadding)) { content() }
             }
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleScaffold.kt
@@ -26,7 +26,7 @@ fun HustleScaffold(
     floatingActionButtonPosition: FabPosition = FabPosition.End,
     containerColor: Color = MaterialTheme.colorScheme.background,
     contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    contentWindowInsets: WindowInsets = WindowInsets(0.dp),
+    // contentWindowInsets: WindowInsets = WindowInsets(0.dp),
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Scaffold(
@@ -38,7 +38,7 @@ fun HustleScaffold(
         floatingActionButtonPosition = floatingActionButtonPosition,
         containerColor = containerColor,
         contentColor = contentColor,
-        contentWindowInsets = contentWindowInsets,
+        // contentWindowInsets = contentWindowInsets,
         content = content,
     )
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleScaffold.kt
@@ -1,0 +1,45 @@
+package must.kdroiders.hustlehub.sharedComposables
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * Standardized reusable Scaffold for HustleHub screens.
+ *
+ * Configured with [contentWindowInsets] = 0.dp by default so screens retain full, precise control
+ * over status bar and navigation bar padding without double-inset conflicts.
+ */
+@Composable
+fun HustleScaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
+    floatingActionButton: @Composable () -> Unit = {},
+    floatingActionButtonPosition: FabPosition = FabPosition.End,
+    containerColor: Color = MaterialTheme.colorScheme.background,
+    contentColor: Color = MaterialTheme.colorScheme.onBackground,
+    contentWindowInsets: WindowInsets = WindowInsets(0.dp),
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = topBar,
+        bottomBar = bottomBar,
+        snackbarHost = snackbarHost,
+        floatingActionButton = floatingActionButton,
+        floatingActionButtonPosition = floatingActionButtonPosition,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        contentWindowInsets = contentWindowInsets,
+        content = content,
+    )
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleScaffold.kt
@@ -1,14 +1,12 @@
 package must.kdroiders.hustlehub.sharedComposables
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 
 /**
  * Standardized reusable Scaffold for HustleHub screens.

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleScaffold.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/remote/AuthApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/remote/AuthApiService.kt
@@ -28,6 +28,7 @@ data class UserResponseDto(
     // isVerified → "verified", isActive → "active" in the JSON response.
     val verified: Boolean,
     val active: Boolean,
+    val allowCalls: Boolean? = null,
     val hustleScore: Float? = null,
     val reviewCount: Int? = null,
     val lat: Double? = null,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/repository/AuthRepositoryImpl.kt
@@ -6,6 +6,8 @@ import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GoogleAuthProvider
+import com.google.firebase.auth.UserProfileChangeRequest
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
 import must.kdroiders.hustlehub.core.api.FirebaseAuthErrorMapper
 import must.kdroiders.hustlehub.ui.features.auth.domain.repository.AuthRepository
@@ -17,8 +19,9 @@ import javax.inject.Singleton
 /**
  * Firebase Auth implementation of [AuthRepository].
  *
+ * Idiomatic Kotlin implementation using [runCatching] pipelines.
  * All Firebase exceptions are routed through [FirebaseAuthErrorMapper] before being
- * rethrown, so callers always receive a user-friendly error message.
+ * rethrown, while preserving coroutine cancellation.
  */
 @Singleton
 class AuthRepositoryImpl
@@ -36,38 +39,38 @@ class AuthRepositoryImpl
         override suspend fun login(
             email: String,
             password: String,
-        ): LoginResult {
-            return try {
-                val result = firebaseAuth
-                    .signInWithEmailAndPassword(email, password)
-                    .await()
+        ): LoginResult = runCatching {
+            val result = firebaseAuth
+                .signInWithEmailAndPassword(email, password)
+                .await()
 
-                val user = result.user
-                    ?: throw Exception("Login failed: no user returned")
+            val user = result.user
+                ?: throw Exception("Login failed: no user returned")
 
-                // Reload to get the latest emailVerified status from Firebase servers
-                user.reload().await()
-                // Refresh the ID token cache
-                user.getIdToken(true).await()
+            // Reload to get the latest emailVerified status from Firebase servers
+            user.reload().await()
+            // Refresh the ID token cache
+            user.getIdToken(true).await()
 
-                // Auto-send a new verification link if the email is still unverified
-                if (!user.isEmailVerified) {
-                    try {
-                        user.sendEmailVerification().await()
-                        Timber.d("Automatic verification link re-sent to %s", email)
-                    } catch (e: Exception) {
-                        Timber.e(e, "Failed to auto-send verification email on login")
-                    }
+            // Auto-send a new verification link if the email is still unverified
+            if (!user.isEmailVerified) {
+                runCatching {
+                    user.sendEmailVerification().await()
+                    Timber.d("Automatic verification link re-sent to %s", email)
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Timber.e(e, "Failed to auto-send verification email on login")
                 }
-
-                LoginResult(
-                    user = user,
-                    isEmailVerified = user.isEmailVerified,
-                )
-            } catch (e: Exception) {
-                Timber.e(e, "Login failed for %s", email)
-                throw Exception(FirebaseAuthErrorMapper.map(e), e)
             }
+
+            LoginResult(
+                user = user,
+                isEmailVerified = user.isEmailVerified,
+            )
+        }.getOrElse { e ->
+            if (e is CancellationException) throw e
+            Timber.e(e, "Login failed for %s", email)
+            throw Exception(FirebaseAuthErrorMapper.map(e), e)
         }
 
         /**
@@ -81,43 +84,44 @@ class AuthRepositoryImpl
             name: String,
             email: String,
             password: String,
-        ): LoginResult {
-            return try {
-                val result = firebaseAuth
-                    .createUserWithEmailAndPassword(email, password)
-                    .await()
+        ): LoginResult = runCatching {
+            val result = firebaseAuth
+                .createUserWithEmailAndPassword(email, password)
+                .await()
 
-                val user = result.user
-                    ?: throw Exception("Sign-up failed: no user returned")
+            val user = result.user
+                ?: throw Exception("Sign-up failed: no user returned")
 
-                // Set Firebase display name
-                try {
-                    val profileUpdates = com.google.firebase.auth.UserProfileChangeRequest
-                        .Builder()
-                        .setDisplayName(name)
-                        .build()
-                    user.updateProfile(profileUpdates).await()
-                    Timber.d("Firebase profile updated with name: %s", name)
-                } catch (e: Exception) {
-                    Timber.e(e, "Failed to update Firebase profile display name")
-                }
-
-                // Send the verification email link
-                try {
-                    user.sendEmailVerification().await()
-                    Timber.d("Verification email sent to %s", email)
-                } catch (e: Exception) {
-                    Timber.e(e, "Failed to send verification email on sign-up")
-                }
-
-                LoginResult(
-                    user = user,
-                    isEmailVerified = user.isEmailVerified,
-                )
-            } catch (e: Exception) {
-                Timber.e(e, "Sign-up failed for %s", email)
-                throw Exception(FirebaseAuthErrorMapper.map(e), e)
+            // Set Firebase display name
+            runCatching {
+                val profileUpdates = UserProfileChangeRequest
+                    .Builder()
+                    .setDisplayName(name)
+                    .build()
+                user.updateProfile(profileUpdates).await()
+                Timber.d("Firebase profile updated with name: %s", name)
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+                Timber.e(e, "Failed to update Firebase profile display name")
             }
+
+            // Send the verification email link
+            runCatching {
+                user.sendEmailVerification().await()
+                Timber.d("Verification email sent to %s", email)
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+                Timber.e(e, "Failed to send verification email on sign-up")
+            }
+
+            LoginResult(
+                user = user,
+                isEmailVerified = user.isEmailVerified,
+            )
+        }.getOrElse { e ->
+            if (e is CancellationException) throw e
+            Timber.e(e, "Sign-up failed for %s", email)
+            throw Exception(FirebaseAuthErrorMapper.map(e), e)
         }
 
         /**
@@ -126,21 +130,20 @@ class AuthRepositoryImpl
          * Domain validation (@must.ac.ke) is enforced in [LoginViewModel] after this
          * call succeeds, because Firebase does not know our domain restriction.
          */
-        override suspend fun signInWithGoogle(idToken: String): LoginResult {
-            return try {
-                val credential = GoogleAuthProvider.getCredential(idToken, null)
-                val result = firebaseAuth.signInWithCredential(credential).await()
-                val user = result.user
-                    ?: throw Exception("Google sign-in failed: no user returned")
+        override suspend fun signInWithGoogle(idToken: String): LoginResult = runCatching {
+            val credential = GoogleAuthProvider.getCredential(idToken, null)
+            val result = firebaseAuth.signInWithCredential(credential).await()
+            val user = result.user
+                ?: throw Exception("Google sign-in failed: no user returned")
 
-                LoginResult(
-                    user = user,
-                    isEmailVerified = user.isEmailVerified,
-                )
-            } catch (e: Exception) {
-                Timber.e(e, "Google sign-in failed")
-                throw Exception(FirebaseAuthErrorMapper.map(e), e)
-            }
+            LoginResult(
+                user = user,
+                isEmailVerified = user.isEmailVerified,
+            )
+        }.getOrElse { e ->
+            if (e is CancellationException) throw e
+            Timber.e(e, "Google sign-in failed")
+            throw Exception(FirebaseAuthErrorMapper.map(e), e)
         }
 
         /**
@@ -150,12 +153,13 @@ class AuthRepositoryImpl
          * uses a link rather than a numeric OTP.
          */
         override suspend fun sendOtp(email: String) {
-            try {
+            runCatching {
                 val user = firebaseAuth.currentUser
                     ?: throw Exception("No signed-in user to send a verification email to")
                 user.sendEmailVerification().await()
                 Timber.d("Verification email link sent to %s", email)
-            } catch (e: Exception) {
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
                 Timber.e(e, "Failed to send verification email link")
                 throw Exception(FirebaseAuthErrorMapper.map(e), e)
             }
@@ -171,7 +175,7 @@ class AuthRepositoryImpl
             email: String,
             otp: String,
         ) {
-            try {
+            runCatching {
                 val user = firebaseAuth.currentUser
                     ?: throw Exception("No signed-in user to verify")
 
@@ -183,10 +187,9 @@ class AuthRepositoryImpl
                             "verification link, then tap \"Verify\" below.",
                     )
                 }
-            } catch (e: Exception) {
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
                 Timber.e(e, "Email verification check failed")
-                // Only re-wrap if this is a Firebase exception; plain Exceptions already have
-                // a clear message from the check above.
                 throw if (e is com.google.firebase.auth.FirebaseAuthException) {
                     Exception(FirebaseAuthErrorMapper.map(e), e)
                 } else {
@@ -210,10 +213,11 @@ class AuthRepositoryImpl
 
         /** Sends a password reset email to the given email address. */
         override suspend fun sendPasswordResetEmail(email: String) {
-            try {
+            runCatching {
                 firebaseAuth.sendPasswordResetEmail(email).await()
                 Timber.d("Password reset email sent to %s", email)
-            } catch (e: Exception) {
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
                 Timber.e(e, "Failed to send password reset email")
                 throw Exception(FirebaseAuthErrorMapper.map(e), e)
             }
@@ -226,36 +230,32 @@ class AuthRepositoryImpl
         override suspend fun changePassword(
             currentPassword: String,
             newPassword: String,
-        ): Result<Unit> {
-            return try {
-                val user = firebaseAuth.currentUser
-                    ?: return Result.failure(Exception("User not logged in"))
+        ): Result<Unit> = runCatching {
+            val user = firebaseAuth.currentUser
+                ?: throw Exception("User not logged in")
 
-                val email = user.email
-                    ?: return Result.failure(Exception("Email not found for current user"))
+            val email = user.email
+                ?: throw Exception("Email not found for current user")
 
-                if (currentPassword == newPassword) {
-                    return Result.failure(Exception("New password cannot be the same as the current password"))
-                }
+            if (currentPassword == newPassword) {
+                throw Exception("New password cannot be the same as the current password")
+            }
 
-                // Create the credential
-                val credential = EmailAuthProvider.getCredential(email, currentPassword)
+            // Create the credential
+            val credential = EmailAuthProvider.getCredential(email, currentPassword)
 
-                // Re-authenticate to ensure the session is fresh and the current password is correct
-                user.reauthenticate(credential).await()
+            // Re-authenticate to ensure the session is fresh and the current password is correct
+            user.reauthenticate(credential).await()
 
-                // Update to the new password
-                user.updatePassword(newPassword).await()
-
-                Result.success(Unit)
-            } catch (e: FirebaseAuthInvalidUserException) {
-                Result.failure(Exception("User account is disabled or deleted."))
-            } catch (e: FirebaseAuthInvalidCredentialsException) {
-                Result.failure(Exception("Incorrect current password."))
-            } catch (e: Exception) {
-                // Catch all other Firebase exceptions (e.g. network errors, weak password)
-                // and safely return them as a Result.failure instead of crashing.
-                Result.failure(e)
+            // Update to the new password
+            user.updatePassword(newPassword).await()
+            Unit
+        }.recoverCatching { e ->
+            if (e is CancellationException) throw e
+            when (e) {
+                is FirebaseAuthInvalidUserException -> throw Exception("User account is disabled or deleted.")
+                is FirebaseAuthInvalidCredentialsException -> throw Exception("Incorrect current password.")
+                else -> throw e
             }
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/repository/AuthRepositoryImpl.kt
@@ -39,39 +39,40 @@ class AuthRepositoryImpl
         override suspend fun login(
             email: String,
             password: String,
-        ): LoginResult = runCatching {
-            val result = firebaseAuth
-                .signInWithEmailAndPassword(email, password)
-                .await()
+        ): LoginResult =
+            runCatching {
+                val result = firebaseAuth
+                    .signInWithEmailAndPassword(email, password)
+                    .await()
 
-            val user = result.user
-                ?: throw Exception("Login failed: no user returned")
+                val user = result.user
+                    ?: throw Exception("Login failed: no user returned")
 
-            // Reload to get the latest emailVerified status from Firebase servers
-            user.reload().await()
-            // Refresh the ID token cache
-            user.getIdToken(true).await()
+                // Reload to get the latest emailVerified status from Firebase servers
+                user.reload().await()
+                // Refresh the ID token cache
+                user.getIdToken(true).await()
 
-            // Auto-send a new verification link if the email is still unverified
-            if (!user.isEmailVerified) {
-                runCatching {
-                    user.sendEmailVerification().await()
-                    Timber.d("Automatic verification link re-sent to %s", email)
-                }.onFailure { e ->
-                    if (e is CancellationException) throw e
-                    Timber.e(e, "Failed to auto-send verification email on login")
+                // Auto-send a new verification link if the email is still unverified
+                if (!user.isEmailVerified) {
+                    runCatching {
+                        user.sendEmailVerification().await()
+                        Timber.d("Automatic verification link re-sent to %s", email)
+                    }.onFailure { e ->
+                        if (e is CancellationException) throw e
+                        Timber.e(e, "Failed to auto-send verification email on login")
+                    }
                 }
-            }
 
-            LoginResult(
-                user = user,
-                isEmailVerified = user.isEmailVerified,
-            )
-        }.getOrElse { e ->
-            if (e is CancellationException) throw e
-            Timber.e(e, "Login failed for %s", email)
-            throw Exception(FirebaseAuthErrorMapper.map(e), e)
-        }
+                LoginResult(
+                    user = user,
+                    isEmailVerified = user.isEmailVerified,
+                )
+            }.getOrElse { e ->
+                if (e is CancellationException) throw e
+                Timber.e(e, "Login failed for %s", email)
+                throw Exception(FirebaseAuthErrorMapper.map(e), e)
+            }
 
         /**
          * Creates a new Firebase user and sends a verification email.
@@ -84,45 +85,46 @@ class AuthRepositoryImpl
             name: String,
             email: String,
             password: String,
-        ): LoginResult = runCatching {
-            val result = firebaseAuth
-                .createUserWithEmailAndPassword(email, password)
-                .await()
-
-            val user = result.user
-                ?: throw Exception("Sign-up failed: no user returned")
-
-            // Set Firebase display name
+        ): LoginResult =
             runCatching {
-                val profileUpdates = UserProfileChangeRequest
-                    .Builder()
-                    .setDisplayName(name)
-                    .build()
-                user.updateProfile(profileUpdates).await()
-                Timber.d("Firebase profile updated with name: %s", name)
-            }.onFailure { e ->
-                if (e is CancellationException) throw e
-                Timber.e(e, "Failed to update Firebase profile display name")
-            }
+                val result = firebaseAuth
+                    .createUserWithEmailAndPassword(email, password)
+                    .await()
 
-            // Send the verification email link
-            runCatching {
-                user.sendEmailVerification().await()
-                Timber.d("Verification email sent to %s", email)
-            }.onFailure { e ->
-                if (e is CancellationException) throw e
-                Timber.e(e, "Failed to send verification email on sign-up")
-            }
+                val user = result.user
+                    ?: throw Exception("Sign-up failed: no user returned")
 
-            LoginResult(
-                user = user,
-                isEmailVerified = user.isEmailVerified,
-            )
-        }.getOrElse { e ->
-            if (e is CancellationException) throw e
-            Timber.e(e, "Sign-up failed for %s", email)
-            throw Exception(FirebaseAuthErrorMapper.map(e), e)
-        }
+                // Set Firebase display name
+                runCatching {
+                    val profileUpdates = UserProfileChangeRequest
+                        .Builder()
+                        .setDisplayName(name)
+                        .build()
+                    user.updateProfile(profileUpdates).await()
+                    Timber.d("Firebase profile updated with name: %s", name)
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Timber.e(e, "Failed to update Firebase profile display name")
+                }
+
+                // Send the verification email link
+                runCatching {
+                    user.sendEmailVerification().await()
+                    Timber.d("Verification email sent to %s", email)
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Timber.e(e, "Failed to send verification email on sign-up")
+                }
+
+                LoginResult(
+                    user = user,
+                    isEmailVerified = user.isEmailVerified,
+                )
+            }.getOrElse { e ->
+                if (e is CancellationException) throw e
+                Timber.e(e, "Sign-up failed for %s", email)
+                throw Exception(FirebaseAuthErrorMapper.map(e), e)
+            }
 
         /**
          * Signs in with a Google ID token obtained from the Credential Manager flow.
@@ -130,21 +132,22 @@ class AuthRepositoryImpl
          * Domain validation (@must.ac.ke) is enforced in [LoginViewModel] after this
          * call succeeds, because Firebase does not know our domain restriction.
          */
-        override suspend fun signInWithGoogle(idToken: String): LoginResult = runCatching {
-            val credential = GoogleAuthProvider.getCredential(idToken, null)
-            val result = firebaseAuth.signInWithCredential(credential).await()
-            val user = result.user
-                ?: throw Exception("Google sign-in failed: no user returned")
+        override suspend fun signInWithGoogle(idToken: String): LoginResult =
+            runCatching {
+                val credential = GoogleAuthProvider.getCredential(idToken, null)
+                val result = firebaseAuth.signInWithCredential(credential).await()
+                val user = result.user
+                    ?: throw Exception("Google sign-in failed: no user returned")
 
-            LoginResult(
-                user = user,
-                isEmailVerified = user.isEmailVerified,
-            )
-        }.getOrElse { e ->
-            if (e is CancellationException) throw e
-            Timber.e(e, "Google sign-in failed")
-            throw Exception(FirebaseAuthErrorMapper.map(e), e)
-        }
+                LoginResult(
+                    user = user,
+                    isEmailVerified = user.isEmailVerified,
+                )
+            }.getOrElse { e ->
+                if (e is CancellationException) throw e
+                Timber.e(e, "Google sign-in failed")
+                throw Exception(FirebaseAuthErrorMapper.map(e), e)
+            }
 
         /**
          * Sends a Firebase email verification link to the currently signed-in user.
@@ -230,32 +233,33 @@ class AuthRepositoryImpl
         override suspend fun changePassword(
             currentPassword: String,
             newPassword: String,
-        ): Result<Unit> = runCatching {
-            val user = firebaseAuth.currentUser
-                ?: throw Exception("User not logged in")
+        ): Result<Unit> =
+            runCatching {
+                val user = firebaseAuth.currentUser
+                    ?: throw Exception("User not logged in")
 
-            val email = user.email
-                ?: throw Exception("Email not found for current user")
+                val email = user.email
+                    ?: throw Exception("Email not found for current user")
 
-            if (currentPassword == newPassword) {
-                throw Exception("New password cannot be the same as the current password")
+                if (currentPassword == newPassword) {
+                    throw Exception("New password cannot be the same as the current password")
+                }
+
+                // Create the credential
+                val credential = EmailAuthProvider.getCredential(email, currentPassword)
+
+                // Re-authenticate to ensure the session is fresh and the current password is correct
+                user.reauthenticate(credential).await()
+
+                // Update to the new password
+                user.updatePassword(newPassword).await()
+                Unit
+            }.recoverCatching { e ->
+                if (e is CancellationException) throw e
+                when (e) {
+                    is FirebaseAuthInvalidUserException -> throw Exception("User account is disabled or deleted.")
+                    is FirebaseAuthInvalidCredentialsException -> throw Exception("Incorrect current password.")
+                    else -> throw e
+                }
             }
-
-            // Create the credential
-            val credential = EmailAuthProvider.getCredential(email, currentPassword)
-
-            // Re-authenticate to ensure the session is fresh and the current password is correct
-            user.reauthenticate(credential).await()
-
-            // Update to the new password
-            user.updatePassword(newPassword).await()
-            Unit
-        }.recoverCatching { e ->
-            if (e is CancellationException) throw e
-            when (e) {
-                is FirebaseAuthInvalidUserException -> throw Exception("User account is disabled or deleted.")
-                is FirebaseAuthInvalidCredentialsException -> throw Exception("Incorrect current password.")
-                else -> throw e
-            }
-        }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -21,7 +20,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -36,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.sharedComposables.HustleTextField
 import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.ChangePasswordViewModel
 import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.PasswordStrength

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
@@ -52,7 +52,6 @@ fun ChangePasswordScreen(
     HustleScaffold(
         topBar = {
             TopAppBar(
-                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = { Text("Change Password") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -48,9 +50,10 @@ fun ChangePasswordScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
 
-    Scaffold(
+    HustleScaffold(
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = { Text("Change Password") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
@@ -1,6 +1,5 @@
 package must.kdroiders.hustlehub.ui.features.auth.presentation.view
 
-import android.widget.Toast
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -24,6 +23,8 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -32,12 +33,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
@@ -49,6 +50,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.R
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
 import must.kdroiders.hustlehub.sharedComposables.HustleButtonVariant
@@ -65,8 +67,15 @@ fun LoginScreen(
     loginViewModel: LoginViewModel = hiltViewModel(),
 ) {
     val uiState by loginViewModel.uiState.collectAsState()
-    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var showForgotPasswordDialog by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let { err ->
+            snackbarHostState.showSnackbar(err)
+        }
+    }
 
     // Prefill email if passed from navigation (e.g. after registration or email verification)
     LaunchedEffect(prefilledEmail) {
@@ -233,7 +242,7 @@ fun LoginScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontSize = MaterialTheme.typography.bodyMedium.fontSize,
                     ),
-                ) { append("Don't have an account?  ") }
+                ) { append("New here?  ") }
                 pushStringAnnotation("signup", "signup")
                 withStyle(
                     SpanStyle(
@@ -241,7 +250,7 @@ fun LoginScreen(
                         fontWeight = FontWeight.Bold,
                         fontSize = MaterialTheme.typography.bodyMedium.fontSize,
                     ),
-                ) { append("Sign Up") }
+                ) { append("Create Account") }
                 pop()
             }
             ClickableText(
@@ -263,7 +272,8 @@ fun LoginScreen(
                 title = { Text("Reset Password") },
                 text = {
                     Text(
-                        "Send a password reset email to ${if (uiState.email.isNotBlank()) uiState.email else "your email address"}?",
+                        "Enter your student email address to receive a password reset link.",
+                        style = MaterialTheme.typography.bodyMedium,
                     )
                 },
                 confirmButton = {
@@ -273,15 +283,19 @@ fun LoginScreen(
                             loginViewModel.sendPasswordResetEmail(
                                 email = uiState.email,
                                 onSuccess = {
-                                    Toast.makeText(context, "Password reset email sent to ${uiState.email}", Toast.LENGTH_LONG).show()
+                                    scope.launch {
+                                        snackbarHostState.showSnackbar("Password reset link sent to your email")
+                                    }
                                 },
                                 onError = { err ->
-                                    Toast.makeText(context, err, Toast.LENGTH_LONG).show()
+                                    scope.launch {
+                                        snackbarHostState.showSnackbar(err)
+                                    }
                                 },
                             )
                         },
                     ) {
-                        Text("Send")
+                        Text("Send Link")
                     }
                 },
                 dismissButton = {
@@ -291,6 +305,13 @@ fun LoginScreen(
                 },
             )
         }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp),
+        )
     }
 }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/SignUpScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/SignUpScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -21,9 +22,12 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import must.kdroiders.hustlehub.R
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleButtonVariant
 import must.kdroiders.hustlehub.sharedComposables.HustleTextField
 import must.kdroiders.hustlehub.ui.features.auth.presentation.view.components.PasswordStrengthIndicator
 import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.SignUpViewModel
@@ -32,129 +36,191 @@ import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.SignUpVi
 fun SignUpScreen(
     onNavigateToLogin: () -> Unit,
     onSignUpSuccess: (email: String) -> Unit,
+    onGoogleSignInClick: () -> Unit = {},
     signUpViewModel: SignUpViewModel = hiltViewModel(),
 ) {
     val uiState by signUpViewModel.uiState.collectAsStateWithLifecycle()
     val scrollState = rememberScrollState()
+    val snackbarHostState = remember { SnackbarHostState() }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp)
-            .verticalScroll(scrollState),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Text(
-            text = "Create Account",
-            style = MaterialTheme.typography.headlineLarge,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp),
-        )
-        Text(
-            text = "Join HustleHub with your student email",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 32.dp),
-        )
-
-        HustleTextField(
-            value = uiState.name,
-            onValueChange = signUpViewModel::onNameChanged,
-            label = "Full Name",
-            modifier = Modifier.fillMaxWidth(),
-            isError = uiState.nameError != null,
-            errorText = uiState.nameError,
-            leadingIcon = Icons.Default.Person,
-            keyboardOptions = KeyboardOptions(
-                capitalization = KeyboardCapitalization.Words,
-                imeAction = ImeAction.Next,
-            ),
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        HustleTextField(
-            value = uiState.email,
-            onValueChange = signUpViewModel::onEmailChanged,
-            label = "Must Student Email",
-            placeholder = "example@students.must.ac.ke",
-            modifier = Modifier.fillMaxWidth(),
-            isError = uiState.emailError != null,
-            errorText = uiState.emailError,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Email,
-                imeAction = ImeAction.Next,
-            ),
-            leadingIcon = Icons.Default.Email,
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        HustleTextField(
-            value = uiState.password,
-            onValueChange = signUpViewModel::onPasswordChanged,
-            label = "Password",
-            modifier = Modifier.fillMaxWidth(),
-            isError = uiState.passwordError != null,
-            errorText = uiState.passwordError,
-            isPassword = true,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Password,
-                imeAction = ImeAction.Next,
-            ),
-            leadingIcon = Icons.Default.Lock,
-        )
-        if (uiState.password.isNotEmpty()) {
-            PasswordStrengthIndicator(strength = uiState.passwordStrength)
+    LaunchedEffect(uiState.signUpError) {
+        uiState.signUpError?.let { err ->
+            snackbarHostState.showSnackbar(err)
         }
-        Spacer(modifier = Modifier.height(16.dp))
+    }
 
-        HustleTextField(
-            value = uiState.confirmPassword,
-            onValueChange = signUpViewModel::onConfirmPasswordChanged,
-            label = "Confirm Password",
-            modifier = Modifier.fillMaxWidth(),
-            isError = uiState.confirmPasswordError != null,
-            errorText = uiState.confirmPasswordError,
-            isPassword = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            leadingIcon = Icons.Default.Lock,
-        )
-        Spacer(modifier = Modifier.height(32.dp))
-
-        HustleButton(
-            text = "Sign Up",
-            onClick = { signUpViewModel.signUp(onSignUpSuccess) },
-            modifier = Modifier.fillMaxWidth(),
-            loading = uiState.isLoading,
-        )
-
-        uiState.signUpError?.let {
-            Spacer(modifier = Modifier.height(16.dp))
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp)
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
             Text(
-                text = it,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall,
+                text = "Create Account",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+            Text(
+                text = "Join HustleHub with your student email",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 32.dp),
+            )
+
+            HustleTextField(
+                value = uiState.name,
+                onValueChange = signUpViewModel::onNameChanged,
+                label = "Full Name",
+                modifier = Modifier.fillMaxWidth(),
+                isError = uiState.nameError != null,
+                errorText = uiState.nameError,
+                leadingIcon = Icons.Default.Person,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Words,
+                    imeAction = ImeAction.Next,
+                ),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            HustleTextField(
+                value = uiState.email,
+                onValueChange = signUpViewModel::onEmailChanged,
+                label = "Must Student Email",
+                placeholder = "example@students.must.ac.ke",
+                modifier = Modifier.fillMaxWidth(),
+                isError = uiState.emailError != null,
+                errorText = uiState.emailError,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Email,
+                    imeAction = ImeAction.Next,
+                ),
+                leadingIcon = Icons.Default.Email,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            HustleTextField(
+                value = uiState.password,
+                onValueChange = signUpViewModel::onPasswordChanged,
+                label = "Password",
+                modifier = Modifier.fillMaxWidth(),
+                isError = uiState.passwordError != null,
+                errorText = uiState.passwordError,
+                isPassword = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    imeAction = ImeAction.Next,
+                ),
+                leadingIcon = Icons.Default.Lock,
+            )
+            if (uiState.password.isNotEmpty()) {
+                PasswordStrengthIndicator(strength = uiState.passwordStrength)
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            HustleTextField(
+                value = uiState.confirmPassword,
+                onValueChange = signUpViewModel::onConfirmPasswordChanged,
+                label = "Confirm Password",
+                modifier = Modifier.fillMaxWidth(),
+                isError = uiState.confirmPasswordError != null,
+                errorText = uiState.confirmPasswordError,
+                isPassword = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                leadingIcon = Icons.Default.Lock,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+
+            HustleButton(
+                text = "Sign Up",
+                onClick = { signUpViewModel.signUp(onSignUpSuccess) },
+                modifier = Modifier.fillMaxWidth(),
+                loading = uiState.isLoading,
+            )
+
+            uiState.signUpError?.let {
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            // OR divider
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                HorizontalDivider(
+                    modifier = Modifier.weight(1f),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+                Text(
+                    text = "  OR  ",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    letterSpacing = 1.sp,
+                )
+                HorizontalDivider(
+                    modifier = Modifier.weight(1f),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            // Google sign-in button
+            HustleButton(
+                text = "Continue with Google",
+                onClick = { onGoogleSignInClick() },
+                variant = HustleButtonVariant.Outlined,
+                painter = painterResource(id = R.drawable.google),
+                iconSize = 22.dp,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(modifier = Modifier.height(36.dp))
+
+            val annotatedString = buildAnnotatedString {
+                withStyle(
+                    SpanStyle(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                    ),
+                ) { append("Already have an account?  ") }
+                pushStringAnnotation(tag = "login", annotation = "login")
+                withStyle(
+                    SpanStyle(
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                    ),
+                ) { append("Login") }
+                pop()
+            }
+
+            ClickableText(
+                text = annotatedString,
+                onClick = { offset ->
+                    annotatedString.getStringAnnotations(tag = "login", start = offset, end = offset).firstOrNull()?.let {
+                        onNavigateToLogin()
+                    }
+                },
             )
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
-
-        val annotatedString = buildAnnotatedString {
-            append("Already have an account? ")
-            pushStringAnnotation(tag = "login", annotation = "login")
-            withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)) {
-                append("Login")
-            }
-            pop()
-        }
-
-        ClickableText(
-            text = annotatedString,
-            onClick = { offset ->
-                annotatedString.getStringAnnotations(tag = "login", start = offset, end = offset).firstOrNull()?.let {
-                    onNavigateToLogin()
-                }
-            },
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp),
         )
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
@@ -16,12 +16,12 @@ import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.ConversationDao
 import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.MessageDao
 import must.kdroiders.hustlehub.ui.features.chat.data.local.entity.toDomain
 import must.kdroiders.hustlehub.ui.features.chat.data.local.entity.toEntity
+import must.kdroiders.hustlehub.ui.features.chat.data.remote.ChatWebSocketService
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.ConversationApiService
-import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.CreateConversationRequest
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.ConversationResponse
+import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.CreateConversationRequest
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.MessageResponse
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.SendMessageRequest
-import must.kdroiders.hustlehub.ui.features.chat.data.remote.ChatWebSocketService
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Conversation
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Message
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.MessageType

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/data/repository/ChatRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -15,12 +16,12 @@ import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.ConversationDao
 import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.MessageDao
 import must.kdroiders.hustlehub.ui.features.chat.data.local.entity.toDomain
 import must.kdroiders.hustlehub.ui.features.chat.data.local.entity.toEntity
-import must.kdroiders.hustlehub.ui.features.chat.data.remote.ChatWebSocketService
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.ConversationApiService
-import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.ConversationResponse
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.CreateConversationRequest
+import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.ConversationResponse
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.MessageResponse
 import must.kdroiders.hustlehub.ui.features.chat.data.remote.dto.SendMessageRequest
+import must.kdroiders.hustlehub.ui.features.chat.data.remote.ChatWebSocketService
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Conversation
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Message
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.MessageType
@@ -36,16 +37,16 @@ class ChatRepositoryImpl
     constructor(
         @ApplicationContext private val context: Context,
         private val conversationApiService: ConversationApiService,
-        private val chatWebSocketService: ChatWebSocketService,
         private val conversationDao: ConversationDao,
         private val messageDao: MessageDao,
+        private val chatWebSocketService: ChatWebSocketService,
         private val firebaseAuth: FirebaseAuth?,
     ) : ChatRepository {
         @Volatile
         private var activeConversationId: String? = null
 
         override fun setActiveConversation(conversationId: String?) {
-            this.activeConversationId = conversationId
+            activeConversationId = conversationId
         }
 
         override fun getConversations(): Flow<List<Conversation>> {
@@ -56,18 +57,14 @@ class ChatRepositoryImpl
 
         override suspend fun refreshConversations(): Result<Unit> =
             withContext(Dispatchers.IO) {
-                try {
+                runCatching {
                     val response = conversationApiService.getConversations(0, 50)
-                    if (response.success && response.data != null) {
-                        val entities = response.data.content.map { it.toEntity() }
-                        conversationDao.upsertAll(entities)
-                        Result.success(Unit)
-                    } else {
-                        Result.failure(Exception(response.message))
-                    }
-                } catch (e: Exception) {
+                    check(response.success && response.data != null) { response.message ?: "Failed to refresh conversations" }
+                    val entities = response.data.content.map { it.toEntity() }
+                    conversationDao.upsertAll(entities)
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                     Timber.e(e, "Failed to refresh conversations")
-                    Result.failure(e)
                 }
             }
 
@@ -76,19 +73,16 @@ class ChatRepositoryImpl
             serviceId: String?,
         ): Result<Conversation> =
             withContext(Dispatchers.IO) {
-                try {
+                runCatching {
                     val request = CreateConversationRequest(otherUserId, serviceId)
                     val response = conversationApiService.getOrCreateConversation(request)
-                    if (response.success && response.data != null) {
-                        val conversation = response.data.toDomainModel()
-                        conversationDao.upsert(conversation.toEntity())
-                        Result.success(conversation)
-                    } else {
-                        Result.failure(Exception(response.message))
-                    }
-                } catch (e: Exception) {
+                    check(response.success && response.data != null) { response.message ?: "Failed to get or create conversation" }
+                    val conversation = response.data.toDomainModel()
+                    conversationDao.upsert(conversation.toEntity())
+                    conversation
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                     Timber.e(e, "Failed to get or create conversation")
-                    Result.failure(e)
                 }
             }
 
@@ -103,46 +97,40 @@ class ChatRepositoryImpl
             page: Int,
         ): Result<Unit> =
             withContext(Dispatchers.IO) {
-                try {
+                runCatching {
                     val response = conversationApiService.getMessages(conversationId, page, 50)
-                    if (response.success && response.data != null) {
-                        val gson = Gson()
-                        val localIdsToDelete = response.data.content.mapNotNull { msg ->
-                            try {
-                                if (msg.metadata != null) {
-                                    val metaObj = gson.fromJson(msg.metadata, JsonObject::class.java)
-                                    if (metaObj.has("localId")) {
-                                        metaObj.get("localId").asString
-                                    } else {
-                                        null
-                                    }
+                    check(response.success && response.data != null) { response.message ?: "Failed to load message history" }
+                    val gson = Gson()
+                    val localIdsToDelete = response.data.content.mapNotNull { msg ->
+                        if (msg.metadata != null) {
+                            runCatching {
+                                val metaObj = gson.fromJson(msg.metadata, JsonObject::class.java)
+                                if (metaObj.has("localId")) {
+                                    metaObj.get("localId").asString
                                 } else {
                                     null
                                 }
-                            } catch (e: Exception) {
-                                null
-                            }
+                            }.getOrNull()
+                        } else {
+                            null
                         }
-                        if (localIdsToDelete.isNotEmpty()) {
-                            localIdsToDelete.forEach { messageDao.deleteById(it) }
-                        }
-                        val entities = response.data.content.mapNotNull { msgDto ->
-                            val msgDomain = msgDto.toDomainModel()
-                            val processed = applyDeletionStatusToMessage(msgDomain)
-                            processed?.toEntity()
-                        }
-                        messageDao.upsertAll(entities)
-                        Result.success(Unit)
-                    } else {
-                        Result.failure(Exception(response.message))
                     }
-                } catch (e: Exception) {
+                    if (localIdsToDelete.isNotEmpty()) {
+                        localIdsToDelete.forEach { messageDao.deleteById(it) }
+                    }
+                    val entities = response.data.content.mapNotNull { msgDto ->
+                        val msgDomain = msgDto.toDomainModel()
+                        val processed = applyDeletionStatusToMessage(msgDomain)
+                        processed?.toEntity()
+                    }
+                    messageDao.upsertAll(entities)
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                     Timber.e(e, "Failed to load message history")
                     if (e is retrofit2.HttpException && e.code() == 404) {
                         conversationDao.deleteById(conversationId)
                         messageDao.deleteByConversation(conversationId)
                     }
-                    Result.failure(e)
                 }
             }
 
@@ -154,21 +142,19 @@ class ChatRepositoryImpl
             metadata: String?,
         ): Result<Unit> =
             withContext(Dispatchers.IO) {
-                // Optimistic UI Update: Create a temporary message
                 val tempId = "temp_${UUID.randomUUID()}"
                 val currentUserId = firebaseAuth?.currentUser?.uid ?: ""
                 val currentTimestamp = java.time.Instant
                     .now()
                     .toString()
 
-                // Embed localId into metadata
                 val gson = Gson()
                 val metadataJson = if (metadata != null) {
-                    try {
+                    runCatching {
                         gson.fromJson(metadata, JsonObject::class.java).apply {
                             addProperty("localId", tempId)
                         }
-                    } catch (e: Exception) {
+                    }.getOrElse {
                         JsonObject().apply { addProperty("localId", tempId) }
                     }
                 } else {
@@ -192,7 +178,7 @@ class ChatRepositoryImpl
                     isFailed = false,
                 )
 
-                try {
+                runCatching {
                     messageDao.upsert(tempMessage.toEntity())
 
                     val request = SendMessageRequest(
@@ -204,59 +190,38 @@ class ChatRepositoryImpl
                     )
                     chatWebSocketService.connect()
                     chatWebSocketService.sendMessage(request)
-                    Result.success(Unit)
-                } catch (e: Exception) {
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                     Timber.e(e, "Failed to send message over WebSocket, marking as failed")
-                    val failedMessage = Message(
-                        id = tempMessage.id,
-                        conversationId = tempMessage.conversationId,
-                        senderId = tempMessage.senderId,
-                        type = tempMessage.type,
-                        content = tempMessage.content,
-                        mediaUrl = tempMessage.mediaUrl,
-                        thumbnailUrl = tempMessage.thumbnailUrl,
-                        metadata = tempMessage.metadata,
-                        timestamp = tempMessage.timestamp,
-                        deliveredAt = tempMessage.deliveredAt,
-                        readAt = tempMessage.readAt,
-                        isSynced = tempMessage.isSynced,
-                        isFailed = true,
-                    )
+                    val failedMessage = tempMessage.copy(isFailed = true)
                     messageDao.upsert(failedMessage.toEntity())
-                    Result.failure(e)
                 }
             }
 
         override suspend fun markAsRead(conversationId: String): Result<Unit> =
             withContext(Dispatchers.IO) {
-                try {
+                runCatching {
                     val response = conversationApiService.markAsRead(conversationId)
-                    if (response.success) {
-                        val cached = conversationDao.getById(conversationId)
-                        if (cached != null) {
-                            conversationDao.upsert(cached.copy(unreadCount = 0))
-                        }
-                        Result.success(Unit)
-                    } else {
-                        Result.failure(Exception(response.message))
+                    check(response.success) { response.message ?: "Failed to mark conversation as read" }
+                    val cached = conversationDao.getById(conversationId)
+                    if (cached != null) {
+                        conversationDao.upsert(cached.copy(unreadCount = 0))
                     }
-                } catch (e: Exception) {
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                     Timber.e(e, "Failed to mark conversation as read")
                     if (e is retrofit2.HttpException && e.code() == 404) {
                         conversationDao.deleteById(conversationId)
                         messageDao.deleteByConversation(conversationId)
                     }
-                    Result.failure(e)
                 }
             }
 
         override suspend fun connectWebSocket(conversationId: String): Flow<Message> =
             flow {
                 try {
-                    // Ensure WebSocket is connected
                     chatWebSocketService.connect()
 
-                    // Subscribe to conversation fresh on each collection
                     chatWebSocketService
                         .subscribeToConversation(conversationId)
                         .map { it.toDomainModel() }
@@ -268,18 +233,18 @@ class ChatRepositoryImpl
                                 val isFromOtherUser = cachedConv?.let { message.senderId == it.otherUserId } ?: false
                                 val isFromSelf = !isFromOtherUser
 
-                                // Remove optimistic message if this is the real one from the server
                                 if (isFromSelf) {
-                                    try {
-                                        if (message.metadata != null) {
+                                    if (message.metadata != null) {
+                                        runCatching {
                                             val metaObj = gson.fromJson(message.metadata, JsonObject::class.java)
                                             if (metaObj.has("localId")) {
                                                 val localId = metaObj.get("localId").asString
                                                 messageDao.deleteById(localId)
                                             }
+                                        }.onFailure { e ->
+                                            if (e is CancellationException) throw e
+                                            Timber.e(e, "Error processing localId from metadata")
                                         }
-                                    } catch (e: Exception) {
-                                        Timber.e(e, "Error processing localId from metadata")
                                     }
                                 }
 
@@ -294,7 +259,6 @@ class ChatRepositoryImpl
                                                 lastMessage = proc.content,
                                                 lastMessageType = proc.type.name,
                                                 lastMessageAt = proc.timestamp,
-                                                // Only increment badge for messages from others if the chat is NOT active
                                                 unreadCount = if (isFromOtherUser && !isActive) {
                                                     cachedConv.unreadCount + 1
                                                 } else {
@@ -303,7 +267,6 @@ class ChatRepositoryImpl
                                             ),
                                         )
 
-                                        // Post a local notification for incoming messages if the chat is not active.
                                         if (isFromOtherUser && !isActive) {
                                             val senderName = cachedConv.otherUserName
                                             val preview = when (proc.type.name) {
@@ -319,8 +282,6 @@ class ChatRepositoryImpl
                                                 messagePreview = preview,
                                             )
                                         } else if (isFromOtherUser && isActive) {
-                                            // If the conversation is currently active, mark the new message as read on the backend
-                                            // since the user is actively viewing it.
                                             markAsRead(conversationId)
                                         }
                                     }
@@ -354,6 +315,7 @@ class ChatRepositoryImpl
                             }
                         }
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     chatWebSocketService.disconnect()
                     throw e
                 }
@@ -369,37 +331,29 @@ class ChatRepositoryImpl
             chatWebSocketService.disconnect()
         }
 
-        override suspend fun deleteConversation(conversationId: String): Result<Unit> {
-            return withContext(Dispatchers.IO) {
-                try {
-                    // 1. Delete from local database
+        override suspend fun deleteConversation(conversationId: String): Result<Unit> =
+            withContext(Dispatchers.IO) {
+                runCatching {
                     conversationDao.deleteById(conversationId)
                     messageDao.deleteByConversation(conversationId)
 
-                    // 2. Perform the remote API delete call
                     val response = conversationApiService.deleteConversation(conversationId)
-                    if (response.success) {
-                        Result.success(Unit)
-                    } else {
-                        Result.failure(Exception(response.message ?: "Failed to delete conversation on server"))
-                    }
-                } catch (e: Exception) {
-                    Result.failure(e)
+                    check(response.success) { response.message ?: "Failed to delete conversation on server" }
+                    Unit
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                 }
             }
-        }
 
         override suspend fun deleteMessageForMe(messageId: String): Result<Unit> =
             withContext(Dispatchers.IO) {
-                try {
+                runCatching {
                     markMessageDeletedForMe(messageId)
 
-                    // Delete from local DB
                     val cached = messageDao.getById(messageId)
                     if (cached != null) {
                         messageDao.deleteById(messageId)
 
-                        // Update conversation preview if needed
                         val conv = conversationDao.getById(cached.conversationId)
                         if (conv != null && conv.lastMessageAt == cached.timestamp) {
                             val latest = messageDao.getLatestMessage(cached.conversationId)
@@ -423,43 +377,41 @@ class ChatRepositoryImpl
                         }
                     }
 
-                    // Call backend REST endpoint (handle lack of endpoint gracefully)
-                    try {
+                    runCatching {
                         conversationApiService.deleteMessageForMe(messageId)
-                    } catch (e: Exception) {
+                    }.onFailure { e ->
+                        if (e is CancellationException) throw e
                         Timber.w(e, "Remote deleteMessageForMe failed, treating as local-only success")
                     }
-                    Result.success(Unit)
-                } catch (e: Exception) {
-                    Result.failure(e)
+                    Unit
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                 }
             }
 
         override suspend fun deleteMessageForEveryone(messageId: String): Result<Unit> =
             withContext(Dispatchers.IO) {
-                try {
+                runCatching {
                     markMessageDeletedForEveryone(messageId)
 
-                    // Call backend REST endpoint (handle lack of endpoint gracefully)
-                    try {
+                    runCatching {
                         conversationApiService.deleteMessageForEveryone(messageId)
-                    } catch (e: Exception) {
+                    }.onFailure { e ->
+                        if (e is CancellationException) throw e
                         Timber.w(e, "Remote deleteMessageForEveryone failed, treating as local-only success")
                     }
 
-                    // Update locally
                     val cached = messageDao.getById(messageId)
                     if (cached != null) {
                         val gson = Gson()
-                        val metaObj = try {
+                        val metaObj = runCatching {
                             if (!cached.metadata.isNullOrBlank()) {
                                 gson.fromJson(cached.metadata, JsonObject::class.java)
                             } else {
                                 JsonObject()
                             }
-                        } catch (e: Exception) {
-                            JsonObject()
-                        }
+                        }.getOrElse { JsonObject() }
+
                         metaObj.addProperty("isDeleted", true)
                         val updated = cached.copy(
                             content = "This message was deleted",
@@ -469,7 +421,6 @@ class ChatRepositoryImpl
                         )
                         messageDao.upsert(updated)
 
-                        // Update conversation preview if needed
                         val conv = conversationDao.getById(cached.conversationId)
                         if (conv != null && conv.lastMessageAt == cached.timestamp) {
                             conversationDao.upsert(
@@ -480,9 +431,9 @@ class ChatRepositoryImpl
                             )
                         }
                     }
-                    Result.success(Unit)
-                } catch (e: Exception) {
-                    Result.failure(e)
+                    Unit
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                 }
             }
 
@@ -507,15 +458,14 @@ class ChatRepositoryImpl
             if (status == "for_me") return null
 
             val gson = Gson()
-            val metaObj = try {
+            val metaObj = runCatching {
                 if (!message.metadata.isNullOrBlank()) {
                     gson.fromJson(message.metadata, JsonObject::class.java)
                 } else {
                     JsonObject()
                 }
-            } catch (e: Exception) {
-                JsonObject()
-            }
+            }.getOrElse { JsonObject() }
+
             metaObj.addProperty("isDeleted", true)
             return message.copy(
                 content = "This message was deleted",
@@ -525,8 +475,6 @@ class ChatRepositoryImpl
             )
         }
     }
-
-// Mapper extensions for DTOs to Domain models
 
 private fun ConversationResponse.toDomainModel(): Conversation =
     Conversation(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ChatLocationPickerSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ChatLocationPickerSheet.kt
@@ -128,6 +128,7 @@ fun ChatLocationPickerSheet(
                 withContext(Dispatchers.IO) {
                     try {
                         val geocoder = Geocoder(context, Locale.getDefault())
+
                         @Suppress("DEPRECATION")
                         val addresses = geocoder.getFromLocation(gpsLat, gpsLng, 1)
                         if (!addresses.isNullOrEmpty()) {
@@ -433,7 +434,10 @@ private fun AccuracyDot(accuracy: Float) {
 }
 
 @Composable
-private fun LandmarkChip(label: String, onClick: () -> Unit) {
+private fun LandmarkChip(
+    label: String,
+    onClick: () -> Unit,
+) {
     SuggestionChip(
         onClick = onClick,
         label = {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ChatLocationPickerSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ChatLocationPickerSheet.kt
@@ -1,0 +1,460 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package must.kdroiders.hustlehub.ui.features.chat.presentation.components
+
+import android.location.Geocoder
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.android.gms.location.LocationServices
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.MapLocationPickerModal
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.extractAreaName
+import java.util.Locale
+
+// Campus Landmark Presets
+// Coordinates centered on MUST / Nchiru campus, Meru, Kenya
+data class CampusLandmark(val label: String, val lat: Double, val lng: Double)
+
+private val MUST_LANDMARKS = listOf(
+    CampusLandmark("Main Gate", -0.0076, 37.6534),
+    CampusLandmark("Library", -0.0072, 37.6540),
+    CampusLandmark("Sci & Tech", -0.0068, 37.6548),
+    CampusLandmark("Hostels Area", -0.0090, 37.6520),
+    CampusLandmark("Student Center", -0.0082, 37.6528),
+    CampusLandmark("Administration", -0.0074, 37.6530),
+)
+
+/**
+ * WhatsApp-style location sharing sheet.
+ *
+ * Three ways to share a location in chat:
+ *  1. Send Current Location — live GPS with accuracy badge + reverse-geocoded address preview
+ *  2. Campus Landmark presets — quick-select chips for MUST/Nchiru landmarks
+ *  3. Choose on Map — opens [MapLocationPickerModal] for exact pin drop
+ */
+@Composable
+fun ChatLocationPickerSheet(
+    onDismiss: () -> Unit,
+    onLocationSelected: (lat: Double, lng: Double, label: String) -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // Sub-screen: show map picker when requested
+    var showMapPicker by remember { mutableStateOf(false) }
+
+    // GPS state
+    var gpsLat by remember { mutableStateOf(0.0) }
+    var gpsLng by remember { mutableStateOf(0.0) }
+    var gpsAccuracy by remember { mutableStateOf<Float?>(null) }
+    var gpsAddress by remember { mutableStateOf("") }
+    var gpsAreaName by remember { mutableStateOf("") }
+    var isLoadingGps by remember { mutableStateOf(true) }
+    var isGeocodingGps by remember { mutableStateOf(false) }
+
+    // Fetch current GPS location on first composition
+    LaunchedEffect(Unit) {
+        val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+        isLoadingGps = true
+        try {
+            @Suppress("MissingPermission")
+            val location = fusedClient.lastLocation.await()
+            if (location != null) {
+                gpsLat = location.latitude
+                gpsLng = location.longitude
+                gpsAccuracy = location.accuracy
+                isLoadingGps = false
+
+                // Reverse-geocode in background
+                isGeocodingGps = true
+                withContext(Dispatchers.IO) {
+                    try {
+                        val geocoder = Geocoder(context, Locale.getDefault())
+                        @Suppress("DEPRECATION")
+                        val addresses = geocoder.getFromLocation(gpsLat, gpsLng, 1)
+                        if (!addresses.isNullOrEmpty()) {
+                            val addr = addresses[0]
+                            val lines = (0..addr.maxAddressLineIndex).mapNotNull { addr.getAddressLine(it) }
+                            gpsAddress = lines.joinToString(", ")
+                            gpsAreaName = extractAreaName(gpsAddress)
+                        }
+                    } catch (_: Exception) {
+                        gpsAreaName = "Current Location"
+                    } finally {
+                        isGeocodingGps = false
+                    }
+                }
+            } else {
+                isLoadingGps = false
+            }
+        } catch (_: SecurityException) {
+            isLoadingGps = false
+        }
+    }
+
+    // Open MapLocationPickerModal when requested
+    if (showMapPicker) {
+        MapLocationPickerModal(
+            initialLat = if (gpsLat != 0.0) gpsLat else -0.0076,
+            initialLng = if (gpsLng != 0.0) gpsLng else 37.6534,
+            onLocationConfirmed = { lat, lng, label ->
+                onLocationSelected(lat, lng, label)
+                showMapPicker = false
+                onDismiss()
+            },
+            onDismiss = { showMapPicker = false },
+        )
+        return
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp),
+        ) {
+            // Sheet title
+            Text(
+                text = "Share Location",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+            )
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+
+            Spacer(Modifier.height(8.dp))
+
+            // Section 1: Current GPS location
+            CurrentLocationCard(
+                isLoadingGps = isLoadingGps,
+                isGeocodingGps = isGeocodingGps,
+                gpsAreaName = gpsAreaName.ifBlank { "Current Location" },
+                gpsAddress = gpsAddress,
+                gpsAccuracy = gpsAccuracy,
+                onSend = {
+                    if (gpsLat != 0.0 || gpsLng != 0.0) {
+                        onLocationSelected(gpsLat, gpsLng, gpsAreaName.ifBlank { "Current Location" })
+                        scope.launch { sheetState.hide() }.invokeOnCompletion { onDismiss() }
+                    }
+                },
+            )
+
+            Spacer(Modifier.height(12.dp))
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 20.dp),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+            )
+            Spacer(Modifier.height(12.dp))
+
+            // Section 2: Campus landmark presets
+            Text(
+                text = "Campus Landmarks",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
+            )
+            Spacer(Modifier.height(6.dp))
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 20.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(MUST_LANDMARKS) { landmark ->
+                    LandmarkChip(
+                        label = landmark.label,
+                        onClick = {
+                            onLocationSelected(landmark.lat, landmark.lng, landmark.label)
+                            scope.launch { sheetState.hide() }.invokeOnCompletion { onDismiss() }
+                        },
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = 20.dp),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+            )
+            Spacer(Modifier.height(4.dp))
+
+            // Section 3: Open map picker
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { showMapPicker = true }
+                    .padding(horizontal = 20.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            shape = RoundedCornerShape(12.dp),
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Map,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(22.dp),
+                    )
+                }
+                Spacer(Modifier.width(14.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Choose on Map",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = "Drop a pin anywhere on the map",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Icon(
+                    imageVector = Icons.Default.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+// Sub-composables
+
+@Composable
+private fun CurrentLocationCard(
+    isLoadingGps: Boolean,
+    isGeocodingGps: Boolean,
+    gpsAreaName: String,
+    gpsAddress: String,
+    gpsAccuracy: Float?,
+    onSend: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Icon container
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shape = RoundedCornerShape(12.dp),
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Default.MyLocation,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+
+        Spacer(Modifier.width(14.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            if (isLoadingGps) {
+                Text(
+                    text = "Getting your location…",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+                LinearWavyProgressIndicator(
+                    modifier = Modifier
+                        .fillMaxWidth(0.5f)
+                        .height(3.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            } else {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = gpsAreaName,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (isGeocodingGps) {
+                        Spacer(Modifier.width(6.dp))
+                        LinearWavyProgressIndicator(
+                            modifier = Modifier
+                                .width(32.dp)
+                                .height(3.dp),
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+                Spacer(Modifier.height(2.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    // Accuracy dot
+                    if (gpsAccuracy != null) {
+                        AccuracyDot(accuracy = gpsAccuracy)
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            text = "Accurate to ${gpsAccuracy.toInt()}m",
+                            fontSize = 11.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                if (gpsAddress.isNotBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = gpsAddress,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.width(12.dp))
+
+        // Send button
+        Button(
+            onClick = onSend,
+            enabled = !isLoadingGps,
+            shape = RoundedCornerShape(12.dp),
+            contentPadding = PaddingValues(
+                horizontal = 16.dp,
+                vertical = 8.dp,
+            ),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+        ) {
+            Icon(
+                imageVector = Icons.Default.LocationOn,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(4.dp))
+            Text("Send", fontWeight = FontWeight.Bold, fontSize = 13.sp)
+        }
+    }
+}
+
+/**
+ * Animated green dot that pulses to indicate live GPS lock.
+ * Turns amber when accuracy is poor (> 50m).
+ */
+@Composable
+private fun AccuracyDot(accuracy: Float) {
+    val dotColor = if (accuracy <= 50f) Color(0xFF34C759) else Color(0xFFFF9500)
+    val infiniteTransition = rememberInfiniteTransition(label = "gpsDot")
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 0.4f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(900), RepeatMode.Reverse),
+        label = "gpsDotAlpha",
+    )
+    Box(
+        modifier = Modifier
+            .size(8.dp)
+            .background(dotColor.copy(alpha = alpha), CircleShape),
+    )
+}
+
+@Composable
+private fun LandmarkChip(label: String, onClick: () -> Unit) {
+    SuggestionChip(
+        onClick = onClick,
+        label = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = null,
+                    modifier = Modifier.size(13.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(label, style = MaterialTheme.typography.labelMedium)
+            }
+        },
+        colors = SuggestionChipDefaults.suggestionChipColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
+            labelColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        border = SuggestionChipDefaults.suggestionChipBorder(
+            enabled = true,
+            borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f),
+        ),
+    )
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -631,7 +631,7 @@ private const val WAVEFORM_BAR_COUNT = 40
 @Composable
 private fun LocationMessageContent(
     message: Message,
-    textColor: androidx.compose.ui.graphics.Color,
+    textColor: Color,
     currentUserLocation: android.location.Location?,
     onClick: (Double, Double, String) -> Unit,
 ) {
@@ -645,8 +645,8 @@ private fun LocationMessageContent(
     }
     val mapsApiKey = stringResource(id = R.string.google_maps_key)
     val staticMapUrl = remember(locationData, mapsApiKey) {
-        if (locationData != null) {
-            "https://maps.googleapis.com/maps/api/staticmap?center=${locationData.lat},${locationData.lng}&zoom=15&size=300x150&scale=2&markers=${locationData.lat},${locationData.lng}&key=$mapsApiKey"
+        if (locationData != null && mapsApiKey.isNotBlank()) {
+            "https://maps.googleapis.com/maps/api/staticmap?center=${locationData.lat},${locationData.lng}&zoom=16&size=400x200&scale=2&markers=color:red%7C${locationData.lat},${locationData.lng}&key=$mapsApiKey"
         } else {
             ""
         }
@@ -678,7 +678,7 @@ private fun LocationMessageContent(
 
     Column(
         modifier = Modifier
-            .width(240.dp)
+            .width(250.dp)
             .clickable {
                 if (locationData != null) {
                     onClick(
@@ -687,8 +687,9 @@ private fun LocationMessageContent(
                         locationData.label ?: "Shared Location",
                     )
                 }
-            }.padding(4.dp),
+            }.padding(2.dp),
     ) {
+        // Location title & distance badge
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(bottom = 6.dp),
@@ -700,53 +701,78 @@ private fun LocationMessageContent(
                 modifier = Modifier.size(20.dp),
             )
             Spacer(modifier = Modifier.width(6.dp))
-            Text(
-                text = locationData?.label ?: "Shared Location",
-                color = textColor,
-                fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.bodyMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = locationData?.label ?: "Shared Location",
+                    color = textColor,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (distanceText != null) {
+                    Text(
+                        text = distanceText,
+                        color = textColor.copy(alpha = 0.85f),
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+            }
         }
 
-        if (staticMapUrl.isNotEmpty()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(130.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f)),
-            ) {
+        // Map Preview Thumbnail
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(135.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(textColor.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (staticMapUrl.isNotEmpty()) {
                 AsyncImage(
                     model = staticMapUrl,
                     contentDescription = "Map Preview",
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop,
                 )
+            } else {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        contentDescription = null,
+                        tint = textColor.copy(alpha = 0.6f),
+                        modifier = Modifier.size(36.dp),
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "Shared Location Pin",
+                        fontSize = 11.sp,
+                        color = textColor.copy(alpha = 0.7f),
+                    )
+                }
             }
         }
 
         Spacer(modifier = Modifier.height(6.dp))
 
-        Text(
-            text = "Tap to open in Maps",
-            color = textColor.copy(alpha = 0.8f),
-            fontSize = 11.sp,
-            fontWeight = FontWeight.Medium,
-        )
-
-        if (distanceText != null) {
-            Spacer(modifier = Modifier.height(2.dp))
+        // Get Directions CTA line
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
             Text(
-                text = distanceText,
-                color = textColor.copy(alpha = 0.9f),
+                text = "Tap to view in Maps",
+                color = textColor.copy(alpha = 0.85f),
                 fontSize = 11.sp,
-                fontWeight = FontWeight.Bold,
+                fontWeight = FontWeight.SemiBold,
             )
         }
     }
 }
+
 
 @Composable
 private fun ServiceCardMessageContent(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -68,7 +68,16 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
 import com.google.gson.Gson
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapType
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.rememberUpdatedMarkerState
 import must.kdroiders.hustlehub.R
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
 import must.kdroiders.hustlehub.sharedComposables.HustleButtonVariant
@@ -643,14 +652,10 @@ private fun LocationMessageContent(
             null
         }
     }
-    val mapsApiKey = stringResource(id = R.string.google_maps_key)
-    val staticMapUrl = remember(locationData, mapsApiKey) {
-        if (locationData != null && mapsApiKey.isNotBlank()) {
-            "https://maps.googleapis.com/maps/api/staticmap?center=${locationData.lat},${locationData.lng}&zoom=16&size=400x200&scale=2&markers=color:red%7C${locationData.lat},${locationData.lng}&key=$mapsApiKey"
-        } else {
-            ""
-        }
+    val latLng = remember(locationData) {
+        if (locationData != null) LatLng(locationData.lat, locationData.lng) else null
     }
+
     val distanceText = remember(locationData, currentUserLocation) {
         if (locationData != null && currentUserLocation != null) {
             val results = FloatArray(1)
@@ -721,7 +726,7 @@ private fun LocationMessageContent(
             }
         }
 
-        // Map Preview Thumbnail
+        // Map Preview Thumbnail — renders native GoogleMap view
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -730,13 +735,43 @@ private fun LocationMessageContent(
                 .background(textColor.copy(alpha = 0.12f)),
             contentAlignment = Alignment.Center,
         ) {
-            if (staticMapUrl.isNotEmpty()) {
-                AsyncImage(
-                    model = staticMapUrl,
-                    contentDescription = "Map Preview",
+            if (latLng != null) {
+                val cameraPositionState = rememberCameraPositionState {
+                    position = CameraPosition.fromLatLngZoom(latLng, 16f)
+                }
+                val markerState = rememberUpdatedMarkerState(position = latLng)
+                val mapUiSettings = remember {
+                    MapUiSettings(
+                        zoomControlsEnabled = false,
+                        scrollGesturesEnabled = false,
+                        zoomGesturesEnabled = false,
+                        tiltGesturesEnabled = false,
+                        rotationGesturesEnabled = false,
+                        myLocationButtonEnabled = false,
+                        compassEnabled = false,
+                        mapToolbarEnabled = false,
+                    )
+                }
+
+                GoogleMap(
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop,
-                )
+                    cameraPositionState = cameraPositionState,
+                    uiSettings = mapUiSettings,
+                    onMapClick = {
+                        if (locationData != null) {
+                            onClick(
+                                locationData.lat,
+                                locationData.lng,
+                                locationData.label ?: "Shared Location",
+                            )
+                        }
+                    },
+                ) {
+                    Marker(
+                        state = markerState,
+                        title = locationData?.label ?: "Shared Location",
+                    )
+                }
             } else {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Icon(
@@ -772,6 +807,7 @@ private fun LocationMessageContent(
         }
     }
 }
+
 
 
 @Composable

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -72,13 +71,10 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.gson.Gson
 import com.google.maps.android.compose.GoogleMap
-import com.google.maps.android.compose.MapProperties
-import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberUpdatedMarkerState
-import must.kdroiders.hustlehub.R
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
 import must.kdroiders.hustlehub.sharedComposables.HustleButtonVariant
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Message
@@ -807,8 +803,6 @@ private fun LocationMessageContent(
         }
     }
 }
-
-
 
 @Composable
 private fun ServiceCardMessageContent(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -68,9 +68,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.google.android.gms.maps.model.CameraPosition
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import com.google.android.gms.maps.model.LatLng
 import com.google.gson.Gson
 import com.google.maps.android.compose.GoogleMap
@@ -84,6 +81,9 @@ import must.kdroiders.hustlehub.ui.features.chat.domain.model.Message
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.MessageType
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.isDeleted
 import must.kdroiders.hustlehub.ui.features.chat.presentation.audio.PlayerState
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import kotlin.math.roundToInt
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -68,6 +68,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.google.android.gms.maps.model.CameraPosition
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import com.google.android.gms.maps.model.LatLng
 import com.google.gson.Gson
 import com.google.maps.android.compose.GoogleMap
@@ -911,16 +914,19 @@ private fun ServiceCardMessageContent(
 }
 
 private fun formatTimestamp(isoString: String?): String {
-    if (isoString == null) return ""
+    if (isoString.isNullOrBlank()) return ""
     return try {
-        val parts = isoString.split("T")
-        if (parts.size >= 2) {
-            parts[1].substring(0, 5) // "HH:MM"
-        } else {
+        val instant = Instant.parse(isoString)
+        val zonedDateTime = instant.atZone(ZoneId.systemDefault())
+        val formatter = DateTimeFormatter.ofPattern("HH:mm")
+        zonedDateTime.format(formatter)
+    } catch (e: Exception) {
+        try {
+            val parts = isoString.split("T")
+            if (parts.size >= 2) parts[1].substring(0, 5) else isoString
+        } catch (_: Exception) {
             isoString
         }
-    } catch (e: Exception) {
-        isoString
     }
 }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -99,6 +99,7 @@ import must.kdroiders.hustlehub.core.utils.saveImageToGallery
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.MessageType
 import must.kdroiders.hustlehub.ui.features.chat.presentation.audio.VoiceRecorder
+import must.kdroiders.hustlehub.ui.features.chat.presentation.components.ChatLocationPickerSheet
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.DateSeparator
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.MessageBubble
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ChatDetailViewModel
@@ -133,7 +134,7 @@ fun ChatDetailScreen(
     var isRecording by remember { mutableStateOf(false) }
     var recordingDurationSeconds by remember { mutableIntStateOf(0) }
     var recordingFile by remember { mutableStateOf<File?>(null) }
-    var showLocationDialog by remember { mutableStateOf(false) }
+    var showLocationPickerSheet by remember { mutableStateOf(false) }
     var showAttachmentMenu by remember { mutableStateOf(false) }
     // Fullscreen image viewer
     var selectedImageUrl by remember { mutableStateOf<String?>(null) }
@@ -154,50 +155,13 @@ fun ChatDetailScreen(
     val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
     var currentUserLocation by remember { mutableStateOf<android.location.Location?>(null) }
 
-    val shareCurrentLocation: () -> Unit = {
-        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as android.location.LocationManager
-        val isGpsEnabled = locationManager.isProviderEnabled(android.location.LocationManager.GPS_PROVIDER) ||
-            locationManager.isProviderEnabled(android.location.LocationManager.NETWORK_PROVIDER)
-
-        if (!isGpsEnabled) {
-            Toast.makeText(context, "GPS is disabled. Please enable it in Settings.", Toast.LENGTH_LONG).show()
-        } else {
-            val hasFineLocation = ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.ACCESS_FINE_LOCATION,
-            ) == PackageManager.PERMISSION_GRANTED
-            val hasCoarseLocation = ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.ACCESS_COARSE_LOCATION,
-            ) == PackageManager.PERMISSION_GRANTED
-
-            if (hasFineLocation || hasCoarseLocation) {
-                try {
-                    fusedLocationClient.lastLocation
-                        .addOnSuccessListener { location: android.location.Location? ->
-                            if (location != null) {
-                                currentUserLocation = location
-                                viewModel.sendLocationMessage(location.latitude, location.longitude, "Current Location")
-                            } else {
-                                Toast.makeText(context, "Could not retrieve location. Please try again.", Toast.LENGTH_SHORT).show()
-                            }
-                        }.addOnFailureListener { e ->
-                            Toast.makeText(context, "Error getting location: ${e.message}", Toast.LENGTH_SHORT).show()
-                        }
-                } catch (e: SecurityException) {
-                    Toast.makeText(context, "Permission error: ${e.message}", Toast.LENGTH_SHORT).show()
-                }
-            }
-        }
-    }
-
     val locationPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions(),
     ) { permissions ->
         val granted = permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
             permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true
         if (granted) {
-            shareCurrentLocation()
+            showLocationPickerSheet = true
         } else {
             Toast.makeText(context, "Location permission denied. Cannot share location.", Toast.LENGTH_SHORT).show()
         }
@@ -214,7 +178,7 @@ fun ChatDetailScreen(
         ) == PackageManager.PERMISSION_GRANTED
 
         if (hasFineLocation || hasCoarseLocation) {
-            shareCurrentLocation()
+            showLocationPickerSheet = true
         } else {
             locationPermissionLauncher.launch(
                 arrayOf(
@@ -360,13 +324,13 @@ fun ChatDetailScreen(
         }
     }
 
-    // Dialog to select preset location to share
-    if (showLocationDialog) {
-        LocationSelectorDialog(
-            onDismiss = { showLocationDialog = false },
+    // Location picker sheet (WhatsApp style)
+    if (showLocationPickerSheet) {
+        ChatLocationPickerSheet(
+            onDismiss = { showLocationPickerSheet = false },
             onLocationSelected = { lat, lng, label ->
                 viewModel.sendLocationMessage(lat, lng, label)
-                showLocationDialog = false
+                showLocationPickerSheet = false
             },
         )
     }
@@ -971,69 +935,6 @@ private fun AttachmentOption(
     }
 }
 
-@Composable
-private fun LocationSelectorDialog(
-    onDismiss: () -> Unit,
-    onLocationSelected: (Double, Double, String) -> Unit,
-) {
-    val locations = listOf(
-        Triple(0.0515, 37.6456, "Hostel C"),
-        Triple(0.0530, 37.6480, "Main Library"),
-        Triple(0.0505, 37.6440, "Student Center"),
-        Triple(0.0485, 37.6425, "Main Gate"),
-    )
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Share Location") },
-        text = {
-            Column {
-                Text(
-                    text = "Choose a campus location to share:",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(bottom = 12.dp),
-                )
-                locations.forEach { (lat, lng, label) ->
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 4.dp)
-                            .clickable { onLocationSelected(lat, lng, label) },
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
-                        ),
-                    ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(12.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.LocationOn,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                            )
-                            Spacer(modifier = Modifier.width(12.dp))
-                            Text(
-                                text = label,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {},
-        dismissButton = {
-            IconButton(onClick = onDismiss) {
-                Text("Cancel", color = MaterialTheme.colorScheme.primary)
-            }
-        },
-    )
-}
 
 private fun formatSeconds(totalSeconds: Int): String {
     val minutes = totalSeconds / 60

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -431,7 +431,6 @@ fun ChatDetailScreen(
     HustleScaffold(
         topBar = {
             TopAppBar(
-                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -22,7 +22,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -427,9 +429,10 @@ fun ChatDetailScreen(
         }
     }
 
-    Scaffold(
+    HustleScaffold(
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -1,7 +1,6 @@
 package must.kdroiders.hustlehub.ui.features.chat.presentation.view
 
 import android.Manifest
-import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.widget.Toast
@@ -18,7 +17,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -44,9 +42,6 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Mic
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -934,7 +929,6 @@ private fun AttachmentOption(
         )
     }
 }
-
 
 private fun formatSeconds(totalSeconds: Int): String {
     val minutes = totalSeconds / 60

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -18,13 +18,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
-import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -56,7 +55,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SuggestionChip
@@ -98,6 +96,7 @@ import must.kdroiders.hustlehub.core.notification.ActiveConversationTracker
 import must.kdroiders.hustlehub.core.utils.ImageCompressor
 import must.kdroiders.hustlehub.core.utils.createTempCameraFile
 import must.kdroiders.hustlehub.core.utils.saveImageToGallery
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.MessageType
 import must.kdroiders.hustlehub.ui.features.chat.presentation.audio.VoiceRecorder
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.DateSeparator

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.sharedComposables.EmptyStateView
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
@@ -62,9 +62,9 @@ import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.Conversa
 fun ChatScreen(
     onNavigateToChatDetail: (String) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: ConversationListViewModel = hiltViewModel(),
+    conversationListViewModel: ConversationListViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val state by conversationListViewModel.uiState.collectAsState()
 
     HustleScaffold(
         topBar = {
@@ -112,7 +112,7 @@ fun ChatScreen(
                     val pullToRefreshState = rememberPullToRefreshState()
                     PullToRefreshBox(
                         isRefreshing = state.isRefreshing,
-                        onRefresh = viewModel::refreshConversations,
+                        onRefresh = conversationListViewModel::refreshConversations,
                         modifier = Modifier.fillMaxSize(),
                         state = pullToRefreshState,
                         indicator = {
@@ -136,7 +136,7 @@ fun ChatScreen(
                                 val dismissState = rememberSwipeToDismissBoxState(
                                     confirmValueChange = { dismissValue ->
                                         if (dismissValue == SwipeToDismissBoxValue.EndToStart) {
-                                            viewModel.deleteConversation(conversation.id)
+                                            conversationListViewModel.deleteConversation(conversation.id)
                                             true
                                         } else {
                                             false

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -53,13 +53,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import must.kdroiders.hustlehub.sharedComposables.EmptyStateView
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Conversation
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ConversationListViewModel
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -65,9 +67,10 @@ fun ChatScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
 
-    Scaffold(
+    HustleScaffold(
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Text(
                         text = "Messages",

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -53,6 +53,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import must.kdroiders.hustlehub.sharedComposables.EmptyStateView
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Conversation
@@ -334,16 +337,18 @@ private fun ConversationItem(
 }
 
 private fun formatTimestamp(isoString: String?): String {
-    if (isoString == null) return ""
+    if (isoString.isNullOrBlank()) return ""
     return try {
-        val parts = isoString.split("T")
-        if (parts.size >= 2) {
-            val time = parts[1].substring(0, 5) // "HH:MM"
-            time
-        } else {
+        val instant = Instant.parse(isoString)
+        val zonedDateTime = instant.atZone(ZoneId.systemDefault())
+        val formatter = DateTimeFormatter.ofPattern("HH:mm")
+        zonedDateTime.format(formatter)
+    } catch (e: Exception) {
+        try {
+            val parts = isoString.split("T")
+            if (parts.size >= 2) parts[1].substring(0, 5) else isoString
+        } catch (_: Exception) {
             isoString
         }
-    } catch (e: Exception) {
-        isoString
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -8,12 +8,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
-import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -31,7 +30,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
@@ -55,6 +53,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.sharedComposables.EmptyStateView
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Conversation
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ConversationListViewModel
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -25,8 +25,9 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Work
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -57,7 +58,7 @@ import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.Conversation
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ConversationListViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ChatScreen(
     onNavigateToChatDetail: (String) -> Unit,
@@ -93,7 +94,7 @@ fun ChatScreen(
         ) {
             when {
                 state.isLoading && !state.isRefreshing -> {
-                    CircularProgressIndicator(
+                    CircularWavyProgressIndicator(
                         modifier = Modifier.align(Alignment.Center),
                         color = MaterialTheme.colorScheme.primary,
                     )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/data/repository/AiSearchRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/data/repository/AiSearchRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package must.kdroiders.hustlehub.ui.features.home.data.repository
 
+import kotlinx.coroutines.CancellationException
 import must.kdroiders.hustlehub.ui.features.home.data.remote.AiSearchRequest
 import must.kdroiders.hustlehub.ui.features.home.data.remote.AiSearchResponse
 import must.kdroiders.hustlehub.ui.features.home.data.remote.DiscoveryApiService
@@ -48,18 +49,15 @@ class AiSearchRepositoryImpl(
             }
         }
 
-        return try {
+        return runCatching {
             val request = AiSearchRequest(query = query, userLocation = userLocation, maxResults = maxResults)
             val response = discoveryApiService.aiSearch(request)
-            if (response.success && response.data != null) {
-                cache[cacheKey] = now to response.data
-                Result.success(response.data)
-            } else {
-                Result.failure(Exception(response.message))
-            }
-        } catch (e: Exception) {
+            check(response.success && response.data != null) { response.message ?: "AI search failed" }
+            cache[cacheKey] = now to response.data
+            response.data
+        }.onFailure { e ->
+            if (e is CancellationException) throw e
             Timber.w(e, "AI search network failure for query='$query'")
-            Result.failure(e)
         }
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/AvailableNowGrid.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/AvailableNowGrid.kt
@@ -104,8 +104,7 @@ fun LiveServiceCard(
             .clickable {
                 Toast.makeText(context, "Coming soon", Toast.LENGTH_SHORT).show()
                 onServiceClick(service.id)
-            }
-            .padding(bottom = 12.dp),
+            }.padding(bottom = 12.dp),
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/AvailableNowGrid.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/AvailableNowGrid.kt
@@ -1,5 +1,6 @@
 package must.kdroiders.hustlehub.ui.features.home.presentation.components
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -28,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -90,13 +92,19 @@ fun AvailableNowGrid(
 @Composable
 fun LiveServiceCard(
     service: LiveService,
+    onServiceClick: (serviceId: String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+
     Column(
         modifier = modifier
             .clip(RoundedCornerShape(16.dp))
             .background(MaterialTheme.colorScheme.surface)
-            .clickable { /* TODO: navigate to service detail */ }
+            .clickable {
+                Toast.makeText(context, "Coming soon", Toast.LENGTH_SHORT).show()
+                onServiceClick(service.id)
+            }
             .padding(bottom = 12.dp),
     ) {
         Box(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
@@ -1,5 +1,6 @@
 package must.kdroiders.hustlehub.ui.features.home.presentation.components
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -27,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -36,8 +38,11 @@ fun HomeTopBar(
     initials: String,
     notificationCount: Int,
     onNotificationClick: () -> Unit,
+    onProfileClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -121,7 +126,13 @@ fun HomeTopBar(
                         ),
                         shape = CircleShape,
                     ).background(MaterialTheme.colorScheme.surfaceVariant)
-                    .clickable { /* TODO: navigate to profile */ },
+                    .clickable {
+                        if (onProfileClick != null) {
+                            onProfileClick()
+                        } else {
+                            Toast.makeText(context, "Coming soon", Toast.LENGTH_SHORT).show()
+                        }
+                    },
                 contentAlignment = Alignment.Center,
             ) {
                 Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/ProviderBannerCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/ProviderBannerCard.kt
@@ -1,0 +1,117 @@
+package must.kdroiders.hustlehub.ui.features.home.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Storefront
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import must.kdroiders.hustlehub.R
+import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleButtonVariant
+import must.kdroiders.hustlehub.sharedComposables.HustleCard
+import must.kdroiders.hustlehub.sharedComposables.HustleCardVariant
+
+@Composable
+fun ProviderBannerCard(
+    onListServiceClick: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val gradientBrush = Brush.horizontalGradient(
+        colors = listOf(
+            MaterialTheme.colorScheme.primary,
+            MaterialTheme.colorScheme.secondary,
+        ),
+    )
+
+    HustleCard(
+        variant = HustleCardVariant.Glass,
+        modifier = modifier,
+    ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.fillMaxWidth().padding(end = 32.dp)) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(gradientBrush)
+                        .padding(horizontal = 10.dp, vertical = 6.dp),
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Outlined.Storefront,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            text = stringResource(R.string.banner_provider_label),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(10.dp))
+
+                Text(
+                    text = stringResource(R.string.banner_provider_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Spacer(Modifier.height(4.dp))
+
+                Text(
+                    text = stringResource(R.string.banner_provider_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(Modifier.height(14.dp))
+
+                HustleButton(
+                    text = stringResource(R.string.banner_provider_action),
+                    onClick = onListServiceClick,
+                    variant = HustleButtonVariant.Primary,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.TopEnd),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.banner_provider_dismiss),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/TopHustlersRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/TopHustlersRow.kt
@@ -1,5 +1,6 @@
 package must.kdroiders.hustlehub.ui.features.home.presentation.components
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -29,27 +30,58 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.ui.features.home.domain.model.TopHustler
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceCategory
-import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
 
 @Composable
 fun TopHustlersRow(
     hustlers: List<TopHustler>,
+    onHustlerClick: (hustlerId: String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    if (hustlers.isEmpty()) return
+
+    Column(modifier = modifier) {
+        TopHustlersHeader()
+        Spacer(modifier = Modifier.height(12.dp))
+        TopHustlersCarousel(hustlers = hustlers, onHustlerClick = onHustlerClick)
+    }
+}
+
+@Composable
+fun TopHustlersHeader(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "Top Hustlers",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+fun TopHustlersCarousel(
+    hustlers: List<TopHustler>,
+    onHustlerClick: (hustlerId: String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     LazyRow(
-        modifier = modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(horizontal = 16.dp),
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 0.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         items(items = hustlers, key = { it.id }) { hustler ->
-            TopHustlerCard(hustler = hustler)
+            TopHustlerCard(hustler = hustler, onHustlerClick = onHustlerClick)
         }
     }
 }
@@ -57,15 +89,21 @@ fun TopHustlersRow(
 @Composable
 fun TopHustlerCard(
     hustler: TopHustler,
+    onHustlerClick: (hustlerId: String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+
     Box(
         modifier = modifier
             .width(180.dp)
             .height(240.dp)
             .clip(RoundedCornerShape(16.dp))
             .background(MaterialTheme.colorScheme.surface)
-            .clickable { /* TODO: navigate to service detail */ },
+            .clickable {
+                Toast.makeText(context, "Coming soon", Toast.LENGTH_SHORT).show()
+                onHustlerClick(hustler.id)
+            },
     ) {
         // Hero image (placeholder gradient when no URL)
         Box(
@@ -83,74 +121,72 @@ fun TopHustlerCard(
                     ),
                 ),
         ) {
-            // Load actual image if URL provided
             if (hustler.imageUrl.isNotBlank()) {
                 AsyncImage(
                     model = hustler.imageUrl,
-                    contentDescription = hustler.serviceTitle,
-                    contentScale = ContentScale.Crop,
+                    contentDescription = hustler.providerName,
                     modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
                 )
-            }
-
-            // Rating badge
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(8.dp)
-                    .clip(RoundedCornerShape(20.dp))
-                    .background(Color.Black.copy(alpha = 0.55f))
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.Star,
-                        contentDescription = null,
-                        tint = HustleWarningAmber,
-                        modifier = Modifier.size(12.dp),
-                    )
-                    Spacer(Modifier.width(3.dp))
-                    Text(
-                        text = hustler.rating.toString(),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 11.sp,
-                    )
-                }
             }
         }
 
-        // Bottom info
+        // Card info bottom overlay
         Column(
             modifier = Modifier
-                .align(Alignment.BottomStart)
                 .fillMaxWidth()
-                .padding(start = 10.dp, end = 10.dp, bottom = 10.dp, top = 6.dp),
+                .align(Alignment.BottomStart)
+                .padding(12.dp),
         ) {
             Text(
-                text = hustler.category.label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 11.sp,
-            )
-            Text(
-                text = hustler.serviceTitle,
+                text = hustler.providerName,
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                fontSize = 13.sp,
             )
-            Spacer(Modifier.height(2.dp))
+
+            Spacer(modifier = Modifier.height(2.dp))
+
             Text(
-                text = hustler.priceLabel,
-                style = MaterialTheme.typography.labelSmall,
+                text = hustler.serviceTitle,
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 11.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = "Rating",
+                        tint = Color(0xFFFFB300),
+                        modifier = Modifier.size(14.dp),
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = "%.1f".format(hustler.rating),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+
+                Text(
+                    text = hustler.priceLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/AiSearchScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/AiSearchScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -17,7 +18,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/AiSearchScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/AiSearchScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
@@ -82,6 +83,7 @@ fun AiSearchScreen(
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             TopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = { Text("AI Search", fontWeight = FontWeight.SemiBold) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -1,5 +1,10 @@
 package must.kdroiders.hustlehub.ui.features.home.presentation.view
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -51,6 +56,7 @@ import must.kdroiders.hustlehub.ui.features.home.presentation.components.EmptySe
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.FeaturedServicesRow
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.HomeSearchBar
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.HomeTopBar
+import must.kdroiders.hustlehub.ui.features.home.presentation.components.ProviderBannerCard
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCard
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCardShimmer
 import must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel.HomeViewModel
@@ -77,6 +83,7 @@ fun HomeScreen(
     onNavigateToSearch: () -> Unit = {},
     onNavigateToAiSearch: () -> Unit = {},
     onNavigateToNotifications: () -> Unit = {},
+    onNavigateToCreateService: () -> Unit = {},
 ) {
     val state by viewModel.uiState.collectAsState()
     val gridState = rememberLazyGridState()
@@ -159,6 +166,20 @@ fun HomeScreen(
                         notificationCount = state.notificationCount,
                         onNotificationClick = onNavigateToNotifications,
                     )
+                }
+
+                item(key = "provider_banner", span = { GridItemSpan(maxLineSpan) }) {
+                    AnimatedVisibility(
+                        visible = state.showProviderBanner,
+                        enter = expandVertically() + fadeIn(),
+                        exit = shrinkVertically() + fadeOut(),
+                    ) {
+                        ProviderBannerCard(
+                            onListServiceClick = onNavigateToCreateService,
+                            onDismiss = viewModel::dismissProviderBanner,
+                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+                        )
+                    }
                 }
 
                 item(key = "searchbar", span = { GridItemSpan(maxLineSpan) }) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -61,6 +61,7 @@ import must.kdroiders.hustlehub.ui.features.home.presentation.components.Service
 import must.kdroiders.hustlehub.ui.features.home.presentation.components.ServiceCardShimmer
 import must.kdroiders.hustlehub.ui.features.home.presentation.viewmodel.HomeViewModel
 import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
+import must.kdroiders.hustlehub.ui.theme.LocalDimensions
 
 /** Number of shimmer placeholders shown while the initial page loads. */
 private const val SHIMMER_COUNT = 6
@@ -119,6 +120,8 @@ fun HomeScreen(
         }
     }
 
+    val dimensions = LocalDimensions.current
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -142,21 +145,21 @@ fun HomeScreen(
             },
         ) {
             LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
+                columns = GridCells.Fixed(dimensions.gridColumns),
                 state = gridState,
                 modifier = Modifier
                     .fillMaxSize()
                     .statusBarsPadding()
                     .testTag("home_service_grid"),
                 contentPadding = PaddingValues(
-                    start = 12.dp,
-                    end = 12.dp,
+                    start = dimensions.horizontalPadding,
+                    end = dimensions.horizontalPadding,
                     bottom = 100.dp,
                 ),
                 verticalArrangement = androidx.compose.foundation.layout.Arrangement
-                    .spacedBy(12.dp),
+                    .spacedBy(dimensions.gridSpacing),
                 horizontalArrangement = androidx.compose.foundation.layout.Arrangement
-                    .spacedBy(12.dp),
+                    .spacedBy(dimensions.gridSpacing),
             ) {
                 // Header items span both columns.
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/view/HomeScreen.kt
@@ -149,7 +149,6 @@ fun HomeScreen(
                 state = gridState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .statusBarsPadding()
                     .testTag("home_service_grid"),
                 contentPadding = PaddingValues(
                     start = dimensions.horizontalPadding,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/viewmodel/HomeViewModel.kt
@@ -8,11 +8,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.core.auth.AuthManager
+import must.kdroiders.hustlehub.datastore.UserPreferences
 import must.kdroiders.hustlehub.ui.features.home.domain.usecase.BrowseServicesUseCase
 import must.kdroiders.hustlehub.ui.features.notification.domain.repository.NotificationRepository
+import must.kdroiders.hustlehub.ui.features.profile.domain.model.UserRole
 import must.kdroiders.hustlehub.ui.features.profile.domain.repository.UserRepository
 import must.kdroiders.hustlehub.ui.features.profile.domain.util.HustleScoreCalculator
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Service
@@ -27,9 +30,7 @@ data class HomeUiState(
     val searchQuery: String = "",
     val providerInitials: String = "HH",
     val notificationCount: Int = 0,
-    // Paginated real services from backend
     val services: List<Service> = emptyList(),
-    /** Top 5 highest-rated services derived from the loaded list — powers the Featured row. */
     val featuredServices: List<Service> = emptyList(),
     val isLoadingServices: Boolean = false,
     val isRefreshing: Boolean = false,
@@ -38,6 +39,7 @@ data class HomeUiState(
     val currentPage: Int = 0,
     val error: String? = null,
     val isLoading: Boolean = false,
+    val showProviderBanner: Boolean = false,
 )
 
 @HiltViewModel
@@ -48,6 +50,7 @@ class HomeViewModel
         private val authManager: AuthManager,
         private val userRepository: UserRepository,
         private val notificationRepository: NotificationRepository,
+        private val userPreferences: UserPreferences,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(HomeUiState())
         val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
@@ -58,6 +61,24 @@ class HomeViewModel
             loadUserInitials()
             fetchServices(reset = true)
             loadNotificationCount()
+            observeProviderBannerVisibility()
+        }
+
+        private fun observeProviderBannerVisibility() {
+            viewModelScope.launch {
+                combine(
+                    userPreferences.cachedUser,
+                    userPreferences.isProviderBannerDismissed,
+                ) { user, dismissed ->
+                    !dismissed && user.role == UserRole.CUSTOMER
+                }.collect { show ->
+                    _uiState.update { it.copy(showProviderBanner = show) }
+                }
+            }
+        }
+
+        fun dismissProviderBanner() {
+            viewModelScope.launch { userPreferences.dismissProviderBanner() }
         }
 
         private fun loadNotificationCount() {
@@ -85,6 +106,7 @@ class HomeViewModel
                                 parts[0].take(2).uppercase()
                             }
                             _uiState.update { it.copy(providerInitials = initials) }
+                            userPreferences.writeUser(user)
                         }
                     }
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/MapScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/MapScreen.kt
@@ -143,10 +143,16 @@ fun MapScreen(
     // Map Properties & UI settings
     val mapProperties = remember(mapType, isLocationPermissionGranted, isSystemInDark) {
         val styleJson = if (isSystemInDark) MapTheme.DARK_JSON else MapTheme.LIGHT_JSON
+        val styleOptions = try {
+            MapStyleOptions(styleJson)
+        } catch (e: Exception) {
+            Timber.e(e, "Error loading map style options")
+            null
+        }
         MapProperties(
             mapType = mapType,
             isMyLocationEnabled = isLocationPermissionGranted,
-            mapStyleOptions = MapStyleOptions(styleJson),
+            mapStyleOptions = styleOptions,
             minZoomPreference = MapDefaults.MIN_ZOOM,
             maxZoomPreference = MapDefaults.MAX_ZOOM,
         )
@@ -249,16 +255,18 @@ fun MapScreen(
                     true
                 },
                 clusterContent = { cluster ->
+                    val glowColor = MaterialTheme.colorScheme.primary
                     Box(
                         modifier = Modifier
-                            .size(44.dp)
-                            .background(Color(0xFF7C4DFF), shape = CircleShape)
-                            .border(2.dp, Color.White, shape = CircleShape),
+                            .size(46.dp)
+                            .border(3.dp, glowColor.copy(alpha = 0.35f), shape = CircleShape)
+                            .background(glowColor, shape = CircleShape)
+                            .border(2.dp, MaterialTheme.colorScheme.surface, shape = CircleShape),
                         contentAlignment = Alignment.Center,
                     ) {
                         Text(
                             text = cluster.size.toString(),
-                            color = Color.White,
+                            color = MaterialTheme.colorScheme.onPrimary,
                             fontWeight = FontWeight.Bold,
                             fontSize = 14.sp,
                         )
@@ -420,7 +428,8 @@ fun MapScreen(
                     FilterChip(
                         selected = isSelected,
                         onClick = {
-                            mapViewModel.selectCategory(if (category == ServiceCategory.ALL) null else category)
+                            val targetCategory = if (isSelected || category == ServiceCategory.ALL) null else category
+                            mapViewModel.selectCategory(targetCategory)
                         },
                         label = { Text(label, fontSize = 11.sp, fontWeight = FontWeight.SemiBold) },
                         leadingIcon = {
@@ -434,9 +443,20 @@ fun MapScreen(
                             }
                         },
                         colors = FilterChipDefaults.filterChipColors(
+                            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+                            labelColor = MaterialTheme.colorScheme.onSurface,
+                            iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
                             selectedContainerColor = MaterialTheme.colorScheme.primary,
                             selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
                             selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                        border = FilterChipDefaults.filterChipBorder(
+                            enabled = true,
+                            selected = isSelected,
+                            borderColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f),
+                            selectedBorderColor = Color.Transparent,
+                            borderWidth = 1.dp,
+                            selectedBorderWidth = 0.dp,
                         ),
                     )
                 }
@@ -470,8 +490,20 @@ fun MapScreen(
                         }
                     },
                     colors = FilterChipDefaults.filterChipColors(
-                        selectedContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
-                        selectedLabelColor = MaterialTheme.colorScheme.primary,
+                        containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+                        labelColor = MaterialTheme.colorScheme.onSurface,
+                        iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        selectedContainerColor = MaterialTheme.colorScheme.primary,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                        selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+                    border = FilterChipDefaults.filterChipBorder(
+                        enabled = true,
+                        selected = isAvailableOnly,
+                        borderColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f),
+                        selectedBorderColor = Color.Transparent,
+                        borderWidth = 1.dp,
+                        selectedBorderWidth = 0.dp,
                     ),
                 )
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/MapScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/MapScreen.kt
@@ -276,6 +276,9 @@ fun MapScreen(
                     ProviderMarkerContent(pin = pin)
                 },
             )
+
+
+
         }
 
         // 2. Top Floating HUD (Search + Chips + Stats)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/MapScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/MapScreen.kt
@@ -276,9 +276,6 @@ fun MapScreen(
                     ProviderMarkerContent(pin = pin)
                 },
             )
-
-
-
         }
 
         // 2. Top Floating HUD (Search + Chips + Stats)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/MapTheme.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/MapTheme.kt
@@ -1,309 +1,216 @@
 package must.kdroiders.hustlehub.ui.features.map.presentation.view
 
 object MapTheme {
+    // ═══════════════════════════════════════════════════════════════
+    // 🌙 DARK MODE — "Charcoal Slate"
+    // Matte dark grey charcoal base (#16181D). High-contrast steel roads.
+    // Highways pulse with indigo edges. Water is deep navy ocean.
+    // Inspired by: Apple Maps Dark, Mapbox Studio Charcoal, Slate UI.
+    // ═══════════════════════════════════════════════════════════════
     const val DARK_JSON = """[
   {
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#0d0d1a"
-      }
-    ]
+    "stylers": [{ "color": "#16181d" }]
   },
   {
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#8e8eb3"
-      }
-    ]
+    "stylers": [{ "color": "#e2e8f0" }]
   },
   {
     "elementType": "labels.text.stroke",
-    "stylers": [
-      {
-        "color": "#0d0d1a"
-      }
-    ]
+    "stylers": [{ "color": "#16181d" }]
   },
   {
     "featureType": "administrative",
     "elementType": "geometry.stroke",
-    "stylers": [
-      {
-        "color": "#1a1a3a"
-      }
-    ]
+    "stylers": [{ "color": "#2d323e" }]
   },
   {
     "featureType": "administrative.land_parcel",
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#64648c"
-      }
-    ]
+    "stylers": [{ "color": "#788394" }]
+  },
+  {
+    "featureType": "landscape.man_made",
+    "elementType": "geometry",
+    "stylers": [{ "color": "#1f222a" }]
   },
   {
     "featureType": "landscape.natural",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#0d0d1a"
-      }
-    ]
+    "stylers": [{ "color": "#16181d" }]
   },
   {
     "featureType": "poi",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#131326"
-      }
-    ]
+    "stylers": [{ "color": "#1f222a" }]
   },
   {
     "featureType": "poi",
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#7c4dff"
-      }
-    ]
+    "stylers": [{ "color": "#788394" }]
   },
   {
     "featureType": "poi.park",
     "elementType": "geometry.fill",
-    "stylers": [
-      {
-        "color": "#11221a"
-      }
-    ]
+    "stylers": [{ "color": "#11241a" }]
   },
   {
     "featureType": "poi.park",
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#3cd070"
-      }
-    ]
+    "stylers": [{ "color": "#3fb950" }]
   },
   {
     "featureType": "road",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#1a1a35"
-      }
-    ]
+    "stylers": [{ "color": "#2a2e39" }]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry.stroke",
+    "stylers": [{ "color": "#383e4c" }]
   },
   {
     "featureType": "road.arterial",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#202047"
-      }
-    ]
+    "stylers": [{ "color": "#323846" }]
+  },
+  {
+    "featureType": "road.arterial",
+    "elementType": "geometry.stroke",
+    "stylers": [{ "color": "#454c5e" }]
   },
   {
     "featureType": "road.highway",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#2a2a60"
-      }
-    ]
+    "stylers": [{ "color": "#3e465b" }]
   },
   {
     "featureType": "road.highway",
     "elementType": "geometry.stroke",
-    "stylers": [
-      {
-        "color": "#7c4dff"
-      }
-    ]
+    "stylers": [{ "color": "#818cf8" }]
   },
   {
     "featureType": "road.local",
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#8c8cb5"
-      }
-    ]
+    "stylers": [{ "color": "#a0aec0" }]
   },
   {
     "featureType": "transit",
-    "elementType": "line",
-    "stylers": [
-      {
-        "color": "#2a2a50"
-      }
-    ]
+    "elementType": "geometry",
+    "stylers": [{ "color": "#2b303d" }]
   },
   {
     "featureType": "water",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#06060c"
-      }
-    ]
+    "stylers": [{ "color": "#0e1f34" }]
   },
   {
     "featureType": "water",
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#3d3d5c"
-      }
-    ]
+    "stylers": [{ "color": "#58a6ff" }]
   }
 ]"""
 
+    // ═══════════════════════════════════════════════════════════════
+    // ☀️ LIGHT MODE — "Warm Parchment"
+    // Warm cream/ivory base (NOT cold grey). Roads are crisp white
+    // with visible warm-grey edges. Highways are golden amber.
+    // Water is calm sky blue. Parks are natural sage.
+    // Inspired by: Apple Maps, classic cartography, Snazzy Maps.
+    // ═══════════════════════════════════════════════════════════════
     const val LIGHT_JSON = """[
   {
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#f8f9fa"
-      }
-    ]
+    "stylers": [{ "color": "#edebe4" }]
   },
   {
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#495057"
-      }
-    ]
+    "stylers": [{ "color": "#3d3d35" }]
   },
   {
     "elementType": "labels.text.stroke",
-    "stylers": [
-      {
-        "color": "#ffffff"
-      }
-    ]
+    "stylers": [{ "color": "#ffffff" }]
   },
   {
     "featureType": "administrative",
     "elementType": "geometry.stroke",
-    "stylers": [
-      {
-        "color": "#dee2e6"
-      }
-    ]
+    "stylers": [{ "color": "#c8c6be" }]
+  },
+  {
+    "featureType": "landscape.man_made",
+    "elementType": "geometry",
+    "stylers": [{ "color": "#e0ded7" }]
   },
   {
     "featureType": "landscape.natural",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#f1f3f5"
-      }
-    ]
+    "stylers": [{ "color": "#edebe4" }]
   },
   {
     "featureType": "poi",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#e9ecef"
-      }
-    ]
+    "stylers": [{ "color": "#e0ded7" }]
   },
   {
     "featureType": "poi",
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#7c4dff"
-      }
-    ]
+    "stylers": [{ "color": "#78766e" }]
   },
   {
     "featureType": "poi.park",
     "elementType": "geometry.fill",
-    "stylers": [
-      {
-        "color": "#e2f0d9"
-      }
-    ]
+    "stylers": [{ "color": "#c5e1b8" }]
   },
   {
     "featureType": "poi.park",
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#2e7d32"
-      }
-    ]
+    "stylers": [{ "color": "#2d8a30" }]
   },
   {
     "featureType": "road",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#ffffff"
-      }
-    ]
+    "stylers": [{ "color": "#ffffff" }]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry.stroke",
+    "stylers": [{ "color": "#c8c6be" }]
   },
   {
     "featureType": "road.arterial",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#f8f9fa"
-      }
-    ]
+    "stylers": [{ "color": "#ffffff" }]
   },
   {
     "featureType": "road.arterial",
     "elementType": "geometry.stroke",
-    "stylers": [
-      {
-        "color": "#e9ecef"
-      }
-    ]
+    "stylers": [{ "color": "#a8a69e" }]
   },
   {
     "featureType": "road.highway",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#fff3cd"
-      }
-    ]
+    "stylers": [{ "color": "#fde68a" }]
   },
   {
     "featureType": "road.highway",
     "elementType": "geometry.stroke",
-    "stylers": [
-      {
-        "color": "#ffeeba"
-      }
-    ]
+    "stylers": [{ "color": "#d97706" }]
+  },
+  {
+    "featureType": "road.local",
+    "elementType": "labels.text.fill",
+    "stylers": [{ "color": "#4a4842" }]
   },
   {
     "featureType": "water",
     "elementType": "geometry",
-    "stylers": [
-      {
-        "color": "#c5e3fc"
-      }
-    ]
+    "stylers": [{ "color": "#9dc8e8" }]
   },
   {
     "featureType": "water",
     "elementType": "labels.text.fill",
-    "stylers": [
-      {
-        "color": "#495057"
-      }
-    ]
+    "stylers": [{ "color": "#1a6b9c" }]
   }
 ]"""
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/components/MapComponents.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/components/MapComponents.kt
@@ -37,6 +37,7 @@ import must.kdroiders.hustlehub.ui.features.map.domain.model.MapPin
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceCategory
 import kotlin.math.*
 
+
 @Composable
 fun ProviderMarkerContent(pin: MapPin) {
     val (icon, baseColor) = getCategoryIconAndColor(pin.category)
@@ -234,3 +235,4 @@ fun formatDistance(meters: Double): String {
         String.format(java.util.Locale.US, "%.1fkm away", km)
     }
 }
+

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/components/MapComponents.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/components/MapComponents.kt
@@ -37,7 +37,6 @@ import must.kdroiders.hustlehub.ui.features.map.domain.model.MapPin
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceCategory
 import kotlin.math.*
 
-
 @Composable
 fun ProviderMarkerContent(pin: MapPin) {
     val (icon, baseColor) = getCategoryIconAndColor(pin.category)
@@ -235,4 +234,3 @@ fun formatDistance(meters: Double): String {
         String.format(java.util.Locale.US, "%.1fkm away", km)
     }
 }
-

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/components/MapComponents.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/view/components/MapComponents.kt
@@ -44,28 +44,36 @@ fun ProviderMarkerContent(pin: MapPin) {
         when (pin.category) {
             ServiceCategory.SALON -> Color(0xFFB388FF) // Neon light purple
             ServiceCategory.LAUNDRY -> Color(0xFF80D8FF) // Neon cyan/blue
-            ServiceCategory.TUTORING -> Color(0xFF69F0AE) // Neon green
-            ServiceCategory.FOOD -> Color(0xFFFFD740) // Neon yellow/orange
-            ServiceCategory.TECH -> Color(0xFF64FFDA) // Neon teal
+            ServiceCategory.TUTORING -> Color(0xFF00E676) // Neon vibrant green
+            ServiceCategory.FOOD -> Color(0xFFFFB300) // Neon amber/gold
+            ServiceCategory.TECH -> Color(0xFF00E5FF) // Neon cyan
             ServiceCategory.FASHION -> Color(0xFF82B1FF) // Neon blue/indigo
             ServiceCategory.PHOTOGRAPHY -> Color(0xFFFF4081) // Neon pink
             else -> Color(0xFFE0E0E0)
         }
     }
 
+    val pillBgColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+    val titleTextColor = MaterialTheme.colorScheme.onSurface
+    val subtitleTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.width(IntrinsicSize.Max),
     ) {
-        // Pill Layout
+        // Pill Layout with Glowing Neon Outer Halo
         Row(
             modifier = Modifier
-                .background(
-                    color = Color(0xFF131324).copy(alpha = 0.92f),
+                .border(
+                    width = 3.dp,
+                    color = neonColor.copy(alpha = 0.35f),
+                    shape = RoundedCornerShape(26.dp),
+                ).background(
+                    color = pillBgColor,
                     shape = RoundedCornerShape(24.dp),
                 ).border(
                     width = 1.5.dp,
-                    color = neonColor.copy(alpha = 0.85f),
+                    color = neonColor,
                     shape = RoundedCornerShape(24.dp),
                 ).padding(horizontal = 10.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -76,7 +84,7 @@ fun ProviderMarkerContent(pin: MapPin) {
                 modifier = Modifier
                     .size(24.dp)
                     .background(
-                        color = baseColor.copy(alpha = 0.2f),
+                        color = baseColor.copy(alpha = 0.25f),
                         shape = CircleShape,
                     ),
                 contentAlignment = Alignment.Center,
@@ -95,7 +103,7 @@ fun ProviderMarkerContent(pin: MapPin) {
             ) {
                 Text(
                     text = pin.providerName,
-                    color = Color.White,
+                    color = titleTextColor,
                     fontWeight = FontWeight.Bold,
                     fontSize = 11.sp,
                     maxLines = 1,
@@ -107,13 +115,13 @@ fun ProviderMarkerContent(pin: MapPin) {
                 ) {
                     Text(
                         text = pin.category.label,
-                        color = Color.White.copy(alpha = 0.6f),
+                        color = subtitleTextColor,
                         fontSize = 9.sp,
                         fontWeight = FontWeight.Medium,
                     )
                     Text(
                         text = "•",
-                        color = Color.White.copy(alpha = 0.6f),
+                        color = subtitleTextColor,
                         fontSize = 9.sp,
                     )
                     Icon(
@@ -124,7 +132,7 @@ fun ProviderMarkerContent(pin: MapPin) {
                     )
                     Text(
                         text = String.format(java.util.Locale.US, "%.1f", pin.averageRating),
-                        color = Color.White.copy(alpha = 0.8f),
+                        color = titleTextColor,
                         fontSize = 9.sp,
                         fontWeight = FontWeight.Bold,
                     )
@@ -138,10 +146,10 @@ fun ProviderMarkerContent(pin: MapPin) {
                 .offset(y = (-4).dp)
                 .size(10.dp)
                 .graphicsLayer(rotationZ = 45f)
-                .background(Color(0xFF131324).copy(alpha = 0.92f))
+                .background(pillBgColor)
                 .border(
                     width = 1.5.dp,
-                    color = neonColor.copy(alpha = 0.85f),
+                    color = neonColor,
                     shape = RoundedCornerShape(topStart = 0.dp),
                 ),
         )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/map/presentation/viewmodel/MapViewModel.kt
@@ -29,7 +29,7 @@ import kotlin.math.sqrt
 data class MapUiState(
     val pins: List<MapPin> = emptyList(),
     val selectedCategory: ServiceCategory? = null,
-    val availability: ServiceAvailability? = ServiceAvailability.AVAILABLE,
+    val availability: ServiceAvailability? = null,
     val searchQuery: String = "",
     val notificationCount: Int = 0,
     val isLoading: Boolean = false,
@@ -161,8 +161,8 @@ class MapViewModel
             val userLoc = currentState.userLocation
             val lat = userLoc?.latitude
             val lng = userLoc?.longitude
-            // Use a 2 km radius when the user location is known
-            val radius = if (lat != null && lng != null) 2.0 else null
+            // Use a 50 km radius when the user location is known to catch campus & nearby providers
+            val radius = if (lat != null && lng != null) 50.0 else null
 
             getMapPinsUseCase(
                 lat = lat,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/remote/UserApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/remote/UserApiService.kt
@@ -15,6 +15,7 @@ data class UpdateProfileRequest(
     val avatarUrl: String? = null,
     val phone: String? = null,
     val campusLocation: String? = null,
+    val allowCalls: Boolean? = null,
 )
 
 data class OnlineStatusRequest(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImpl.kt
@@ -157,6 +157,7 @@ class UserRepositoryImpl
             phone: String,
             campusLocation: String,
             avatarUrl: String?,
+            allowCalls: Boolean,
         ): Result<User> =
             runCatching {
                 val request = UpdateProfileRequest(
@@ -165,6 +166,7 @@ class UserRepositoryImpl
                     avatarUrl = avatarUrl,
                     phone = phone.takeIf { it.isNotBlank() },
                     campusLocation = campusLocation.takeIf { it.isNotBlank() },
+                    allowCalls = allowCalls,
                 )
                 val response = userApiService.updateMe(request)
                 if (response.success && response.data != null) {
@@ -230,6 +232,7 @@ private fun UserResponseDto.toDomain(): User =
         bio = bio ?: "",
         isVerified = verified,
         isOnline = active,
+        allowCalls = allowCalls ?: false,
         hustleScore = hustleScore ?: 0f,
         reviewCount = reviewCount ?: 0,
         lat = lat,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/model/User.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/model/User.kt
@@ -22,5 +22,6 @@ data class User(
     val reviewCount: Int = 0,
     val lat: Double? = null,
     val lng: Double? = null,
+    val allowCalls: Boolean = false,
     val createdAt: Long = System.currentTimeMillis(),
 )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/repository/UserRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/repository/UserRepository.kt
@@ -69,6 +69,7 @@ interface UserRepository {
         phone: String,
         campusLocation: String,
         avatarUrl: String? = null,
+        allowCalls: Boolean = false,
     ): Result<User>
 
     /**

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/usecase/UpdateProfileUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/usecase/UpdateProfileUseCase.kt
@@ -13,5 +13,6 @@ class UpdateProfileUseCase
             phone: String,
             campusLocation: String,
             avatarUrl: String? = null,
-        ): Result<User> = repository.updateProfile(name, bio, phone, campusLocation, avatarUrl)
+            allowCalls: Boolean = false,
+        ): Result<User> = repository.updateProfile(name, bio, phone, campusLocation, avatarUrl, allowCalls)
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -88,7 +88,6 @@ fun EditProfileScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Text(
                         text = "Edit Profile",

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -8,9 +8,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -28,7 +28,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -7,8 +7,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,18 +19,25 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Call
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -43,6 +52,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
@@ -194,6 +204,66 @@ fun EditProfileScreen(
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
             )
+            Spacer(Modifier.height(16.dp))
+
+            // Phone Call Privacy Toggle Card
+            Card(
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f),
+                        shape = RoundedCornerShape(16.dp),
+                    ),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Call,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                            Text(
+                                text = "Allow Direct Calls",
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 14.sp,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = "Let clients call your phone number directly for urgent service requests.",
+                            fontSize = 12.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            lineHeight = 16.sp,
+                        )
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Switch(
+                        checked = state.allowCalls,
+                        onCheckedChange = viewModel::onAllowCallsChanged,
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                            checkedTrackColor = MaterialTheme.colorScheme.primary,
+                        ),
+                    )
+                }
+            }
 
             Spacer(Modifier.height(32.dp))
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -47,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.sharedComposables.HustleTextField
 import must.kdroiders.hustlehub.sharedComposables.LoadingIndicator
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.EditProfileViewModel
@@ -83,10 +85,11 @@ fun EditProfileScreen(
         }
     }
 
-    Scaffold(
+    HustleScaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Text(
                         text = "Edit Profile",
@@ -109,7 +112,7 @@ fun EditProfileScreen(
             LoadingIndicator(
                 modifier = Modifier.padding(innerPadding).fillMaxSize(),
             )
-            return@Scaffold
+            return@HustleScaffold
         }
 
         Column(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -137,6 +137,8 @@ private fun ProfileContent(
                     phone = user.phone,
                     campusLocation = user.campusLocation,
                     bio = user.bio,
+                    allowCalls = user.allowCalls,
+                    isOwnProfile = true,
                 )
             }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -1,5 +1,10 @@
 package must.kdroiders.hustlehub.ui.features.profile.presentation.view
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,6 +39,7 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileHeader
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileInfo
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileStatsRow
+import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProviderOnboardingCard
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ServiceCard
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ServicesHeader
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileUiState
@@ -167,6 +173,19 @@ private fun ProfileContent(
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
             Spacer(Modifier.height(12.dp))
+        }
+
+        item(key = "provider_onboarding") {
+            AnimatedVisibility(
+                visible = state.services.isEmpty(),
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                ProviderOnboardingCard(
+                    onCreateServiceClick = onAddNewServiceClick,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
         }
 
         // Service cards — each tappable to manage that specific service

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -68,7 +68,7 @@ fun ProfileScreen(
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
-        modifier = Modifier.fillMaxSize().statusBarsPadding(),
+        modifier = Modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.background,
     ) { innerPadding ->
         Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ErrorState
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.LoadingState
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileAvatar
@@ -44,6 +45,7 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ServicesHeader
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileUiState
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileViewModel
+import must.kdroiders.hustlehub.ui.theme.LocalDimensions
 
 @Composable
 fun ProfileScreen(
@@ -58,7 +60,7 @@ fun ProfileScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 
-    Scaffold(
+    HustleScaffold(
         topBar = {
             ProfileHeader(
                 onEditClick = onEditClick,
@@ -109,6 +111,7 @@ private fun ProfileContent(
     onShowSnackbar: (String) -> Unit = {},
 ) {
     val user = state.user ?: return
+    val horizontalPadding = LocalDimensions.current.horizontalPadding
 
     LazyColumn(
         modifier = Modifier
@@ -148,7 +151,7 @@ private fun ProfileContent(
                 serviceCount = state.services.size,
                 reviewCount = state.reviewCount,
                 modifier = Modifier.padding(
-                    horizontal = 16.dp,
+                    horizontal = horizontalPadding,
                 ),
             )
         }
@@ -159,7 +162,7 @@ private fun ProfileContent(
             ProfileBadges(
                 badges = state.badges,
                 modifier = Modifier.padding(
-                    horizontal = 16.dp,
+                    horizontal = horizontalPadding,
                 ),
             )
         }
@@ -170,7 +173,7 @@ private fun ProfileContent(
             ServicesHeader(
                 onAddNewServiceClick = onAddNewServiceClick,
                 onManageServicesClick = onNavigateToMyServices,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = horizontalPadding),
             )
             Spacer(Modifier.height(12.dp))
         }
@@ -183,7 +186,7 @@ private fun ProfileContent(
             ) {
                 ProviderOnboardingCard(
                     onCreateServiceClick = onAddNewServiceClick,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    modifier = Modifier.padding(horizontal = horizontalPadding, vertical = 4.dp),
                 )
             }
         }
@@ -200,7 +203,7 @@ private fun ProfileContent(
                     onToggleService(service.id)
                 },
                 modifier = Modifier.padding(
-                    horizontal = 16.dp,
+                    horizontal = horizontalPadding,
                     vertical = 6.dp,
                 ),
             )
@@ -210,7 +213,7 @@ private fun ProfileContent(
         item(key = "bottom_tabs") {
             Spacer(Modifier.height(20.dp))
             ProfileBottomTabs(
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = horizontalPadding),
                 onAnalyticsClick = { onShowSnackbar("Pay for premium to access it") },
                 onEarningsClick = { onShowSnackbar("Pay for premium to access it") },
             )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -14,11 +14,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
@@ -3,11 +3,11 @@ package must.kdroiders.hustlehub.ui.features.profile.presentation.view
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -21,7 +21,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -37,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import must.kdroiders.hustlehub.sharedComposables.ErrorView
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.sharedComposables.LoadingIndicator
 import must.kdroiders.hustlehub.sharedComposables.SectionHeader
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileAvatar
@@ -44,7 +44,6 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileInfo
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileStatsRow
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ServiceCard
-import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProviderProfileViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
@@ -3,6 +3,7 @@ package must.kdroiders.hustlehub.ui.features.profile.presentation.view
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -43,6 +44,7 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileInfo
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileStatsRow
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ServiceCard
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProviderProfileViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,9 +63,10 @@ fun ProviderProfileScreen(
         providerProfileViewModel.initialize(providerId)
     }
 
-    Scaffold(
+    HustleScaffold(
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Text(
                         text = state.provider?.name ?: "Provider Profile",
@@ -119,7 +122,7 @@ fun ProviderProfileScreen(
                 modifier = Modifier.padding(innerPadding).fillMaxSize(),
             )
             else -> {
-                val provider = state.provider ?: return@Scaffold
+                val provider = state.provider ?: return@HustleScaffold
 
                 LazyColumn(
                     modifier = Modifier

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
@@ -1,5 +1,7 @@
 package must.kdroiders.hustlehub.ui.features.profile.presentation.view
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -7,16 +9,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Call
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,11 +34,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import must.kdroiders.hustlehub.sharedComposables.ErrorView
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleButtonVariant
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.sharedComposables.LoadingIndicator
 import must.kdroiders.hustlehub.sharedComposables.SectionHeader
@@ -57,6 +63,7 @@ fun ProviderProfileScreen(
     onNavigateToServiceDetail: (serviceId: String) -> Unit = {},
 ) {
     val state by providerProfileViewModel.uiState.collectAsState()
+    val context = LocalContext.current
 
     LaunchedEffect(providerId) {
         providerProfileViewModel.initialize(providerId)
@@ -65,7 +72,6 @@ fun ProviderProfileScreen(
     HustleScaffold(
         topBar = {
             TopAppBar(
-                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Text(
                         text = state.provider?.name ?: "Provider Profile",
@@ -100,19 +106,49 @@ fun ProviderProfileScreen(
                                 modifier = Modifier.fillMaxWidth(),
                             )
                         } else {
-                            HustleButton(
-                                text = "Message",
-                                onClick = {
-                                    state.provider?.id?.let { onNavigateToChat(it) }
-                                },
-                                modifier = Modifier.fillMaxWidth(),
-                            )
+                            val provider = state.provider
+                            val canCall = provider?.allowCalls == true && !provider.phone.isBlank()
+
+                            if (canCall) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                ) {
+                                    HustleButton(
+                                        text = "Call",
+                                        variant = HustleButtonVariant.Secondary,
+                                        icon = Icons.Default.Call,
+                                        onClick = {
+                                            val intent = Intent(Intent.ACTION_DIAL, Uri.parse("tel:${provider.phone}"))
+                                            context.startActivity(intent)
+                                        },
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                    HustleButton(
+                                        text = "Message",
+                                        variant = HustleButtonVariant.Primary,
+                                        onClick = {
+                                            onNavigateToChat(provider.id)
+                                        },
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                }
+                            } else {
+                                HustleButton(
+                                    text = "Message",
+                                    onClick = {
+                                        state.provider?.id?.let { onNavigateToChat(it) }
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
                         }
                     }
                 }
             }
         },
     ) { innerPadding ->
+
         when {
             state.isLoading -> LoadingIndicator(modifier = Modifier.padding(innerPadding).fillMaxSize())
             state.error != null -> ErrorView(
@@ -128,58 +164,85 @@ fun ProviderProfileScreen(
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.background),
                     contentPadding = PaddingValues(
-                        top = innerPadding.calculateTopPadding() + 16.dp,
+                        top = innerPadding.calculateTopPadding(),
                         bottom = innerPadding.calculateBottomPadding() + 16.dp,
                     ),
                 ) {
+                    item(key = "header_banner") {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(120.dp)
+                                .background(
+                                    brush = Brush.verticalGradient(
+                                        colors = listOf(
+                                            MaterialTheme.colorScheme.primary.copy(alpha = 0.7f),
+                                            MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                                            MaterialTheme.colorScheme.background,
+                                        ),
+                                    ),
+                                ),
+                        )
+                    }
+
                     item(key = "avatar") {
                         Column(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .offset(y = (-45).dp),
                             horizontalAlignment = Alignment.CenterHorizontally,
                         ) {
-                            ProfileAvatar(photoUrl = provider.profilePhotoUrl)
-                            Spacer(Modifier.height(12.dp))
+                            ProfileAvatar(
+                                photoUrl = provider.profilePhotoUrl,
+                                isVerified = provider.isVerified,
+                            )
+                            Spacer(Modifier.height(10.dp))
                             ProfileInfo(
                                 name = provider.name,
                                 phone = provider.phone,
                                 campusLocation = provider.campusLocation,
                                 bio = provider.bio,
+                                isOnline = provider.isOnline,
+                                allowCalls = provider.allowCalls,
+                                isOwnProfile = state.isOwnProfile,
                             )
                         }
                     }
 
                     item(key = "stats") {
-                        Spacer(Modifier.height(20.dp))
                         ProfileStatsRow(
                             hustleScore = state.hustleScore,
                             serviceCount = state.services.size,
                             reviewCount = state.reviewCount,
-                            modifier = Modifier.padding(horizontal = 16.dp),
+                            modifier = Modifier
+                                .offset(y = (-30).dp)
+                                .padding(horizontal = 16.dp),
                         )
                     }
 
                     if (state.badges.isNotEmpty()) {
                         item(key = "badges") {
-                            Spacer(Modifier.height(16.dp))
                             ProfileBadges(
                                 badges = state.badges,
-                                modifier = Modifier.padding(horizontal = 16.dp),
+                                modifier = Modifier
+                                    .offset(y = (-20).dp)
+                                    .padding(horizontal = 16.dp),
                             )
                         }
                     }
 
                     item(key = "services_header") {
-                        Spacer(Modifier.height(24.dp))
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .offset(y = (-10).dp)
                                 .padding(horizontal = 16.dp),
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             SectionHeader(title = "Services (${state.services.size})")
                         }
-                        Spacer(Modifier.height(12.dp))
+                        Spacer(Modifier.height(4.dp))
                     }
 
                     items(items = state.services, key = { it.id }) { service ->
@@ -187,7 +250,9 @@ fun ProviderProfileScreen(
                             service = service,
                             onClick = { onNavigateToServiceDetail(service.id) },
                             onToggle = {},
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                            modifier = Modifier
+                                .offset(y = (-10).dp)
+                                .padding(horizontal = 16.dp, vertical = 6.dp),
                         )
                     }
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
@@ -1,10 +1,16 @@
 package must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Phone
@@ -14,6 +20,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -25,17 +33,52 @@ fun ProfileInfo(
     phone: String,
     campusLocation: String,
     bio: String,
+    isOnline: Boolean = true,
+    allowCalls: Boolean = false,
+    isOwnProfile: Boolean = false,
 ) {
     Text(
-        text = name.ifBlank { "User" },
-        fontSize = 22.sp,
+        text = name.ifBlank { "Hustler Provider" },
+        fontSize = 24.sp,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onBackground,
         textAlign = TextAlign.Center,
     )
 
-    if (phone.isNotBlank()) {
-        Spacer(Modifier.height(6.dp))
+    Spacer(Modifier.height(8.dp))
+
+    // Live Availability Status Pill
+    val statusColor = if (isOnline) Color(0xFF00E676) else Color(0xFFFF5252)
+    val statusText = if (isOnline) "Available on Campus" else "Off Duty"
+
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(statusColor.copy(alpha = 0.12f))
+            .border(1.dp, statusColor.copy(alpha = 0.3f), RoundedCornerShape(20.dp))
+            .padding(horizontal = 12.dp, vertical = 5.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(statusColor),
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = statusText,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = statusColor,
+            )
+        }
+    }
+
+    // Phone Privacy Guard: Only display phone if it's user's own profile OR provider explicitly allowed direct calls
+    val showPhone = (isOwnProfile || allowCalls) && phone.isNotBlank()
+    if (showPhone) {
+        Spacer(Modifier.height(8.dp))
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 imageVector = Icons.Default.Phone,
@@ -58,13 +101,25 @@ fun ProfileInfo(
             imageVector = Icons.Default.LocationOn,
             contentDescription = null,
             modifier = Modifier.size(14.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            tint = MaterialTheme.colorScheme.primary,
         )
         Spacer(Modifier.width(4.dp))
         Text(
-            text = campusLocation.ifBlank { "Campus" },
+            text = campusLocation.ifBlank { "MUST Main Campus" },
             fontSize = 13.sp,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    if (bio.isNotBlank()) {
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = bio,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 24.dp),
+            lineHeight = 20.sp,
         )
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
@@ -1,0 +1,86 @@
+package must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Storefront
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import must.kdroiders.hustlehub.R
+import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleButtonVariant
+import must.kdroiders.hustlehub.sharedComposables.HustleCard
+import must.kdroiders.hustlehub.sharedComposables.HustleCardVariant
+
+@Composable
+fun ProviderOnboardingCard(
+    onCreateServiceClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    HustleCard(
+        variant = HustleCardVariant.Glass,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(MaterialTheme.colorScheme.secondaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Storefront,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(28.dp),
+                )
+            }
+
+            Spacer(Modifier.height(14.dp))
+
+            Text(
+                text = stringResource(R.string.profile_provider_cta_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Spacer(Modifier.height(6.dp))
+
+            Text(
+                text = stringResource(R.string.profile_provider_cta_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
+
+            Spacer(Modifier.height(18.dp))
+
+            HustleButton(
+                text = stringResource(R.string.profile_provider_cta_action),
+                onClick = onCreateServiceClick,
+                variant = HustleButtonVariant.Primary,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/EditProfileUiState.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/EditProfileUiState.kt
@@ -9,6 +9,7 @@ data class EditProfileUiState(
     val bio: String = "",
     val phone: String = "",
     val campusLocation: String = "",
+    val allowCalls: Boolean = false,
     /** Set to a new URI string when the user picks a photo; null means unchanged. */
     val pendingAvatarUri: String? = null,
     val isSaving: Boolean = false,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/EditProfileViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/EditProfileViewModel.kt
@@ -48,6 +48,7 @@ class EditProfileViewModel
                                 bio = user?.bio ?: "",
                                 phone = user?.phone ?: "",
                                 campusLocation = user?.campusLocation ?: "",
+                                allowCalls = user?.allowCalls ?: false,
                                 isLoading = false,
                             )
                         }
@@ -62,6 +63,7 @@ class EditProfileViewModel
         fun onBioChanged(value: String) = _uiState.update { it.copy(bio = value) }
         fun onPhoneChanged(value: String) = _uiState.update { it.copy(phone = value) }
         fun onCampusLocationChanged(value: String) = _uiState.update { it.copy(campusLocation = value) }
+        fun onAllowCallsChanged(value: Boolean) = _uiState.update { it.copy(allowCalls = value) }
         fun onAvatarPicked(uri: Uri) = _uiState.update { it.copy(pendingAvatarUri = uri.toString()) }
         fun clearError() = _uiState.update { it.copy(error = null) }
 
@@ -96,6 +98,7 @@ class EditProfileViewModel
                     phone = state.phone.trim(),
                     campusLocation = state.campusLocation.trim(),
                     avatarUrl = newAvatarUrl,
+                    allowCalls = state.allowCalls,
                 ).onSuccess {
                     _uiState.update { it.copy(isSaving = false, saveSuccess = true) }
                 }.onFailure { e ->

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
@@ -3,6 +3,7 @@ package must.kdroiders.hustlehub.ui.features.service.data.repository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import must.kdroiders.hustlehub.core.api.PageResponse
 import must.kdroiders.hustlehub.core.auth.AuthManager
 import must.kdroiders.hustlehub.ui.features.service.data.local.dao.ServiceDao
 import must.kdroiders.hustlehub.ui.features.service.data.local.entity.toDomain
@@ -14,7 +15,6 @@ import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.CreateServic
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.ReviewResponse
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.ServiceResponse
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.UpdateServiceRequest
-import must.kdroiders.hustlehub.core.api.PageResponse
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Service
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceAvailability

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
@@ -12,6 +12,7 @@ import must.kdroiders.hustlehub.ui.features.service.data.remote.ServiceApiServic
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.AvailabilityRequest
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.CreateReviewRequest
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.CreateServiceRequest
+import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.LocationDto
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.ReviewResponse
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.ServiceResponse
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.UpdateServiceRequest
@@ -45,9 +46,18 @@ class ServiceRepositoryImpl
             openToBarter: Boolean,
             tags: List<String>,
             portfolioUrls: List<String>,
+            lat: Double?,
+            lng: Double?,
+            locationLabel: String?,
         ): Result<Service> =
             withContext(Dispatchers.IO) {
                 runCatching {
+                    val locationDto = if (lat != null && lng != null) {
+                        LocationDto(lat = lat, lng = lng, label = locationLabel)
+                    } else {
+                        null
+                    }
+
                     val request = CreateServiceRequest(
                         title = title,
                         category = category.name,
@@ -56,6 +66,7 @@ class ServiceRepositoryImpl
                         maxPrice = maxPrice,
                         openToBarter = openToBarter,
                         tags = tags,
+                        location = locationDto,
                         portfolioUrls = portfolioUrls,
                     )
                     val response = apiService.createService(request)
@@ -94,9 +105,18 @@ class ServiceRepositoryImpl
             openToBarter: Boolean?,
             tags: List<String>?,
             portfolioUrls: List<String>?,
+            lat: Double?,
+            lng: Double?,
+            locationLabel: String?,
         ): Result<Service> =
             withContext(Dispatchers.IO) {
                 runCatching {
+                    val locationDto = if (lat != null && lng != null) {
+                        LocationDto(lat = lat, lng = lng, label = locationLabel)
+                    } else {
+                        null
+                    }
+
                     val request = UpdateServiceRequest(
                         title = title,
                         category = category?.name,
@@ -105,6 +125,7 @@ class ServiceRepositoryImpl
                         maxPrice = maxPrice,
                         openToBarter = openToBarter,
                         tags = tags,
+                        location = locationDto,
                         portfolioUrls = portfolioUrls,
                     )
                     val response = apiService.updateService(serviceId, request)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package must.kdroiders.hustlehub.ui.features.service.data.repository
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import must.kdroiders.hustlehub.core.api.PageResponse
 import must.kdroiders.hustlehub.core.auth.AuthManager
 import must.kdroiders.hustlehub.ui.features.service.data.local.dao.ServiceDao
 import must.kdroiders.hustlehub.ui.features.service.data.local.entity.toDomain
@@ -14,6 +14,7 @@ import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.CreateServic
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.ReviewResponse
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.ServiceResponse
 import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.UpdateServiceRequest
+import must.kdroiders.hustlehub.core.api.PageResponse
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Service
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceAvailability
@@ -21,344 +22,294 @@ import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceCategory
 import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
 import timber.log.Timber
 import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
 
-// Cache TTL — entries older than this are evicted before each read
-private const val CACHE_TTL_MS = 30 * 60 * 1_000L
+/** 30-minute cache TTL before cache entries are considered stale. */
+private const val CACHE_TTL_MS = 30 * 60 * 1000L
 
-/**
- * Concrete implementation of [ServiceRepository].
- *
- * Coordinates between the HustleHub REST backend ([ServiceApiService]) and
- * the local Room cache ([ServiceDao]). Room is the single source of truth for
- * the UI; data flows from cache first, refreshed from remote on each call.
- */
-class ServiceRepositoryImpl(
-    private val apiService: ServiceApiService,
-    private val serviceDao: ServiceDao,
-    private val authManager: AuthManager,
-) : ServiceRepository {
-    override suspend fun createService(
-        title: String,
-        category: ServiceCategory,
-        description: String?,
-        minPrice: Int,
-        maxPrice: Int,
-        openToBarter: Boolean,
-        tags: List<String>,
-        portfolioUrls: List<String>,
-    ): Result<Service> =
-        withContext(Dispatchers.IO) {
-            try {
-                val request = CreateServiceRequest(
-                    title = title,
-                    category = category.name,
-                    description = description,
-                    minPrice = minPrice,
-                    maxPrice = maxPrice,
-                    openToBarter = openToBarter,
-                    tags = tags,
-                    portfolioUrls = portfolioUrls,
-                )
-                val response = apiService.createService(request)
-                if (response.success && response.data != null) {
-                    val service = response.data.toDomainModel()
-                    // Write-through: cache the newly created service immediately
-                    serviceDao.upsert(service.toEntity())
-                    Result.success(service)
-                } else {
-                    Result.failure(Exception(response.message))
-                }
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-        }
-
-    override suspend fun getServiceById(serviceId: String): Result<Service> =
-        withContext(Dispatchers.IO) {
-            try {
-                val response = apiService.getServiceById(serviceId)
-                if (response.success && response.data != null) {
+@Singleton
+class ServiceRepositoryImpl
+    @Inject
+    constructor(
+        private val apiService: ServiceApiService,
+        private val serviceDao: ServiceDao,
+        private val authManager: AuthManager,
+    ) : ServiceRepository {
+        override suspend fun createService(
+            title: String,
+            category: ServiceCategory,
+            description: String?,
+            minPrice: Int,
+            maxPrice: Int,
+            openToBarter: Boolean,
+            tags: List<String>,
+            portfolioUrls: List<String>,
+        ): Result<Service> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = CreateServiceRequest(
+                        title = title,
+                        category = category.name,
+                        description = description,
+                        minPrice = minPrice,
+                        maxPrice = maxPrice,
+                        openToBarter = openToBarter,
+                        tags = tags,
+                        portfolioUrls = portfolioUrls,
+                    )
+                    val response = apiService.createService(request)
+                    check(response.success && response.data != null) { response.message ?: "Failed to create service" }
                     val service = response.data.toDomainModel()
                     serviceDao.upsert(service.toEntity())
-                    Result.success(service)
-                } else {
-                    Result.failure(Exception(response.message))
-                }
-            } catch (e: Exception) {
-                // Network unavailable — try cache
-                Timber.w(e, "getServiceById network miss, checking cache")
-                val cached = serviceDao.getServiceById(serviceId)
-                if (cached != null) {
-                    Result.success(cached.toDomain())
-                } else {
-                    Result.failure(e)
+                    service
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                 }
             }
-        }
 
-    override suspend fun updateService(
-        serviceId: String,
-        title: String?,
-        category: ServiceCategory?,
-        description: String?,
-        minPrice: Int?,
-        maxPrice: Int?,
-        openToBarter: Boolean?,
-        tags: List<String>?,
-        portfolioUrls: List<String>?,
-    ): Result<Service> =
-        withContext(Dispatchers.IO) {
-            try {
-                val request = UpdateServiceRequest(
-                    title = title,
-                    category = category?.name,
-                    description = description,
-                    minPrice = minPrice,
-                    maxPrice = maxPrice,
-                    openToBarter = openToBarter,
-                    tags = tags,
-                    portfolioUrls = portfolioUrls,
-                )
-                val response = apiService.updateService(serviceId, request)
-                if (response.success && response.data != null) {
+        override suspend fun getServiceById(serviceId: String): Result<Service> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val response = apiService.getServiceById(serviceId)
+                    check(response.success && response.data != null) { response.message ?: "Failed to fetch service" }
                     val service = response.data.toDomainModel()
                     serviceDao.upsert(service.toEntity())
-                    Result.success(service)
-                } else {
-                    Result.failure(Exception(response.message))
+                    service
+                }.recoverCatching { e ->
+                    if (e is CancellationException) throw e
+                    Timber.w(e, "getServiceById network miss, checking cache")
+                    val cached = serviceDao.getServiceById(serviceId)
+                    cached?.toDomain() ?: throw e
                 }
-            } catch (e: Exception) {
-                Result.failure(e)
             }
-        }
 
-    override suspend fun deleteService(serviceId: String): Result<Unit> =
-        withContext(Dispatchers.IO) {
-            try {
-                val response = apiService.deleteService(serviceId)
-                if (response.success) {
-                    // Remove from cache immediately on confirmed delete
+        override suspend fun updateService(
+            serviceId: String,
+            title: String?,
+            category: ServiceCategory?,
+            description: String?,
+            minPrice: Int?,
+            maxPrice: Int?,
+            openToBarter: Boolean?,
+            tags: List<String>?,
+            portfolioUrls: List<String>?,
+        ): Result<Service> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = UpdateServiceRequest(
+                        title = title,
+                        category = category?.name,
+                        description = description,
+                        minPrice = minPrice,
+                        maxPrice = maxPrice,
+                        openToBarter = openToBarter,
+                        tags = tags,
+                        portfolioUrls = portfolioUrls,
+                    )
+                    val response = apiService.updateService(serviceId, request)
+                    check(response.success && response.data != null) { response.message ?: "Failed to update service" }
+                    val service = response.data.toDomainModel()
+                    serviceDao.upsert(service.toEntity())
+                    service
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
+                }
+            }
+
+        override suspend fun deleteService(serviceId: String): Result<Unit> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val response = apiService.deleteService(serviceId)
+                    check(response.success) { response.message ?: "Failed to delete service" }
                     serviceDao.deleteById(serviceId)
-                    Result.success(Unit)
-                } else {
-                    Result.failure(Exception(response.message))
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                 }
-            } catch (e: Exception) {
-                Result.failure(e)
             }
-        }
 
-    override suspend fun updateAvailability(
-        serviceId: String,
-        availability: ServiceAvailability,
-    ): Result<Service> =
-        withContext(Dispatchers.IO) {
-            try {
-                val request = AvailabilityRequest(availability = availability.name)
-                val response = apiService.updateAvailability(serviceId, request)
-                if (response.success && response.data != null) {
+        override suspend fun updateAvailability(
+            serviceId: String,
+            availability: ServiceAvailability,
+        ): Result<Service> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = AvailabilityRequest(availability = availability.name)
+                    val response = apiService.updateAvailability(serviceId, request)
+                    check(response.success && response.data != null) { response.message ?: "Failed to update availability" }
                     val service = response.data.toDomainModel()
                     serviceDao.upsert(service.toEntity())
-                    Result.success(service)
-                } else {
-                    Result.failure(Exception(response.message))
+                    service
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
                 }
-            } catch (e: Exception) {
-                Result.failure(e)
             }
-        }
 
-    override suspend fun getMyServices(): Result<List<Service>> =
-        withContext(Dispatchers.IO) {
-            val now = System.currentTimeMillis()
-            // Evict anything older than 30 minutes before serving cache
-            serviceDao.deleteStaleEntries(now - CACHE_TTL_MS)
+        override suspend fun getMyServices(): Result<List<Service>> =
+            withContext(Dispatchers.IO) {
+                val now = System.currentTimeMillis()
+                serviceDao.deleteStaleEntries(now - CACHE_TTL_MS)
 
-            try {
-                val response = apiService.getMyServices()
-                if (response.success && response.data != null) {
+                runCatching {
+                    val response = apiService.getMyServices()
+                    check(response.success && response.data != null) { response.message ?: "Failed to fetch my services" }
                     val services = response.data.map { it.toDomainModel() }
-                    // Refresh cache with latest data
                     serviceDao.upsertAll(services.map { it.toEntity(now) })
-                    Result.success(services)
-                } else {
-                    Result.failure(Exception(response.message))
-                }
-            } catch (e: Exception) {
-                // Network unavailable — return only the current user's services from cache
-                Timber.w(e, "getMyServices network miss, serving cache")
-                val currentUser = authManager.currentUser()?.uid ?: ""
-                val cached = serviceDao.getServicesByProvider(currentUser)
-                if (cached.isNotEmpty()) {
-                    Result.success(cached.map { it.toDomain() })
-                } else {
-                    Result.failure(e)
+                    services
+                }.recoverCatching { e ->
+                    if (e is CancellationException) throw e
+                    Timber.w(e, "getMyServices network miss, serving cache")
+                    val currentUser = authManager.currentUser()?.uid ?: ""
+                    val cached = serviceDao.getServicesByProvider(currentUser)
+                    if (cached.isNotEmpty()) {
+                        cached.map { it.toDomain() }
+                    } else {
+                        throw e
+                    }
                 }
             }
-        }
 
-    override suspend fun browseServices(
-        page: Int,
-        size: Int,
-        category: ServiceCategory?,
-        query: String?,
-        availability: ServiceAvailability?,
-        minRating: Double?,
-        maxPrice: Int?,
-        lat: Double?,
-        lng: Double?,
-        radiusKm: Double?,
-        sortBy: String?,
-    ): Result<PageResponse<Service>> =
-        withContext(Dispatchers.IO) {
-            val now = System.currentTimeMillis()
-            serviceDao.deleteStaleEntries(now - CACHE_TTL_MS)
+        override suspend fun browseServices(
+            page: Int,
+            size: Int,
+            category: ServiceCategory?,
+            query: String?,
+            availability: ServiceAvailability?,
+            minRating: Double?,
+            maxPrice: Int?,
+            lat: Double?,
+            lng: Double?,
+            radiusKm: Double?,
+            sortBy: String?,
+        ): Result<PageResponse<Service>> =
+            withContext(Dispatchers.IO) {
+                val now = System.currentTimeMillis()
+                serviceDao.deleteStaleEntries(now - CACHE_TTL_MS)
 
-            try {
-                val categoryStr = if (category == ServiceCategory.ALL) null else category?.name
-                val response = apiService.browseServices(
-                    page = page,
-                    size = size,
-                    category = categoryStr,
-                    query = query,
-                    availability = availability?.name,
-                    minRating = minRating,
-                    maxPrice = maxPrice,
-                    lat = lat,
-                    lng = lng,
-                    radiusKm = radiusKm,
-                    sortBy = sortBy,
-                )
-                if (response.success && response.data != null) {
+                runCatching {
+                    val categoryStr = if (category == ServiceCategory.ALL) null else category?.name
+                    val response = apiService.browseServices(
+                        page = page,
+                        size = size,
+                        category = categoryStr,
+                        query = query,
+                        availability = availability?.name,
+                        minRating = minRating,
+                        maxPrice = maxPrice,
+                        lat = lat,
+                        lng = lng,
+                        radiusKm = radiusKm,
+                        sortBy = sortBy,
+                    )
+                    check(response.success && response.data != null) { response.message ?: "Failed to browse services" }
                     val pageData = response.data
                     val services = pageData.content.map { it.toDomainModel() }
                     if (page == 0) serviceDao.upsertAll(services.map { it.toEntity(now) })
-                    Result.success(
-                        PageResponse(
-                            content = services,
-                            page = pageData.page,
-                            size = pageData.size,
-                            totalElements = pageData.totalElements,
-                            totalPages = pageData.totalPages,
-                        ),
+                    PageResponse(
+                        content = services,
+                        page = pageData.page,
+                        size = pageData.size,
+                        totalElements = pageData.totalElements,
+                        totalPages = pageData.totalPages,
                     )
-                } else {
-                    Result.failure(Exception(response.message))
-                }
-            } catch (e: Exception) {
-                Timber.w(e, "browseServices network miss, serving cache (page $page)")
-                if (page == 0) {
-                    val cached = serviceDao.getAllServices()
-                    if (cached.isNotEmpty()) {
-                        val services = cached.map { it.toDomain() }
-                        Result.success(
+                }.recoverCatching { e ->
+                    if (e is CancellationException) throw e
+                    Timber.w(e, "browseServices network miss, serving cache (page $page)")
+                    if (page == 0) {
+                        val cached = serviceDao.getAllServices()
+                        if (cached.isNotEmpty()) {
+                            val services = cached.map { it.toDomain() }
                             PageResponse(
                                 content = services,
                                 page = 0,
                                 size = services.size,
                                 totalElements = services.size.toLong(),
                                 totalPages = 1,
-                            ),
-                        )
+                            )
+                        } else {
+                            throw e
+                        }
                     } else {
-                        Result.failure(e)
+                        throw e
                     }
-                } else {
-                    Result.failure(e)
                 }
             }
-        }
 
-    override suspend fun searchServices(
-        query: String,
-        page: Int,
-        size: Int,
-    ): Result<PageResponse<Service>> =
-        withContext(Dispatchers.IO) {
-            try {
-                val response = apiService.searchServices(query = query, page = page, size = size)
-                if (response.success && response.data != null) {
+        override suspend fun searchServices(
+            query: String,
+            page: Int,
+            size: Int,
+        ): Result<PageResponse<Service>> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val response = apiService.searchServices(query = query, page = page, size = size)
+                    check(response.success && response.data != null) { response.message ?: "Failed to search services" }
                     val pageData = response.data
                     val services = pageData.content.map { it.toDomainModel() }
-                    Result.success(
-                        PageResponse(
-                            content = services,
-                            page = pageData.page,
-                            size = pageData.size,
-                            totalElements = pageData.totalElements,
-                            totalPages = pageData.totalPages,
-                        ),
+                    PageResponse(
+                        content = services,
+                        page = pageData.page,
+                        size = pageData.size,
+                        totalElements = pageData.totalElements,
+                        totalPages = pageData.totalPages,
                     )
-                } else {
-                    Result.failure(Exception(response.message))
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Timber.w(e, "searchServices failed for query='$query'")
                 }
-            } catch (e: Exception) {
-                Timber.w(e, "searchServices failed for query='$query'")
-                Result.failure(e)
             }
-        }
 
-    override suspend fun getServiceReviews(
-        serviceId: String,
-        page: Int,
-        size: Int,
-    ): Result<PageResponse<Review>> =
-        withContext(Dispatchers.IO) {
-            try {
-                val response = apiService.getServiceReviews(serviceId, page, size)
-                if (response.success && response.data != null) {
+        override suspend fun getServiceReviews(
+            serviceId: String,
+            page: Int,
+            size: Int,
+        ): Result<PageResponse<Review>> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val response = apiService.getServiceReviews(serviceId, page, size)
+                    check(response.success && response.data != null) { response.message ?: "Failed to fetch reviews" }
                     val pageData = response.data
-                    Result.success(
-                        PageResponse(
-                            content = pageData.content.map { it.toDomain() },
-                            page = pageData.page,
-                            size = pageData.size,
-                            totalElements = pageData.totalElements,
-                            totalPages = pageData.totalPages,
-                        ),
+                    PageResponse(
+                        content = pageData.content.map { it.toDomain() },
+                        page = pageData.page,
+                        size = pageData.size,
+                        totalElements = pageData.totalElements,
+                        totalPages = pageData.totalPages,
                     )
-                } else {
-                    Result.failure(Exception(response.message))
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Timber.w(e, "getServiceReviews failed for serviceId='$serviceId'")
                 }
-            } catch (e: Exception) {
-                Timber.w(e, "getServiceReviews failed for serviceId='$serviceId'")
-                Result.failure(e)
             }
-        }
 
-    override suspend fun submitReview(
-        serviceId: String,
-        rating: Int,
-        comment: String?,
-        isAnonymous: Boolean,
-    ): Result<Review> =
-        withContext(Dispatchers.IO) {
-            try {
-                val request = CreateReviewRequest(
-                    serviceId = serviceId,
-                    rating = rating,
-                    comment = comment,
-                    isAnonymous = isAnonymous,
-                )
-                val response = apiService.submitReview(request)
-                if (response.success && response.data != null) {
-                    Result.success(response.data.toDomain())
-                } else {
-                    Result.failure(Exception(response.message))
+        override suspend fun submitReview(
+            serviceId: String,
+            rating: Int,
+            comment: String?,
+            isAnonymous: Boolean,
+        ): Result<Review> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = CreateReviewRequest(
+                        serviceId = serviceId,
+                        rating = rating,
+                        comment = comment,
+                        isAnonymous = isAnonymous,
+                    )
+                    val response = apiService.submitReview(request)
+                    check(response.success && response.data != null) { response.message }
+                    response.data.toDomain()
+                }.recoverCatching { e ->
+                    if (e is CancellationException) throw e
+                    if (e is retrofit2.HttpException && e.code() == 409) {
+                        throw Exception("You have already reviewed this service.")
+                    } else {
+                        Timber.w(e, "submitReview failed for serviceId='$serviceId'")
+                        throw e
+                    }
                 }
-            } catch (e: retrofit2.HttpException) {
-                if (e.code() == 409) {
-                    Result.failure(Exception("You have already reviewed this service."))
-                } else {
-                    Timber.w(e, "submitReview failed — HTTP ${e.code()}")
-                    Result.failure(e)
-                }
-            } catch (e: Exception) {
-                Timber.w(e, "submitReview failed for serviceId='$serviceId'")
-                Result.failure(e)
             }
-        }
-}
+    }
 
 // DTO → Domain mapper (private to this file)
 private fun ServiceResponse.toDomainModel(): Service =

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/repository/ServiceRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/repository/ServiceRepository.kt
@@ -21,12 +21,12 @@ interface ServiceRepository {
         openToBarter: Boolean,
         tags: List<String>,
         portfolioUrls: List<String> = emptyList(),
+        lat: Double? = null,
+        lng: Double? = null,
+        locationLabel: String? = null,
     ): Result<Service>
 
-    /**
-     * Fetches a single service by its UUID.
-     * Falls back to the Room cache if the network is unavailable.
-     */
+    /** Fetches a single service by its UUID. */
     suspend fun getServiceById(serviceId: String): Result<Service>
 
     /** Updates an existing service listing. Null parameters leave the field unchanged. */
@@ -40,6 +40,9 @@ interface ServiceRepository {
         openToBarter: Boolean? = null,
         tags: List<String>? = null,
         portfolioUrls: List<String>? = null,
+        lat: Double? = null,
+        lng: Double? = null,
+        locationLabel: String? = null,
     ): Result<Service>
 
     /** Permanently deletes the service and removes it from the local cache. */

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.CircularWavyProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -69,7 +68,6 @@ import must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceEvent
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceViewModel
 import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
-
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package must.kdroiders.hustlehub.ui.features.service.presentation.view
 
 import android.net.Uri
@@ -15,6 +17,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -31,23 +34,39 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -56,7 +75,14 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.rememberCameraPositionState
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleCard
+import must.kdroiders.hustlehub.sharedComposables.HustleCardVariant
 import must.kdroiders.hustlehub.sharedComposables.HustleTextField
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.AvailabilityChipSelector
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.CategoryDropdown
@@ -66,6 +92,7 @@ import must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.TagChip
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceEvent
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceViewModel
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.LocationSelectionMode
 import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -355,6 +382,20 @@ fun CreateServiceScreen(
                 }
                 Spacer(Modifier.height(16.dp))
 
+                // Service Operating Location
+                ServiceLocationCard(
+                    locationMode = state.locationMode,
+                    selectedLat = state.selectedLat,
+                    selectedLng = state.selectedLng,
+                    locationLabel = state.locationLabel,
+                    onModeChange = viewModel::onLocationModeChange,
+                    onPresetSelect = viewModel::onLocationPresetSelect,
+                    onCustomLocationSelect = viewModel::onCustomLocationSelect,
+                    onLabelChange = viewModel::onLocationLabelChange,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(16.dp))
+
                 // Current status
                 SectionLabel(text = "Current Status")
                 AvailabilityChipSelector(
@@ -411,6 +452,263 @@ fun CreateServiceScreen(
                 contentAlignment = Alignment.Center,
             ) {
                 CircularWavyProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ServiceLocationCard(
+    locationMode: LocationSelectionMode,
+    selectedLat: Double?,
+    selectedLng: Double?,
+    locationLabel: String,
+    onModeChange: (LocationSelectionMode) -> Unit,
+    onPresetSelect: (String, Double, Double) -> Unit,
+    onCustomLocationSelect: (Double, Double, String) -> Unit,
+    onLabelChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var showMapModal by remember { mutableStateOf(false) }
+
+    val presets = remember {
+        listOf(
+            Triple("MUST Main Campus (Nchiru)", -0.0076, 37.6534),
+            Triple("Tuition & Admin Block", -0.0075, 37.6535),
+            Triple("MUST Library", -0.0074, 37.6532),
+            Triple("Engineering & Tech Block", -0.0073, 37.6538),
+            Triple("Campus Hostels", -0.0080, 37.6530),
+        )
+    }
+
+    HustleCard(
+        modifier = modifier,
+        variant = HustleCardVariant.Surface,
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text(
+                    text = "Service Operating Location",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            Spacer(Modifier.height(4.dp))
+
+            Text(
+                text = "Where will you provide this service when operating on campus?",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // Selection Mode Chips
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(
+                    selected = locationMode == LocationSelectionMode.CAMPUS_PRESET,
+                    onClick = { onModeChange(LocationSelectionMode.CAMPUS_PRESET) },
+                    label = { Text("Preset", fontSize = 11.sp) },
+                    leadingIcon = {
+                        Icon(Icons.Default.School, contentDescription = null, modifier = Modifier.size(14.dp))
+                    },
+                )
+
+                FilterChip(
+                    selected = locationMode == LocationSelectionMode.CURRENT_GPS,
+                    onClick = {
+                        onModeChange(LocationSelectionMode.CURRENT_GPS)
+                        val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+                        try {
+                            fusedClient.lastLocation.addOnSuccessListener { loc ->
+                                loc?.let {
+                                    onCustomLocationSelect(it.latitude, it.longitude, "Current Device Location")
+                                }
+                            }
+                        } catch (e: SecurityException) {
+                            timber.log.Timber.e(e, "GPS permission error")
+                        }
+                    },
+                    label = { Text("My GPS", fontSize = 11.sp) },
+                    leadingIcon = {
+                        Icon(Icons.Default.MyLocation, contentDescription = null, modifier = Modifier.size(14.dp))
+                    },
+                )
+
+                FilterChip(
+                    selected = locationMode == LocationSelectionMode.MAP_PICKER,
+                    onClick = {
+                        onModeChange(LocationSelectionMode.MAP_PICKER)
+                        showMapModal = true
+                    },
+                    label = { Text("Pick on Map", fontSize = 11.sp) },
+                    leadingIcon = {
+                        Icon(Icons.Default.Map, contentDescription = null, modifier = Modifier.size(14.dp))
+                    },
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // Details depending on mode
+            when (locationMode) {
+                LocationSelectionMode.CAMPUS_PRESET -> {
+                    Text(
+                        text = "Select Campus Landmark:",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        for ((name, lat, lng) in presets) {
+                            val isSelected = locationLabel == name
+                            FilterChip(
+                                selected = isSelected,
+                                onClick = { onPresetSelect(name, lat, lng) },
+                                label = { Text(name, fontSize = 11.sp) },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                ),
+                            )
+                        }
+                    }
+                }
+                LocationSelectionMode.CURRENT_GPS -> {
+                    Text(
+                        text = if (selectedLat !=
+                            null
+                        ) {
+                            "Detected Coordinates: ${"%.4f".format(selectedLat)}, ${"%.4f".format(selectedLng)}"
+                        } else {
+                            "Detecting GPS location..."
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+                LocationSelectionMode.MAP_PICKER -> {
+                    HustleButton(
+                        text = if (selectedLat != null) "Change Location on Map" else "Open Map Picker",
+                        onClick = { showMapModal = true },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // Location note / building name input
+            HustleTextField(
+                value = locationLabel,
+                onValueChange = onLabelChange,
+                placeholder = "Location note (e.g. Hostel 3, Room 12 or Block B)",
+            )
+        }
+    }
+
+    if (showMapModal) {
+        MapLocationPickerModal(
+            initialLat = selectedLat ?: -0.0076,
+            initialLng = selectedLng ?: 37.6534,
+            onLocationConfirmed = { lat, lng ->
+                onCustomLocationSelect(lat, lng, "Custom Map Location (${"%.4f".format(lat)}, ${"%.4f".format(lng)})")
+                showMapModal = false
+            },
+            onDismiss = { showMapModal = false },
+        )
+    }
+}
+
+@Composable
+private fun MapLocationPickerModal(
+    initialLat: Double,
+    initialLng: Double,
+    onLocationConfirmed: (Double, Double) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(LatLng(initialLat, initialLng), 16f)
+    }
+
+    val mapNestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                return Offset(0f, available.y)
+            }
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.85f),
+        ) {
+            Text(
+                text = "Drag map to center location pin",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .nestedScroll(mapNestedScrollConnection),
+            ) {
+                GoogleMap(
+                    modifier = Modifier.fillMaxSize(),
+                    cameraPositionState = cameraPositionState,
+                )
+
+                // Center pin overlay
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = "Target Pin",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .size(36.dp)
+                        .align(Alignment.Center),
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                HustleButton(
+                    text = "Confirm Location",
+                    onClick = {
+                        val target = cameraPositionState.position.target
+                        onLocationConfirmed(target.latitude, target.longitude)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package must.kdroiders.hustlehub.ui.features.service.presentation.view
 
 import android.net.Uri

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -4,6 +4,7 @@ package must.kdroiders.hustlehub.ui.features.service.presentation.view
 
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
@@ -17,7 +18,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -34,39 +34,23 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Map
-import androidx.compose.material.icons.filled.MyLocation
-import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -74,51 +58,45 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.google.android.gms.location.LocationServices
-import com.google.android.gms.maps.model.CameraPosition
-import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.GoogleMap
-import com.google.maps.android.compose.rememberCameraPositionState
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
-import must.kdroiders.hustlehub.sharedComposables.HustleCard
-import must.kdroiders.hustlehub.sharedComposables.HustleCardVariant
 import must.kdroiders.hustlehub.sharedComposables.HustleTextField
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.AvailabilityChipSelector
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.CategoryDropdown
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ErrorText
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.PortfolioSlots
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.SectionLabel
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ServiceLocationCard
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.TagChip
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceEvent
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.CreateServiceViewModel
-import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.LocationSelectionMode
 import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
+
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CreateServiceScreen(
     serviceId: String? = null,
-    viewModel: CreateServiceViewModel = hiltViewModel(),
+    createServiceViewModel: CreateServiceViewModel = hiltViewModel(),
     onBack: () -> Unit,
     onSuccess: () -> Unit,
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val state by createServiceViewModel.uiState.collectAsState()
     val focusManager = LocalFocusManager.current
     val effectsSpec = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
 
     val imagePicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
     ) { uri: Uri? ->
-        uri?.let { viewModel.onPortfolioImageAdded(it) }
+        uri?.let { createServiceViewModel.onPortfolioImageAdded(it) }
     }
 
     LaunchedEffect(serviceId) {
-        if (serviceId != null) viewModel.loadForEdit(serviceId)
+        if (serviceId != null) createServiceViewModel.loadForEdit(serviceId)
     }
 
     LaunchedEffect(Unit) {
-        viewModel.events.collect { event ->
+        createServiceViewModel.events.collect { event ->
             when (event) {
                 is CreateServiceEvent.Success -> onSuccess()
             }
@@ -187,13 +165,13 @@ fun CreateServiceScreen(
                     newUris = state.portfolioUris,
                     onAddClick = {
                         imagePicker.launch(
-                            androidx.activity.result.PickVisualMediaRequest(
+                            PickVisualMediaRequest(
                                 ActivityResultContracts.PickVisualMedia.ImageOnly,
                             ),
                         )
                     },
-                    onRemoveExisting = viewModel::onPortfolioExistingImageRemoved,
-                    onRemoveNew = viewModel::onPortfolioNewImageRemoved,
+                    onRemoveExisting = createServiceViewModel::onPortfolioExistingImageRemoved,
+                    onRemoveNew = createServiceViewModel::onPortfolioNewImageRemoved,
                 )
                 Spacer(Modifier.height(20.dp))
 
@@ -201,7 +179,7 @@ fun CreateServiceScreen(
                 SectionLabel(text = "Service Title", required = true)
                 HustleTextField(
                     value = state.title,
-                    onValueChange = viewModel::onTitleChange,
+                    onValueChange = createServiceViewModel::onTitleChange,
                     placeholder = "e.g. Professional Braiding Services",
                     isError = state.titleError != null,
                     errorText = state.titleError,
@@ -216,7 +194,7 @@ fun CreateServiceScreen(
                 SectionLabel(text = "Category", required = true)
                 CategoryDropdown(
                     selected = state.category,
-                    onSelect = viewModel::onCategoryChange,
+                    onSelect = createServiceViewModel::onCategoryChange,
                     hasError = state.categoryError != null,
                 )
                 ErrorText(state.categoryError)
@@ -226,7 +204,7 @@ fun CreateServiceScreen(
                 SectionLabel(text = "Description")
                 HustleTextField(
                     value = state.description,
-                    onValueChange = viewModel::onDescriptionChange,
+                    onValueChange = createServiceViewModel::onDescriptionChange,
                     placeholder = "Describe your service details, what you offer, and any prerequisites...",
                     isError = state.descriptionError != null,
                     errorText = state.descriptionError,
@@ -256,7 +234,7 @@ fun CreateServiceScreen(
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     HustleTextField(
                         value = state.minPrice,
-                        onValueChange = viewModel::onMinPriceChange,
+                        onValueChange = createServiceViewModel::onMinPriceChange,
                         placeholder = "Min",
                         isError = state.priceError != null,
                         keyboardOptions = KeyboardOptions(
@@ -267,7 +245,7 @@ fun CreateServiceScreen(
                     )
                     HustleTextField(
                         value = state.maxPrice,
-                        onValueChange = viewModel::onMaxPriceChange,
+                        onValueChange = createServiceViewModel::onMaxPriceChange,
                         placeholder = "Max",
                         isError = state.priceError != null,
                         keyboardOptions = KeyboardOptions(
@@ -302,7 +280,7 @@ fun CreateServiceScreen(
                         modifier = Modifier.padding(bottom = 8.dp),
                     ) {
                         state.tags.forEach { tag ->
-                            TagChip(label = tag, onRemove = { viewModel.removeTag(tag) })
+                            TagChip(label = tag, onRemove = { createServiceViewModel.removeTag(tag) })
                         }
                     }
                 }
@@ -312,7 +290,7 @@ fun CreateServiceScreen(
                 ) {
                     HustleTextField(
                         value = state.tagInput,
-                        onValueChange = viewModel::onTagInputChange,
+                        onValueChange = createServiceViewModel::onTagInputChange,
                         placeholder = "e.g. braids",
                         isError = state.tagError != null,
                         errorText = state.tagError,
@@ -322,7 +300,7 @@ fun CreateServiceScreen(
                         ),
                         keyboardActions = KeyboardActions(
                             onDone = {
-                                viewModel.addTag()
+                                createServiceViewModel.addTag()
                                 focusManager.clearFocus()
                             },
                         ),
@@ -333,7 +311,7 @@ fun CreateServiceScreen(
                             .size(48.dp)
                             .clip(RoundedCornerShape(12.dp))
                             .background(MaterialTheme.colorScheme.primary)
-                            .clickable { viewModel.addTag() },
+                            .clickable { createServiceViewModel.addTag() },
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
@@ -371,7 +349,7 @@ fun CreateServiceScreen(
                     }
                     Switch(
                         checked = state.openToBarter,
-                        onCheckedChange = viewModel::onOpenToBarterChange,
+                        onCheckedChange = createServiceViewModel::onOpenToBarterChange,
                         colors = SwitchDefaults.colors(
                             checkedTrackColor = HustleActiveGreen,
                             checkedThumbColor = Color.White,
@@ -388,10 +366,10 @@ fun CreateServiceScreen(
                     selectedLat = state.selectedLat,
                     selectedLng = state.selectedLng,
                     locationLabel = state.locationLabel,
-                    onModeChange = viewModel::onLocationModeChange,
-                    onPresetSelect = viewModel::onLocationPresetSelect,
-                    onCustomLocationSelect = viewModel::onCustomLocationSelect,
-                    onLabelChange = viewModel::onLocationLabelChange,
+                    onModeChange = createServiceViewModel::onLocationModeChange,
+                    onPresetSelect = createServiceViewModel::onLocationPresetSelect,
+                    onCustomLocationSelect = createServiceViewModel::onCustomLocationSelect,
+                    onLabelChange = createServiceViewModel::onLocationLabelChange,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Spacer(Modifier.height(16.dp))
@@ -400,7 +378,7 @@ fun CreateServiceScreen(
                 SectionLabel(text = "Current Status")
                 AvailabilityChipSelector(
                     current = state.availability,
-                    onSelect = viewModel::onAvailabilityChange,
+                    onSelect = createServiceViewModel::onAvailabilityChange,
                     modifier = Modifier.fillMaxWidth(),
                 )
 
@@ -434,7 +412,7 @@ fun CreateServiceScreen(
                     text = if (state.isLoading) "Publishing…" else "Publish Service",
                     onClick = {
                         focusManager.clearFocus()
-                        viewModel.publish()
+                        createServiceViewModel.publish()
                     },
                     enabled = !state.isLoading,
                     modifier = Modifier.fillMaxWidth(),
@@ -452,263 +430,6 @@ fun CreateServiceScreen(
                 contentAlignment = Alignment.Center,
             ) {
                 CircularWavyProgressIndicator(color = MaterialTheme.colorScheme.primary)
-            }
-        }
-    }
-}
-
-@Composable
-private fun ServiceLocationCard(
-    locationMode: LocationSelectionMode,
-    selectedLat: Double?,
-    selectedLng: Double?,
-    locationLabel: String,
-    onModeChange: (LocationSelectionMode) -> Unit,
-    onPresetSelect: (String, Double, Double) -> Unit,
-    onCustomLocationSelect: (Double, Double, String) -> Unit,
-    onLabelChange: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val context = LocalContext.current
-    var showMapModal by remember { mutableStateOf(false) }
-
-    val presets = remember {
-        listOf(
-            Triple("MUST Main Campus (Nchiru)", -0.0076, 37.6534),
-            Triple("Tuition & Admin Block", -0.0075, 37.6535),
-            Triple("MUST Library", -0.0074, 37.6532),
-            Triple("Engineering & Tech Block", -0.0073, 37.6538),
-            Triple("Campus Hostels", -0.0080, 37.6530),
-        )
-    }
-
-    HustleCard(
-        modifier = modifier,
-        variant = HustleCardVariant.Surface,
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Default.LocationOn,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(20.dp),
-                )
-                Text(
-                    text = "Service Operating Location",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-
-            Spacer(Modifier.height(4.dp))
-
-            Text(
-                text = "Where will you provide this service when operating on campus?",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            Spacer(Modifier.height(12.dp))
-
-            // Selection Mode Chips
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilterChip(
-                    selected = locationMode == LocationSelectionMode.CAMPUS_PRESET,
-                    onClick = { onModeChange(LocationSelectionMode.CAMPUS_PRESET) },
-                    label = { Text("Preset", fontSize = 11.sp) },
-                    leadingIcon = {
-                        Icon(Icons.Default.School, contentDescription = null, modifier = Modifier.size(14.dp))
-                    },
-                )
-
-                FilterChip(
-                    selected = locationMode == LocationSelectionMode.CURRENT_GPS,
-                    onClick = {
-                        onModeChange(LocationSelectionMode.CURRENT_GPS)
-                        val fusedClient = LocationServices.getFusedLocationProviderClient(context)
-                        try {
-                            fusedClient.lastLocation.addOnSuccessListener { loc ->
-                                loc?.let {
-                                    onCustomLocationSelect(it.latitude, it.longitude, "Current Device Location")
-                                }
-                            }
-                        } catch (e: SecurityException) {
-                            timber.log.Timber.e(e, "GPS permission error")
-                        }
-                    },
-                    label = { Text("My GPS", fontSize = 11.sp) },
-                    leadingIcon = {
-                        Icon(Icons.Default.MyLocation, contentDescription = null, modifier = Modifier.size(14.dp))
-                    },
-                )
-
-                FilterChip(
-                    selected = locationMode == LocationSelectionMode.MAP_PICKER,
-                    onClick = {
-                        onModeChange(LocationSelectionMode.MAP_PICKER)
-                        showMapModal = true
-                    },
-                    label = { Text("Pick on Map", fontSize = 11.sp) },
-                    leadingIcon = {
-                        Icon(Icons.Default.Map, contentDescription = null, modifier = Modifier.size(14.dp))
-                    },
-                )
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            // Details depending on mode
-            when (locationMode) {
-                LocationSelectionMode.CAMPUS_PRESET -> {
-                    Text(
-                        text = "Select Campus Landmark:",
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(Modifier.height(6.dp))
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        for ((name, lat, lng) in presets) {
-                            val isSelected = locationLabel == name
-                            FilterChip(
-                                selected = isSelected,
-                                onClick = { onPresetSelect(name, lat, lng) },
-                                label = { Text(name, fontSize = 11.sp) },
-                                colors = FilterChipDefaults.filterChipColors(
-                                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                                ),
-                            )
-                        }
-                    }
-                }
-                LocationSelectionMode.CURRENT_GPS -> {
-                    Text(
-                        text = if (selectedLat !=
-                            null
-                        ) {
-                            "Detected Coordinates: ${"%.4f".format(selectedLat)}, ${"%.4f".format(selectedLng)}"
-                        } else {
-                            "Detecting GPS location..."
-                        },
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary,
-                        fontWeight = FontWeight.Medium,
-                    )
-                }
-                LocationSelectionMode.MAP_PICKER -> {
-                    HustleButton(
-                        text = if (selectedLat != null) "Change Location on Map" else "Open Map Picker",
-                        onClick = { showMapModal = true },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            // Location note / building name input
-            HustleTextField(
-                value = locationLabel,
-                onValueChange = onLabelChange,
-                placeholder = "Location note (e.g. Hostel 3, Room 12 or Block B)",
-            )
-        }
-    }
-
-    if (showMapModal) {
-        MapLocationPickerModal(
-            initialLat = selectedLat ?: -0.0076,
-            initialLng = selectedLng ?: 37.6534,
-            onLocationConfirmed = { lat, lng ->
-                onCustomLocationSelect(lat, lng, "Custom Map Location (${"%.4f".format(lat)}, ${"%.4f".format(lng)})")
-                showMapModal = false
-            },
-            onDismiss = { showMapModal = false },
-        )
-    }
-}
-
-@Composable
-private fun MapLocationPickerModal(
-    initialLat: Double,
-    initialLng: Double,
-    onLocationConfirmed: (Double, Double) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(LatLng(initialLat, initialLng), 16f)
-    }
-
-    val mapNestedScrollConnection = remember {
-        object : NestedScrollConnection {
-            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                return Offset(0f, available.y)
-            }
-        }
-    }
-
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(0.85f),
-        ) {
-            Text(
-                text = "Drag map to center location pin",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            )
-
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .nestedScroll(mapNestedScrollConnection),
-            ) {
-                GoogleMap(
-                    modifier = Modifier.fillMaxSize(),
-                    cameraPositionState = cameraPositionState,
-                )
-
-                // Center pin overlay
-                Icon(
-                    imageVector = Icons.Default.LocationOn,
-                    contentDescription = "Target Pin",
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .size(36.dp)
-                        .align(Alignment.Center),
-                )
-            }
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                HustleButton(
-                    text = "Confirm Location",
-                    onClick = {
-                        val target = cameraPositionState.position.target
-                        onLocationConfirmed(target.latitude, target.longitude)
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                )
             }
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/MyServicesScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/MyServicesScreen.kt
@@ -10,12 +10,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
-import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -31,7 +30,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -56,6 +54,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.DeleteConfirmDialog
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.PortfolioSlots
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ServiceManagementCard

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/MyServicesScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/MyServicesScreen.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -172,9 +174,10 @@ fun MyServicesScreen(
         }
     }
 
-    Scaffold(
+    HustleScaffold(
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Text(
                         text = "My Services",

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/WriteReviewScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/WriteReviewScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,9 +19,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.rememberScrollState
-import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -36,7 +35,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -54,6 +52,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.sharedComposables.HustleTextField
 import must.kdroiders.hustlehub.sharedComposables.RatingBar
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.WriteReviewViewModel

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/WriteReviewScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/WriteReviewScreen.kt
@@ -18,7 +18,9 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.rememberScrollState
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -85,10 +87,11 @@ fun WriteReviewScreen(
         }
     }
 
-    Scaffold(
+    HustleScaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             CenterAlignedTopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = {
                     Text(
                         text = "Write a Review",

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
@@ -1,0 +1,297 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapType
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.rememberUpdatedMarkerState
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.sharedComposables.HustleButton
+
+// Default area for the map picker — Nchiru / MUST campus
+private val NCHIRU_LATLNG = LatLng(-0.0076, 37.6534)
+private const val MAP_PICKER_ZOOM = 17f
+
+// Represents the three map view modes available in the picker
+private enum class PickerMapType(val label: String, val mapType: MapType) {
+    NORMAL("Normal", MapType.NORMAL),
+    SATELLITE("Satellite", MapType.SATELLITE),
+    HYBRID("Hybrid", MapType.HYBRID),
+}
+
+@Composable
+fun MapLocationPickerModal(
+    initialLat: Double,
+    initialLng: Double,
+    onLocationConfirmed: (Double, Double) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // Default to Nchiru if no previous coordinate is set
+    val startLatLng = remember {
+        if (initialLat == 0.0 && initialLng == 0.0) NCHIRU_LATLNG
+        else LatLng(initialLat, initialLng)
+    }
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(startLatLng, MAP_PICKER_ZOOM)
+    }
+
+    // Pinned location — null means no tap yet (center-drag mode only)
+    var pinnedLatLng by remember { mutableStateOf<LatLng?>(null) }
+    val markerState = rememberUpdatedMarkerState(position = startLatLng)
+
+    // Current map type selection
+    var pickerMapType by remember { mutableStateOf(PickerMapType.NORMAL) }
+
+    val mapProperties = remember(pickerMapType) {
+        MapProperties(mapType = pickerMapType.mapType)
+    }
+    val mapUiSettings = remember {
+        MapUiSettings(
+            zoomControlsEnabled = false,
+            myLocationButtonEnabled = false,
+            compassEnabled = true,
+            mapToolbarEnabled = false,
+        )
+    }
+
+    // Swallow vertical scroll so the bottom sheet cannot close when panning the map
+    val mapNestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset =
+                Offset(0f, available.y)
+        }
+    }
+
+    // The coordinate shown in the confirmation card
+    val confirmedLat: Double
+    val confirmedLng: Double
+    if (pinnedLatLng != null) {
+        confirmedLat = pinnedLatLng!!.latitude
+        confirmedLng = pinnedLatLng!!.longitude
+    } else {
+        confirmedLat = cameraPositionState.position.target.latitude
+        confirmedLng = cameraPositionState.position.target.longitude
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = null, // Removed drag handle — map needs all vertical space
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.92f),
+        ) {
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column {
+                    Text(
+                        text = "Pin Your Location",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "Tap the map to drop a pin, or drag to center",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                // Map type toggle button (layers icon)
+                IconButton(onClick = {
+                    // Cycle through map types
+                    pickerMapType = PickerMapType.entries[
+                        (pickerMapType.ordinal + 1) % PickerMapType.entries.size
+                    ]
+                }) {
+                    Icon(
+                        imageVector = Icons.Default.Layers,
+                        contentDescription = "Toggle map type",
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+
+            // Map type chips
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                PickerMapType.entries.forEach { type ->
+                    val isSelected = pickerMapType == type
+                    FilterChip(
+                        selected = isSelected,
+                        onClick = { pickerMapType = type },
+                        label = { Text(type.label, fontSize = 11.sp) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        ),
+                    )
+                }
+            }
+
+            // Map area
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .nestedScroll(mapNestedScrollConnection),
+            ) {
+                GoogleMap(
+                    modifier = Modifier.fillMaxSize(),
+                    cameraPositionState = cameraPositionState,
+                    properties = mapProperties,
+                    uiSettings = mapUiSettings,
+                    onMapClick = { latLng ->
+                        // Tap auto-pins the location and flies the camera there
+                        pinnedLatLng = latLng
+                        markerState.position = latLng
+                        scope.launch {
+                            cameraPositionState.animate(
+                                CameraUpdateFactory.newLatLng(latLng),
+                                durationMs = 300,
+                            )
+                        }
+                    },
+                ) {
+                    // Show marker only when the user has tapped a point
+                    if (pinnedLatLng != null) {
+                        Marker(
+                            state = markerState,
+                            title = "Selected Location",
+                        )
+                    }
+                }
+
+                // Center crosshair — visible when no pin is dropped yet
+                if (pinnedLatLng == null) {
+                    Icon(
+                        imageVector = Icons.Default.Place,
+                        contentDescription = "Drag target",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .align(Alignment.Center),
+                    )
+                }
+            }
+
+            // Confirmation card
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                tonalElevation = 2.dp,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.LocationOn,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Text(
+                            text = if (pinnedLatLng != null) "Pinned location" else "Center of view",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Text(
+                        text = "${"%.5f".format(confirmedLat)}, ${"%.5f".format(confirmedLng)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = if (pinnedLatLng != null)
+                            "Tap anywhere else to move pin"
+                        else
+                            "Drag the map, then tap to drop a pin",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    )
+
+                    Spacer(Modifier.height(8.dp))
+
+                    HustleButton(
+                        text = "Confirm Location",
+                        onClick = { onLocationConfirmed(confirmedLat, confirmedLng) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
@@ -3,11 +3,6 @@
 package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 
 import android.location.Geocoder
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -97,7 +91,11 @@ fun extractAreaName(fullAddress: String): String {
     return when {
         parts.size >= 3 -> {
             val locality = parts.getOrNull(1)?.takeIf { !it.contains(Regex("\\d{5}")) } ?: parts.getOrNull(0)
-            val city = parts.getOrNull(2)?.replace(Regex("\\d+"), "")?.trim()?.takeIf { it.isNotBlank() && it != "Kenya" }
+            val city = parts
+                .getOrNull(2)
+                ?.replace(Regex("\\d+"), "")
+                ?.trim()
+                ?.takeIf { it.isNotBlank() && it != "Kenya" }
             if (city != null && locality != null && city != locality) {
                 "$locality, $city"
             } else {
@@ -122,8 +120,11 @@ fun MapLocationPickerModal(
 
     // Default to Nchiru if no previous coordinate is set
     val startLatLng = remember {
-        if (initialLat == 0.0 && initialLng == 0.0) NCHIRU_LATLNG
-        else LatLng(initialLat, initialLng)
+        if (initialLat == 0.0 && initialLng == 0.0) {
+            NCHIRU_LATLNG
+        } else {
+            LatLng(initialLat, initialLng)
+        }
     }
 
     val cameraPositionState = rememberCameraPositionState {
@@ -156,8 +157,10 @@ fun MapLocationPickerModal(
     // Swallow vertical scroll so the bottom sheet cannot close when panning the map
     val mapNestedScrollConnection = remember {
         object : NestedScrollConnection {
-            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset =
-                Offset(0f, available.y)
+            override fun onPreScroll(
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset = Offset(0f, available.y)
         }
     }
 
@@ -178,6 +181,7 @@ fun MapLocationPickerModal(
         withContext(Dispatchers.IO) {
             try {
                 val geocoder = Geocoder(context, Locale.getDefault())
+
                 @Suppress("DEPRECATION")
                 val addresses = geocoder.getFromLocation(confirmedLat, confirmedLng, 1)
                 if (!addresses.isNullOrEmpty()) {
@@ -237,7 +241,7 @@ fun MapLocationPickerModal(
                 // Map type toggle button (layers icon)
                 IconButton(onClick = {
                     pickerMapType = PickerMapType.entries[
-                        (pickerMapType.ordinal + 1) % PickerMapType.entries.size
+                        (pickerMapType.ordinal + 1) % PickerMapType.entries.size,
                     ]
                 }) {
                     Icon(
@@ -376,8 +380,7 @@ fun MapLocationPickerModal(
                                 .background(
                                     color = MaterialTheme.colorScheme.primaryContainer,
                                     shape = RoundedCornerShape(8.dp),
-                                )
-                                .padding(8.dp),
+                                ).padding(8.dp),
                         ) {
                             Icon(
                                 imageVector = Icons.Default.LocationOn,
@@ -397,7 +400,13 @@ fun MapLocationPickerModal(
                                 overflow = TextOverflow.Ellipsis,
                             )
                             Text(
-                                text = if (geocodedAddress.isNotBlank()) geocodedAddress else "${"%.5f".format(confirmedLat)}, ${"%.5f".format(confirmedLng)}",
+                                text = if (geocodedAddress.isNotBlank()) {
+                                    geocodedAddress
+                                } else {
+                                    "${"%.5f".format(
+                                        confirmedLat,
+                                    )}, ${"%.5f".format(confirmedLng)}"
+                                },
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 maxLines = 1,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
@@ -1,7 +1,14 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 
 package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 
+import android.location.Geocoder
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,21 +20,28 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,14 +49,17 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -53,8 +70,11 @@ import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberUpdatedMarkerState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import java.util.Locale
 
 // Default area for the map picker — Nchiru / MUST campus
 private val NCHIRU_LATLNG = LatLng(-0.0076, 37.6534)
@@ -67,13 +87,36 @@ private enum class PickerMapType(val label: String, val mapType: MapType) {
     HYBRID("Hybrid", MapType.HYBRID),
 }
 
+/**
+ * Helper to extract a clean, concise area/locality name from full geocoded address.
+ * E.g., "Nchiru Market, Meru-Maua Road, Nchiru, Meru, Kenya" → "Nchiru, Meru"
+ */
+fun extractAreaName(fullAddress: String): String {
+    if (fullAddress.isBlank()) return "Selected Location"
+    val parts = fullAddress.split(",").map { it.trim() }
+    return when {
+        parts.size >= 3 -> {
+            val locality = parts.getOrNull(1)?.takeIf { !it.contains(Regex("\\d{5}")) } ?: parts.getOrNull(0)
+            val city = parts.getOrNull(2)?.replace(Regex("\\d+"), "")?.trim()?.takeIf { it.isNotBlank() && it != "Kenya" }
+            if (city != null && locality != null && city != locality) {
+                "$locality, $city"
+            } else {
+                locality ?: parts[0]
+            }
+        }
+        parts.size == 2 -> "${parts[0]}, ${parts[1]}"
+        else -> parts.firstOrNull() ?: fullAddress
+    }
+}
+
 @Composable
 fun MapLocationPickerModal(
     initialLat: Double,
     initialLng: Double,
-    onLocationConfirmed: (Double, Double) -> Unit,
+    onLocationConfirmed: (lat: Double, lng: Double, label: String) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -87,12 +130,16 @@ fun MapLocationPickerModal(
         position = CameraPosition.fromLatLngZoom(startLatLng, MAP_PICKER_ZOOM)
     }
 
-    // Pinned location — null means no tap yet (center-drag mode only)
+    // Pinned location — null means no tap yet (center-drag mode)
     var pinnedLatLng by remember { mutableStateOf<LatLng?>(null) }
     val markerState = rememberUpdatedMarkerState(position = startLatLng)
 
     // Current map type selection
     var pickerMapType by remember { mutableStateOf(PickerMapType.NORMAL) }
+
+    // Geocoded address & loading state
+    var geocodedAddress by remember { mutableStateOf("") }
+    var isGeocoding by remember { mutableStateOf(false) }
 
     val mapProperties = remember(pickerMapType) {
         MapProperties(mapType = pickerMapType.mapType)
@@ -114,7 +161,7 @@ fun MapLocationPickerModal(
         }
     }
 
-    // The coordinate shown in the confirmation card
+    // The active coordinate shown in the confirmation card
     val confirmedLat: Double
     val confirmedLng: Double
     if (pinnedLatLng != null) {
@@ -125,10 +172,41 @@ fun MapLocationPickerModal(
         confirmedLng = cameraPositionState.position.target.longitude
     }
 
+    // Asynchronously reverse-geocode target coordinates (Bongesha pattern)
+    LaunchedEffect(confirmedLat, confirmedLng) {
+        isGeocoding = true
+        withContext(Dispatchers.IO) {
+            try {
+                val geocoder = Geocoder(context, Locale.getDefault())
+                @Suppress("DEPRECATION")
+                val addresses = geocoder.getFromLocation(confirmedLat, confirmedLng, 1)
+                if (!addresses.isNullOrEmpty()) {
+                    val addr = addresses[0]
+                    val lines = (0..addr.maxAddressLineIndex).mapNotNull { addr.getAddressLine(it) }
+                    geocodedAddress = if (lines.isNotEmpty()) lines.joinToString(", ") else ""
+                } else {
+                    geocodedAddress = ""
+                }
+            } catch (e: Exception) {
+                geocodedAddress = ""
+            } finally {
+                isGeocoding = false
+            }
+        }
+    }
+
+    val displayAreaName = remember(geocodedAddress, confirmedLat, confirmedLng) {
+        if (geocodedAddress.isNotBlank()) {
+            extractAreaName(geocodedAddress)
+        } else {
+            "Custom Map Location (${"%.4f".format(confirmedLat)}, ${"%.4f".format(confirmedLng)})"
+        }
+    }
+
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
-        dragHandle = null, // Removed drag handle — map needs all vertical space
+        dragHandle = null,
     ) {
         Column(
             modifier = Modifier
@@ -145,7 +223,7 @@ fun MapLocationPickerModal(
             ) {
                 Column {
                     Text(
-                        text = "Pin Your Location",
+                        text = "Pin Operating Location",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface,
@@ -158,7 +236,6 @@ fun MapLocationPickerModal(
                 }
                 // Map type toggle button (layers icon)
                 IconButton(onClick = {
-                    // Cycle through map types
                     pickerMapType = PickerMapType.entries[
                         (pickerMapType.ordinal + 1) % PickerMapType.entries.size
                     ]
@@ -206,7 +283,6 @@ fun MapLocationPickerModal(
                     properties = mapProperties,
                     uiSettings = mapUiSettings,
                     onMapClick = { latLng ->
-                        // Tap auto-pins the location and flies the camera there
                         pinnedLatLng = latLng
                         markerState.position = latLng
                         scope.launch {
@@ -217,11 +293,10 @@ fun MapLocationPickerModal(
                         }
                     },
                 ) {
-                    // Show marker only when the user has tapped a point
                     if (pinnedLatLng != null) {
                         Marker(
                             state = markerState,
-                            title = "Selected Location",
+                            title = displayAreaName,
                         )
                     }
                 }
@@ -237,57 +312,107 @@ fun MapLocationPickerModal(
                             .align(Alignment.Center),
                     )
                 }
+
+                // Floating "My Location" button (Bongesha pattern)
+                IconButton(
+                    onClick = {
+                        val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+                        try {
+                            fusedClient.lastLocation.addOnSuccessListener { location ->
+                                location?.let {
+                                    val userLatLng = LatLng(it.latitude, it.longitude)
+                                    pinnedLatLng = userLatLng
+                                    markerState.position = userLatLng
+                                    scope.launch {
+                                        cameraPositionState.animate(
+                                            CameraUpdateFactory.newLatLngZoom(userLatLng, MAP_PICKER_ZOOM),
+                                            durationMs = 300,
+                                        )
+                                    }
+                                }
+                            }
+                        } catch (e: SecurityException) {
+                            // Permission check error
+                        }
+                    },
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(16.dp)
+                        .shadow(4.dp, CircleShape)
+                        .background(MaterialTheme.colorScheme.surface, CircleShape)
+                        .size(44.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.MyLocation,
+                        contentDescription = "My Location",
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
             }
 
-            // Confirmation card
+            // Confirmation card (Bongesha styled)
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.surfaceVariant,
                 tonalElevation = 2.dp,
             ) {
                 Column(
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.LocationOn,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(16.dp),
-                        )
-                        Text(
-                            text = if (pinnedLatLng != null) "Pinned location" else "Center of view",
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    if (isGeocoding) {
+                        LinearWavyProgressIndicator(
+                            modifier = Modifier.fillMaxWidth(),
+                            color = MaterialTheme.colorScheme.primary,
                         )
                     }
-                    Text(
-                        text = "${"%.5f".format(confirmedLat)}, ${"%.5f".format(confirmedLng)}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = if (pinnedLatLng != null)
-                            "Tap anywhere else to move pin"
-                        else
-                            "Drag the map, then tap to drop a pin",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                    )
 
-                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .background(
+                                    color = MaterialTheme.colorScheme.primaryContainer,
+                                    shape = RoundedCornerShape(8.dp),
+                                )
+                                .padding(8.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.LocationOn,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = displayAreaName,
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = if (geocodedAddress.isNotBlank()) geocodedAddress else "${"%.5f".format(confirmedLat)}, ${"%.5f".format(confirmedLng)}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(4.dp))
 
                     HustleButton(
                         text = "Confirm Location",
-                        onClick = { onLocationConfirmed(confirmedLat, confirmedLng) },
+                        onClick = {
+                            onLocationConfirmed(confirmedLat, confirmedLng, displayAreaName)
+                        },
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceLocationCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceLocationCard.kt
@@ -2,7 +2,6 @@ package must.kdroiders.hustlehub.ui.features.service.presentation.view.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceLocationCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceLocationCard.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalLayoutApi::class)
-
 package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 
 import androidx.compose.foundation.layout.Arrangement
@@ -209,8 +207,8 @@ fun ServiceLocationCard(
         MapLocationPickerModal(
             initialLat = selectedLat ?: -0.0076,
             initialLng = selectedLng ?: 37.6534,
-            onLocationConfirmed = { lat, lng ->
-                onCustomLocationSelect(lat, lng, "Custom Map Location (${"%.4f".format(lat)}, ${"%.4f".format(lng)})")
+            onLocationConfirmed = { lat, lng, addressLabel ->
+                onCustomLocationSelect(lat, lng, addressLabel)
                 showMapModal = false
             },
             onDismiss = { showMapModal = false },

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceLocationCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceLocationCard.kt
@@ -1,0 +1,219 @@
+@file:OptIn(ExperimentalLayoutApi::class)
+
+package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.android.gms.location.LocationServices
+import must.kdroiders.hustlehub.sharedComposables.HustleButton
+import must.kdroiders.hustlehub.sharedComposables.HustleCard
+import must.kdroiders.hustlehub.sharedComposables.HustleCardVariant
+import must.kdroiders.hustlehub.sharedComposables.HustleTextField
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.LocationSelectionMode
+
+@Composable
+fun ServiceLocationCard(
+    locationMode: LocationSelectionMode,
+    selectedLat: Double?,
+    selectedLng: Double?,
+    locationLabel: String,
+    onModeChange: (LocationSelectionMode) -> Unit,
+    onPresetSelect: (String, Double, Double) -> Unit,
+    onCustomLocationSelect: (Double, Double, String) -> Unit,
+    onLabelChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var showMapModal by remember { mutableStateOf(false) }
+
+    val presets = remember {
+        listOf(
+            Triple("MUST Main Campus (Nchiru)", -0.0076, 37.6534),
+            Triple("Tuition & Admin Block", -0.0075, 37.6535),
+            Triple("MUST Library", -0.0074, 37.6532),
+            Triple("Engineering & Tech Block", -0.0073, 37.6538),
+            Triple("Campus Hostels", -0.0080, 37.6530),
+        )
+    }
+
+    HustleCard(
+        modifier = modifier,
+        variant = HustleCardVariant.Surface,
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text(
+                    text = "Service Operating Location",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            Spacer(Modifier.height(4.dp))
+
+            Text(
+                text = "Where will you provide this service when operating on campus?",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // Selection Mode Chips
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(
+                    selected = locationMode == LocationSelectionMode.CAMPUS_PRESET,
+                    onClick = { onModeChange(LocationSelectionMode.CAMPUS_PRESET) },
+                    label = { Text("Preset", fontSize = 11.sp) },
+                    leadingIcon = {
+                        Icon(Icons.Default.School, contentDescription = null, modifier = Modifier.size(14.dp))
+                    },
+                )
+
+                FilterChip(
+                    selected = locationMode == LocationSelectionMode.CURRENT_GPS,
+                    onClick = {
+                        onModeChange(LocationSelectionMode.CURRENT_GPS)
+                        val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+                        try {
+                            fusedClient.lastLocation.addOnSuccessListener { loc ->
+                                loc?.let {
+                                    onCustomLocationSelect(it.latitude, it.longitude, "Current Device Location")
+                                }
+                            }
+                        } catch (e: SecurityException) {
+                            timber.log.Timber.e(e, "GPS permission error")
+                        }
+                    },
+                    label = { Text("My GPS", fontSize = 11.sp) },
+                    leadingIcon = {
+                        Icon(Icons.Default.MyLocation, contentDescription = null, modifier = Modifier.size(14.dp))
+                    },
+                )
+
+                FilterChip(
+                    selected = locationMode == LocationSelectionMode.MAP_PICKER,
+                    onClick = {
+                        onModeChange(LocationSelectionMode.MAP_PICKER)
+                        showMapModal = true
+                    },
+                    label = { Text("Pick on Map", fontSize = 11.sp) },
+                    leadingIcon = {
+                        Icon(Icons.Default.Map, contentDescription = null, modifier = Modifier.size(14.dp))
+                    },
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // Details depending on mode
+            when (locationMode) {
+                LocationSelectionMode.CAMPUS_PRESET -> {
+                    Text(
+                        text = "Select Campus Landmark:",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        for ((name, lat, lng) in presets) {
+                            val isSelected = locationLabel == name
+                            FilterChip(
+                                selected = isSelected,
+                                onClick = { onPresetSelect(name, lat, lng) },
+                                label = { Text(name, fontSize = 11.sp) },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                ),
+                            )
+                        }
+                    }
+                }
+                LocationSelectionMode.CURRENT_GPS -> {
+                    Text(
+                        text = if (selectedLat != null) {
+                            "Detected Coordinates: ${"%.4f".format(selectedLat)}, ${"%.4f".format(selectedLng)}"
+                        } else {
+                            "Detecting GPS location..."
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+                LocationSelectionMode.MAP_PICKER -> {
+                    HustleButton(
+                        text = if (selectedLat != null) "Change Location on Map" else "Open Map Picker",
+                        onClick = { showMapModal = true },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // Location note / building name input
+            HustleTextField(
+                value = locationLabel,
+                onValueChange = onLabelChange,
+                placeholder = "Location note (e.g. Hostel 3, Room 12 or Block B)",
+            )
+        }
+    }
+
+    if (showMapModal) {
+        MapLocationPickerModal(
+            initialLat = selectedLat ?: -0.0076,
+            initialLng = selectedLng ?: 37.6534,
+            onLocationConfirmed = { lat, lng ->
+                onCustomLocationSelect(lat, lng, "Custom Map Location (${"%.4f".format(lat)}, ${"%.4f".format(lng)})")
+                showMapModal = false
+            },
+            onDismiss = { showMapModal = false },
+        )
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/CreateServiceViewModel.kt
@@ -18,12 +18,19 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.core.utils.ImageCompressor
 import must.kdroiders.hustlehub.ui.features.media.domain.repository.StorageRepository
+import must.kdroiders.hustlehub.ui.features.media.domain.repository.UploadResult
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceAvailability
 import must.kdroiders.hustlehub.ui.features.service.domain.model.ServiceCategory
 import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceByIdUseCase
 import timber.log.Timber
 import javax.inject.Inject
+
+enum class LocationSelectionMode {
+    CAMPUS_PRESET,
+    CURRENT_GPS,
+    MAP_PICKER,
+}
 
 data class CreateServiceUiState(
     val isEditMode: Boolean = false,
@@ -41,6 +48,11 @@ data class CreateServiceUiState(
     val tags: List<String> = emptyList(),
     val tagError: String? = null,
     val openToBarter: Boolean = false,
+    // Operating Location
+    val locationMode: LocationSelectionMode = LocationSelectionMode.CAMPUS_PRESET,
+    val selectedLat: Double? = -0.0076,
+    val selectedLng: Double? = 37.6534,
+    val locationLabel: String = "MUST Main Campus (Nchiru)",
     // Portfolio
     val portfolioUris: List<Uri> = emptyList(), // newly picked local images
     val existingPortfolioUrls: List<String> = emptyList(), // loaded from server on edit
@@ -228,6 +240,60 @@ class CreateServiceViewModel
             }
         }
 
+        // --- Location ---
+
+        fun onLocationModeChange(mode: LocationSelectionMode) {
+            _uiState.update { state ->
+                when (mode) {
+                    LocationSelectionMode.CAMPUS_PRESET -> state.copy(
+                        locationMode = mode,
+                        selectedLat = -0.0076,
+                        selectedLng = 37.6534,
+                        locationLabel = "MUST Main Campus (Nchiru)",
+                    )
+                    LocationSelectionMode.CURRENT_GPS -> state.copy(
+                        locationMode = mode,
+                    )
+                    LocationSelectionMode.MAP_PICKER -> state.copy(
+                        locationMode = mode,
+                    )
+                }
+            }
+        }
+
+        fun onLocationPresetSelect(
+            name: String,
+            lat: Double,
+            lng: Double,
+        ) {
+            _uiState.update {
+                it.copy(
+                    locationMode = LocationSelectionMode.CAMPUS_PRESET,
+                    selectedLat = lat,
+                    selectedLng = lng,
+                    locationLabel = name,
+                )
+            }
+        }
+
+        fun onCustomLocationSelect(
+            lat: Double,
+            lng: Double,
+            label: String,
+        ) {
+            _uiState.update {
+                it.copy(
+                    selectedLat = lat,
+                    selectedLng = lng,
+                    locationLabel = label,
+                )
+            }
+        }
+
+        fun onLocationLabelChange(label: String) {
+            _uiState.update { it.copy(locationLabel = label) }
+        }
+
         fun publish() {
             if (!validate()) return
 
@@ -250,6 +316,9 @@ class CreateServiceViewModel
                         maxPrice = maxPrice,
                         openToBarter = state.openToBarter,
                         tags = state.tags,
+                        lat = state.selectedLat,
+                        lng = state.selectedLng,
+                        locationLabel = state.locationLabel,
                     )
                 } else {
                     serviceRepository.createService(
@@ -260,6 +329,9 @@ class CreateServiceViewModel
                         maxPrice = maxPrice,
                         openToBarter = state.openToBarter,
                         tags = state.tags,
+                        lat = state.selectedLat,
+                        lng = state.selectedLng,
+                        locationLabel = state.locationLabel,
                     )
                 }
 
@@ -278,7 +350,7 @@ class CreateServiceViewModel
                                             // Flow usually emits once then completes for single uploads, collect first result
                                             var url: String? = null
                                             storageRepository.uploadPortfolioImage(targetId, bytes).collect { result ->
-                                                if (result is must.kdroiders.hustlehub.ui.features.media.domain.repository.UploadResult.Success) {
+                                                if (result is UploadResult.Success) {
                                                     url = result.url
                                                 }
                                             }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
@@ -72,7 +72,9 @@ fun SettingsScreen(
                 is SettingsEvent.LoggedOut -> onBack() // parent nav graph pops to Login
                 is SettingsEvent.NavigateToChangePassword -> onNavigateToChangePassword()
                 else -> {
-                    android.widget.Toast.makeText(context, "Coming soon", android.widget.Toast.LENGTH_SHORT).show()
+                    android.widget.Toast
+                        .makeText(context, "Coming soon", android.widget.Toast.LENGTH_SHORT)
+                        .show()
                 }
             }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
@@ -63,13 +63,17 @@ fun SettingsScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
 
+    val context = androidx.compose.ui.platform.LocalContext.current
+
     // Consume one-shot navigation events
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
                 is SettingsEvent.LoggedOut -> onBack() // parent nav graph pops to Login
                 is SettingsEvent.NavigateToChangePassword -> onNavigateToChangePassword()
-                else -> { /* TODO: handle sub-screen navigation */ }
+                else -> {
+                    android.widget.Toast.makeText(context, "Coming soon", android.widget.Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/viewmodel/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package must.kdroiders.hustlehub.ui.features.settings.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -10,10 +11,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import must.kdroiders.hustlehub.data.local.AppDatabase
 import must.kdroiders.hustlehub.datastore.UserPreferences
 import must.kdroiders.hustlehub.ui.features.auth.domain.repository.AuthRepository
 import must.kdroiders.hustlehub.ui.features.auth.domain.usecase.SignOutUseCase
-import must.kdroiders.hustlehub.ui.features.service.data.local.dao.ServiceDao
+import must.kdroiders.hustlehub.ui.features.chat.domain.repository.ChatRepository
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -63,7 +66,8 @@ class SettingsViewModel
         private val authRepository: AuthRepository,
         private val signOutUseCase: SignOutUseCase,
         private val userPreferences: UserPreferences,
-        private val serviceDao: ServiceDao,
+        private val appDatabase: AppDatabase,
+        private val chatRepository: ChatRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(SettingsUiState())
         val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
@@ -97,7 +101,6 @@ class SettingsViewModel
 
         fun onDarkModeToggled(enabled: Boolean) {
             _uiState.update { it.copy(isDarkMode = enabled) }
-            // TODO: persist via DataStore — userPreferences.setDarkMode(enabled)
         }
 
         // Navigation triggers
@@ -115,16 +118,19 @@ class SettingsViewModel
 
         /**
          * Signs the user out of Firebase Auth via [SignOutUseCase], clears the cached
-         * user from DataStore, and emits [SettingsEvent.LoggedOut] to trigger navigation
-         * back to the Login screen.
+         * user from DataStore, disconnects active WebSockets, clears local Room database tables,
+         * and emits [SettingsEvent.LoggedOut] to trigger navigation back to the Login screen.
          */
         fun onLogOutClicked() {
             viewModelScope.launch {
                 _uiState.update { it.copy(isLoggingOut = true, error = null) }
                 try {
+                    runCatching { chatRepository.disconnectWebSocket() }
                     signOutUseCase()
                     userPreferences.clearUser()
-                    serviceDao.clearAll()
+                    withContext(Dispatchers.IO) {
+                        appDatabase.clearAllTables()
+                    }
                     _events.send(SettingsEvent.LoggedOut)
                 } catch (e: Exception) {
                     Timber.e(e, "Sign out failed")

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Color.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Color.kt
@@ -7,8 +7,9 @@ val HustlePrimaryBlue = Color(0xFF1E88E5) // Main brand/action color
 val HustleLinkBlue = Color(0xFF2563EB) // Clickable text — Sign Up, Forgot password
 
 // Light mode surfaces
-val HustleLightBackground = Color(0xFFF5F7FA) // Page background (very light grey)
-val HustleWhite = Color(0xFFFFFFFF) // Cards, inputs, Google button
+val HustleLightBackground = Color(0xFFF8FAFC) // Clean slate page canvas
+val HustleWhite = Color(0xFFFFFFFF) // Crisp card surface
+val HustleLightSurfaceVariant = Color(0xFFF1F5F9) // Distinct tonal card container fill
 
 // Text
 val HustleDarkNavy = Color(0xFF0F172A) // Strong title text — "Hustle" wordmark

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Dimensions.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Dimensions.kt
@@ -1,26 +1,22 @@
 package must.kdroiders.hustlehub.ui.theme
 
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
- * HustleHub spacing system based on a 4dp grid.
- *
- * Example usage:
- * ```kotlin
- * Column(
- *     modifier = Modifier.padding(LocalDimensions.current.spacing16)
- * ) {
- *     Text("Hello")
- *     Spacer(modifier = Modifier.height(LocalDimensions.current.spacing8))
- *     Text("World")
- * }
- * ```
+ * Adaptive responsive dimensions system.
+ * Optimized for card-heavy marketplace layouts with immersive edge-to-edge margins.
  */
 @Immutable
 data class Dimensions(
+    val horizontalPadding: Dp = 12.dp,
+    val verticalPadding: Dp = 12.dp,
+    val gridSpacing: Dp = 10.dp,
+    val gridColumns: Int = 2,
+    val cardCornerRadius: Dp = 20.dp,
+    val cardContentPadding: Dp = 16.dp,
     val spacing4: Dp = 4.dp,
     val spacing8: Dp = 8.dp,
     val spacing12: Dp = 12.dp,
@@ -30,8 +26,36 @@ data class Dimensions(
     val spacing48: Dp = 48.dp,
 )
 
-// Shared singleton — never changes at runtime
-val DefaultDimensions = Dimensions()
+/** Small compact phones (< 360dp width e.g. Pixel 4a / small budget devices) */
+fun compactDimensions() = Dimensions(
+    horizontalPadding = 8.dp,
+    verticalPadding = 8.dp,
+    gridSpacing = 8.dp,
+    gridColumns = 2,
+    cardCornerRadius = 16.dp,
+    cardContentPadding = 12.dp,
+)
 
-// staticCompositionLocalOf: reads are NOT tracked, so no recomposition when provided value changes
-val LocalDimensions = staticCompositionLocalOf { DefaultDimensions }
+/** Standard devices (360dp – 600dp width) */
+fun standardDimensions() = Dimensions(
+    horizontalPadding = 12.dp,
+    verticalPadding = 12.dp,
+    gridSpacing = 10.dp,
+    gridColumns = 2,
+    cardCornerRadius = 20.dp,
+    cardContentPadding = 16.dp,
+)
+
+/** Large foldables and tablets (>= 600dp width) */
+fun expandedDimensions() = Dimensions(
+    horizontalPadding = 20.dp,
+    verticalPadding = 16.dp,
+    gridSpacing = 14.dp,
+    gridColumns = 3,
+    cardCornerRadius = 24.dp,
+    cardContentPadding = 20.dp,
+)
+
+val DefaultDimensions = standardDimensions()
+
+val LocalDimensions = compositionLocalOf { DefaultDimensions }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Dimensions.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Dimensions.kt
@@ -27,34 +27,37 @@ data class Dimensions(
 )
 
 /** Small compact phones (< 360dp width e.g. Pixel 4a / small budget devices) */
-fun compactDimensions() = Dimensions(
-    horizontalPadding = 8.dp,
-    verticalPadding = 8.dp,
-    gridSpacing = 8.dp,
-    gridColumns = 2,
-    cardCornerRadius = 16.dp,
-    cardContentPadding = 12.dp,
-)
+fun compactDimensions() =
+    Dimensions(
+        horizontalPadding = 8.dp,
+        verticalPadding = 8.dp,
+        gridSpacing = 8.dp,
+        gridColumns = 2,
+        cardCornerRadius = 16.dp,
+        cardContentPadding = 12.dp,
+    )
 
 /** Standard devices (360dp – 600dp width) */
-fun standardDimensions() = Dimensions(
-    horizontalPadding = 12.dp,
-    verticalPadding = 12.dp,
-    gridSpacing = 10.dp,
-    gridColumns = 2,
-    cardCornerRadius = 20.dp,
-    cardContentPadding = 16.dp,
-)
+fun standardDimensions() =
+    Dimensions(
+        horizontalPadding = 12.dp,
+        verticalPadding = 12.dp,
+        gridSpacing = 10.dp,
+        gridColumns = 2,
+        cardCornerRadius = 20.dp,
+        cardContentPadding = 16.dp,
+    )
 
 /** Large foldables and tablets (>= 600dp width) */
-fun expandedDimensions() = Dimensions(
-    horizontalPadding = 20.dp,
-    verticalPadding = 16.dp,
-    gridSpacing = 14.dp,
-    gridColumns = 3,
-    cardCornerRadius = 24.dp,
-    cardContentPadding = 20.dp,
-)
+fun expandedDimensions() =
+    Dimensions(
+        horizontalPadding = 20.dp,
+        verticalPadding = 16.dp,
+        gridSpacing = 14.dp,
+        gridColumns = 3,
+        cardCornerRadius = 24.dp,
+        cardContentPadding = 20.dp,
+    )
 
 val DefaultDimensions = standardDimensions()
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Theme.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Theme.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 
 private val LightColorScheme = lightColorScheme(
@@ -94,7 +95,16 @@ fun HustleHubTheme(
         else -> LightColorScheme
     }
 
-    CompositionLocalProvider(LocalDimensions provides DefaultDimensions) {
+    val configuration = LocalConfiguration.current
+    val screenWidthDp = configuration.screenWidthDp
+
+    val dimensions = when {
+        screenWidthDp < 360 -> compactDimensions()
+        screenWidthDp >= 600 -> expandedDimensions()
+        else -> standardDimensions()
+    }
+
+    CompositionLocalProvider(LocalDimensions provides dimensions) {
         MaterialTheme(
             colorScheme = colorScheme,
             typography = Typography,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Theme.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/theme/Theme.kt
@@ -34,7 +34,7 @@ private val LightColorScheme = lightColorScheme(
     onBackground = HustleDarkNavy,
     surface = HustleWhite,
     onSurface = HustleDarkNavy,
-    surfaceVariant = HustleLightBackground,
+    surfaceVariant = HustleLightSurfaceVariant,
     onSurfaceVariant = HustleMediumGrey,
 
     outline = HustleInputBorder,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,16 @@
     <string name="portfolio_status_percent">%1$d%%</string>
     <!-- %1$d = uploaded count, %2$d = total selected -->
     <string name="portfolio_upload_success_count">%1$d of %2$d images uploaded successfully</string>
+
+    <!-- Provider banner (Home screen) -->
+    <string name="banner_provider_label">For Hustlers</string>
+    <string name="banner_provider_title">Start Earning on Campus</string>
+    <string name="banner_provider_subtitle">List your skills and get discovered by students at MUST.</string>
+    <string name="banner_provider_action">List a Service</string>
+    <string name="banner_provider_dismiss">Dismiss provider banner</string>
+
+    <!-- Provider onboarding card (Profile screen) -->
+    <string name="profile_provider_cta_title">Start Your Campus Business</string>
+    <string name="profile_provider_cta_body">List your skills and earn from fellow students at MUST.</string>
+    <string name="profile_provider_cta_action">Create Your First Service</string>
 </resources>

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/map/presentation/viewmodel/MapViewModelTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/map/presentation/viewmodel/MapViewModelTest.kt
@@ -62,7 +62,7 @@ class MapViewModelTest {
         val state = viewModel.uiState.value
         assertTrue(state.pins.isEmpty())
         assertNull(state.selectedCategory)
-        assertEquals(ServiceAvailability.AVAILABLE, state.availability)
+        assertNull(state.availability)
         assertNull(state.userLocation)
         assertNull(state.error)
     }
@@ -80,7 +80,7 @@ class MapViewModelTest {
                     lng = null,
                     radiusKm = null,
                     category = ServiceCategory.SALON,
-                    availability = ServiceAvailability.AVAILABLE,
+                    availability = null,
                 )
             }
         }

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,453 @@
+# HustleHub Android — Development Lanes Plan
+
+> **Stack**: Jetpack Compose · Kotlin 2.x · Hilt · Navigation 3 · Retrofit 2 · Room · OkHttp 4 · Firebase Auth · Material 3 Expressive
+> **Branching**: `lane/feature-branch` → `working` → `dev` → `main`
+
+---
+
+## Overview
+
+The Android frontend is organized into **development lanes** matching the backend's vertical slices. Each lane owns: Retrofit API services, Room entities/DAOs, repository implementations, use cases, ViewModels, Compose screens, and tests for that domain.
+
+Lanes 1–7 cover the MVP features (auth, discovery, chat, reviews, media, notifications). This document defines the **Phase 2 lanes** that correspond to the backend's Lanes 8, 9, and 10.
+
+```
+Lane 8: Monetization & M-Pesa UI         ← Depends on backend Lane 8 APIs being deployed
+Lane 9: Reporting & Pro Badge UI         ← Depends on backend Lanes 8 + 9
+Lane 10: Security Hardening & E2EE Chat  ← Depends on backend Lane 10 (key exchange endpoints)
+```
+
+> **Parallelism**: Lanes 8, 9, and 10 can be developed in parallel by different Android engineers. Each lane is self-contained within its feature package. Lane 10 touches shared chat code (Lane 4) so coordinate with that lane owner.
+
+---
+
+## Lane 8 — Monetization & M-Pesa UI
+
+**Branch**: `lane/monetization-ui`
+**Depends on**: Backend Lane 8 deployed (STK push + subscription endpoints live)
+**Backend APIs consumed**:
+- `POST /api/v1/payments/stk-push`
+- `GET /api/v1/payments/status/{checkoutRequestId}`
+- `GET /api/v1/subscriptions/me`
+
+### Context
+
+Students upgrade to **HustleHub Pro** (~150 KES/month) or purchase **Featured Listing Boosts** (~50 KES/3 days) via M-Pesa Express (STK Push). The Android client triggers the STK push, polls for payment status, and updates the local user state upon successful payment. Pro users see expanded upload limits and a Verified Pro Badge across the app.
+
+### Deliverables
+
+#### Navigation
+- Add `NavKey.Subscription` to `HustleNavKeys.kt` — navigable from Profile screen and discovery feed upgrade prompts
+- Add `NavKey.PaymentStatus(checkoutRequestId: String)` — navigable after STK push trigger
+
+#### Retrofit API Service
+- **`PaymentApiService.kt`** (`feature/monetization/data/remote/`):
+  ```kotlin
+  @POST("payments/stk-push")
+  suspend fun initiateStkPush(@Body request: StkPushRequest): ApiResponse<StkPushResponse>
+
+  @GET("payments/status/{checkoutRequestId}")
+  suspend fun getPaymentStatus(@Path("checkoutRequestId") id: String): ApiResponse<PaymentStatusResponse>
+
+  @GET("subscriptions/me")
+  suspend fun getMySubscription(): ApiResponse<SubscriptionResponse?>
+  ```
+
+#### DTOs (`feature/monetization/data/model/`)
+- `StkPushRequest.kt` — `phoneNumber: String`, `planType: String` (`PRO` / `FEATURED`), `serviceId: String?`
+- `StkPushResponse.kt` — `checkoutRequestId: String`, `responseDescription: String`
+- `PaymentStatusResponse.kt` — `status: String` (`PENDING`, `COMPLETED`, `FAILED`), `mpesaReceiptNumber: String?`
+- `SubscriptionResponse.kt` — `planType: String`, `status: String`, `startDate: String`, `endDate: String`, `isActive: Boolean`
+
+#### Repository
+- **`PaymentRepository.kt`** (`feature/monetization/domain/`):
+  ```kotlin
+  interface PaymentRepository {
+      suspend fun initiateStkPush(phoneNumber: String, planType: String, serviceId: String?): Result<StkPushResponse>
+      suspend fun getPaymentStatus(checkoutRequestId: String): Result<PaymentStatusResponse>
+      suspend fun getMySubscription(): Result<SubscriptionResponse?>
+  }
+  ```
+- **`PaymentRepositoryImpl.kt`** (`feature/monetization/data/`) — calls `PaymentApiService`, maps API responses to `Result<T>`
+
+#### Use Cases (`feature/monetization/domain/usecase/`)
+- `InitiateStkPushUseCase.kt` — validates phone number format (`07XX` → `254XX` conversion), calls repository
+- `PollPaymentStatusUseCase.kt` — polls `getPaymentStatus()` every 3 seconds up to 10 attempts, emits `Flow<PaymentPollState>` with states: `Waiting`, `Completed(receipt)`, `Failed(reason)`, `Timeout`
+- `GetSubscriptionUseCase.kt` — fetches current subscription, returns `null` if none active
+
+#### ViewModel
+- **`MonetizationViewModel.kt`** (`feature/monetization/presentation/`):
+  ```kotlin
+  @HiltViewModel
+  class MonetizationViewModel @Inject constructor(
+      private val initiateStkPush: InitiateStkPushUseCase,
+      private val pollPaymentStatus: PollPaymentStatusUseCase,
+      private val getSubscription: GetSubscriptionUseCase
+  ) : ViewModel() {
+      val subscriptionState: StateFlow<UiState<SubscriptionResponse?>>
+      val paymentState: StateFlow<PaymentUiState>  // Idle, Prompting, Polling, Success, Failed
+
+      fun triggerPayment(phoneNumber: String, planType: String, serviceId: String? = null)
+      fun loadSubscription()
+  }
+  ```
+
+#### Compose Screens (`feature/monetization/presentation/`)
+- **`SubscriptionScreen.kt`**:
+  - Hero section showing HustleHub Pro benefits (badge, priority ranking, 15 photos, auto-replies, analytics)
+  - Side-by-side comparison card: Free Tier vs Pro Tier
+  - Phone number input field (pre-filled from user profile, Kenyan format validation: `07XX...`)
+  - "Upgrade to Pro — 150 KES/month" Material 3 FilledTonalButton
+  - "Boost This Service — 50 KES/3 days" secondary button (when navigated from a specific service)
+  - Bottom sheet with M-Pesa terms and payment info
+- **`PaymentStatusScreen.kt`**:
+  - Animated waiting state: "Check your phone for the M-Pesa PIN prompt..."
+  - Polling indicator with step counter ("Verifying payment... attempt 3/10")
+  - Success state: confetti animation + receipt number + "You're now a Pro Hustler!" message
+  - Failed state: error message + "Try Again" button
+  - Timeout state: "Payment not confirmed. Check your M-Pesa messages and contact support."
+
+#### Pro Badge Integration (modify existing screens)
+- **`HustleCard.kt`** (`sharedComposables/`):
+  - Add `isVerifiedPro: Boolean` parameter
+  - Render a Material 3 `AssistChip` with star icon and "PRO" label next to provider name when `true`
+  - Badge color: `MaterialTheme.colorScheme.tertiary` with subtle glow effect
+- **`ProfileScreen.kt`**:
+  - Show "HustleHub Pro" status card with expiration date if user has active subscription
+  - Show "Upgrade to Pro" CTA button if no active subscription
+- **`ServiceDetailScreen.kt`**:
+  - Display Pro badge next to provider name
+  - For Pro providers: show "Featured" chip if `featuredUntil` is in the future
+- **`CreateServiceScreen.kt`**:
+  - Enforce portfolio photo limits: max 3 for Free, max 15 for Pro
+  - Show upgrade prompt when Free user hits the 3-photo limit
+  - Enable video pitch upload button only for Pro users
+
+#### DataStore Updates
+- **`UserPreferences.kt`** (`datastore/`):
+  - Add `isProUser: Boolean` and `proExpiresAt: String?` fields
+  - Update after subscription fetch to avoid redundant network calls
+
+#### Hilt Module
+- **`MonetizationModule.kt`** (`di/`):
+  - Provide `PaymentApiService` via Retrofit
+  - Bind `PaymentRepository` to `PaymentRepositoryImpl`
+
+#### Tests
+- `InitiateStkPushUseCaseTest` — phone format conversion, valid/invalid phone rejection
+- `PollPaymentStatusUseCaseTest` — success after 3 polls, failure, timeout after 10 polls
+- `MonetizationViewModelTest` — trigger payment flow, verify state transitions (Idle → Prompting → Polling → Success)
+
+---
+
+## Lane 9 — Reporting & Pro Badge UI
+
+**Branch**: `lane/reporting-ui`
+**Depends on**: Backend Lane 9 deployed (report submission + admin APIs live)
+**Backend APIs consumed**:
+- `POST /api/v1/reports`
+
+### Context
+
+Any user can report fraudulent or inappropriate services, providers, or chat behavior. The Android client provides a reporting flow accessible from service detail screens, user profiles, and chat screens. This lane also handles rendering admin-applied badges (verified, suspended indicators) surfaced via existing user/service API responses.
+
+### Deliverables
+
+#### Retrofit API Service
+- **`ReportApiService.kt`** (`feature/reporting/data/remote/`):
+  ```kotlin
+  @POST("reports")
+  suspend fun submitReport(@Body request: SubmitReportRequest): ApiResponse<Unit>
+  ```
+
+#### DTOs (`feature/reporting/data/model/`)
+- `SubmitReportRequest.kt` — `reportedUserId: String?`, `reportedServiceId: String?`, `reason: String`, `details: String?`
+- Report reasons enum: `FRAUD`, `HARASSMENT`, `SPAM`, `INAPPROPRIATE_CONTENT`, `UNFULFILLED_SERVICE`, `OTHER`
+
+#### Repository
+- **`ReportRepository.kt`** (`feature/reporting/domain/`) — interface
+- **`ReportRepositoryImpl.kt`** (`feature/reporting/data/`) — calls `ReportApiService`
+
+#### Use Cases
+- `SubmitReportUseCase.kt` — validates at least one target (user or service) is provided, calls repository
+
+#### ViewModel
+- **`ReportViewModel.kt`** (`feature/reporting/presentation/`):
+  - `val reportState: StateFlow<UiState<Unit>>` — Idle, Loading, Success, Error
+  - `fun submitReport(reportedUserId: String?, reportedServiceId: String?, reason: String, details: String?)`
+
+#### Compose UI (`feature/reporting/presentation/`)
+- **`ReportBottomSheet.kt`**:
+  - Material 3 `ModalBottomSheet` with:
+    - Radio button group for report reason (Fraud, Harassment, Spam, Inappropriate Content, Unfulfilled Service, Other)
+    - Optional details `OutlinedTextField` (max 500 chars)
+    - "Submit Report" button
+    - Success confirmation with "We'll review this within 24 hours" message
+  - Launchable from:
+    - `ServiceDetailScreen.kt` — "Report this service" menu item in top app bar overflow menu
+    - `ProfileScreen.kt` — "Report this user" menu item (only on other users' profiles)
+    - `ChatScreen.kt` — "Report this conversation" menu item
+
+#### Suspension State Handling
+- **`ApiClient.kt`** (modify `core/api/`):
+  - Handle `403` responses with body containing `"Account suspended"` — navigate user to a `SuspendedScreen`
+- **`SuspendedScreen.kt`** (`feature/auth/presentation/`):
+  - Full-screen overlay: "Your account has been suspended"
+  - Display suspension reason from API response
+  - "Contact Support" button linking to email
+  - Sign Out button
+
+#### Model Updates (modify existing)
+- **`User.kt`** (`data/model/`):
+  - Add `isVerifiedPro: Boolean`, `role: String`, `isSuspended: Boolean` fields
+- **`Service.kt`** (`data/model/`):
+  - Add `featuredUntil: String?`, `providerIsVerifiedPro: Boolean` fields
+
+#### Hilt Module
+- **`ReportingModule.kt`** (`di/`) — provide `ReportApiService`, bind `ReportRepository`
+
+#### Tests
+- `SubmitReportUseCaseTest` — valid report submission, reject report with no target
+- `ReportViewModelTest` — verify state transitions, error handling
+
+---
+
+## Lane 10 — Security Hardening & E2EE Chat
+
+**Branch**: `lane/security-e2ee`
+**Depends on**: Backend Lane 10 deployed (key exchange endpoints + encrypted message relay live)
+
+### Context
+
+This lane implements **client-side AES-256-GCM encryption** for all chat messages. Messages are encrypted on-device before being sent over WebSocket and decrypted on the receiving device. The backend stores only ciphertext and acts as a zero-knowledge relay. Key exchange uses **ECDH (Elliptic Curve Diffie-Hellman)** with keys stored in the **Android KeyStore**.
+
+### Deliverables
+
+#### Cryptography Layer (`core/security/`)
+- **`CryptoManager.kt`**:
+  - **Key generation**:
+    - `generateKeyPair(): KeyPair` — generates ECDH P-256 key pair stored in Android KeyStore
+    - `getOrCreateKeyPair(conversationId: String): KeyPair` — lazy initialization per conversation
+  - **Key agreement**:
+    - `deriveSharedSecret(privateKey: PrivateKey, peerPublicKey: PublicKey): SecretKey` — ECDH key agreement → HKDF to derive 256-bit AES key
+  - **Encryption/Decryption**:
+    ```kotlin
+    data class EncryptedPayload(
+        val ciphertext: String,  // Base64-encoded
+        val iv: String,          // Base64-encoded 12-byte IV
+        val authTag: String      // Base64-encoded (included in GCM ciphertext)
+    )
+
+    fun encrypt(plaintext: String, secretKey: SecretKey): EncryptedPayload
+    fun decrypt(payload: EncryptedPayload, secretKey: SecretKey): String
+    ```
+  - **Cipher spec**: `AES/GCM/NoPadding`, 256-bit key, 12-byte random IV per message, 128-bit auth tag
+  - All keys stored in `AndroidKeyStore` — never exposed to application memory in plaintext
+- **`KeyExchangeHandler.kt`**:
+  - Automatically exchanges ECDH public keys when a conversation is first opened
+  - Caches the derived shared secret per conversation in an encrypted `SharedPreferences` (via EncryptedSharedPreferences from Jetpack Security)
+  - Handles re-keying if a user reinstalls the app (detect missing local key → re-exchange)
+
+#### Retrofit API Service (Key Exchange)
+- **`KeyExchangeApiService.kt`** (`feature/chat/data/remote/`):
+  ```kotlin
+  @POST("conversations/{id}/keys")
+  suspend fun uploadPublicKey(@Path("id") conversationId: String, @Body key: PublicKeyRequest): ApiResponse<Unit>
+
+  @GET("conversations/{id}/keys")
+  suspend fun getPeerPublicKey(@Path("id") conversationId: String): ApiResponse<PeerKeyResponse>
+  ```
+
+#### DTOs
+- `PublicKeyRequest.kt` — `publicKey: String` (Base64-encoded ECDH public key)
+- `PeerKeyResponse.kt` — `publicKey: String`, `userId: String`
+- `EncryptedMessagePayload.kt` — `encryptedContent: String`, `iv: String`, `authTag: String`, `type: String`
+
+#### Chat Integration (modify Lane 4 code)
+- **`ChatWebSocketService.kt`** (`feature/chat/data/remote/`):
+  - Before sending: call `CryptoManager.encrypt()` → send `EncryptedMessagePayload` over STOMP
+  - On receive: parse `EncryptedMessagePayload` from STOMP frame → call `CryptoManager.decrypt()` → emit plaintext to ViewModel
+- **`ChatViewModel.kt`** (`feature/chat/presentation/`):
+  - On conversation open: call `KeyExchangeHandler.ensureKeysExchanged(conversationId)`
+  - If key exchange fails (peer hasn't uploaded key yet): show "Waiting for encryption setup..." state
+  - All message encryption/decryption happens transparently — Compose UI only ever sees plaintext
+- **`ChatRepositoryImpl.kt`** (`feature/chat/data/`):
+  - Room `CachedMessage` entity: store `encryptedContent` in local DB, decrypt on read
+  - Alternatively: store plaintext locally (since device is already trusted), encrypt only for transit
+
+#### Room Entity Update
+- **`CachedMessage.kt`** (`local/entity/`):
+  - Add `isEncrypted: Boolean` field
+  - Add `iv: String?` and `authTag: String?` fields
+  - Migration: `Room.databaseBuilder().addMigrations(MIGRATION_X_Y)` to add new columns
+
+#### OkHttp Certificate Pinning (`core/api/`)
+- **`ApiClient.kt`** — add `CertificatePinner` for the production API domain:
+  ```kotlin
+  val certificatePinner = CertificatePinner.Builder()
+      .add("api.hustlehub.app", "sha256/AAAA...")  // pin production cert
+      .build()
+  ```
+  - Only enable in release builds (`BuildConfig.DEBUG` check)
+  - Document pin rotation procedure in `CONTRIBUTING.md`
+
+#### Network Security Config
+- **`network_security_config.xml`** (`res/xml/`):
+  - Production: only trust system CAs + pinned certificates
+  - Debug: additionally trust user-installed CAs (for Charles Proxy / mitmproxy during development)
+
+#### DataStore Encryption
+- **`UserPreferences.kt`** (`datastore/`):
+  - Migrate from `Preferences DataStore` to `EncryptedSharedPreferences` for sensitive fields: `firebaseUid`, `authToken`, `proExpiresAt`
+  - Non-sensitive fields (theme preference, onboarding complete) remain in regular DataStore
+
+#### Hilt Module Updates
+- **`SecurityModule.kt`** (`di/`):
+  - Provide `CryptoManager` as singleton
+  - Provide `KeyExchangeHandler` with `KeyExchangeApiService` dependency
+  - Provide `EncryptedSharedPreferences` instance
+
+#### Tests
+- `CryptoManagerTest` — encrypt/decrypt round-trip, verify different IV per message, verify auth tag validation (tampered ciphertext → exception)
+- `KeyExchangeHandlerTest` — mock API, verify key upload, verify shared secret derivation, verify re-key on missing local key
+- `ChatViewModelTest` — verify messages are encrypted before send, decrypted on receive, key exchange failure shows waiting state
+
+---
+
+## Shared Infrastructure Decisions
+
+### Phone Number Formatting (Lane 8)
+Kenyan M-Pesa phone numbers must be in `254XXXXXXXXX` format (12 digits). The Android client must convert common user input formats:
+- `07XX...` → `2547XX...`
+- `+254XX...` → `254XX...`
+- `01XX...` → `2541XX...`
+
+Implement this in `InitiateStkPushUseCase` and unit test all format variations.
+
+### Pro Status Caching
+After fetching subscription status from the backend, cache `isProUser` in `UserPreferences` DataStore. Use this cached value to:
+- Show/hide Pro badges immediately without network calls
+- Enforce upload limits on the client side (defense-in-depth; backend also enforces)
+- Refresh on app launch and after successful payment
+
+### E2EE Key Lifecycle
+- Keys are generated per-conversation, not per-user
+- If a user reinstalls the app, local keys are lost. The `KeyExchangeHandler` detects this and initiates a re-key exchange
+- Old messages encrypted with the previous key cannot be decrypted after reinstall — this is a known trade-off of true E2EE. Display "[Message encrypted with a previous key]" for unrecoverable messages
+
+### Reporting UX
+The report bottom sheet should be accessible from **3 touchpoints**:
+1. Service detail screen → overflow menu → "Report Service"
+2. User profile screen → overflow menu → "Report User"
+3. Chat screen → overflow menu → "Report Conversation"
+
+Each touchpoint passes the appropriate `reportedUserId` and/or `reportedServiceId` to the `ReportViewModel`.
+
+---
+
+## Package Structure (Phase 2 Additions)
+
+```
+must.kdroiders.hustlehub/
+├── core/
+│   ├── api/
+│   │   └── ApiClient.kt              ← Modified Lane 10 (cert pinning)
+│   ├── security/                      ← NEW Lane 10
+│   │   ├── CryptoManager.kt
+│   │   └── KeyExchangeHandler.kt
+│   └── ui/
+│       └── HustleCard.kt             ← Modified Lane 8 (Pro badge)
+├── di/
+│   ├── MonetizationModule.kt          ← NEW Lane 8
+│   ├── ReportingModule.kt            ← NEW Lane 9
+│   └── SecurityModule.kt             ← NEW Lane 10
+├── ui/features/
+│   ├── monetization/                  ← NEW Lane 8
+│   │   ├── data/
+│   │   │   ├── remote/
+│   │   │   │   └── PaymentApiService.kt
+│   │   │   ├── model/
+│   │   │   │   ├── StkPushRequest.kt
+│   │   │   │   ├── StkPushResponse.kt
+│   │   │   │   ├── PaymentStatusResponse.kt
+│   │   │   │   └── SubscriptionResponse.kt
+│   │   │   └── PaymentRepositoryImpl.kt
+│   │   ├── domain/
+│   │   │   ├── PaymentRepository.kt
+│   │   │   └── usecase/
+│   │   │       ├── InitiateStkPushUseCase.kt
+│   │   │       ├── PollPaymentStatusUseCase.kt
+│   │   │       └── GetSubscriptionUseCase.kt
+│   │   └── presentation/
+│   │       ├── MonetizationViewModel.kt
+│   │       ├── SubscriptionScreen.kt
+│   │       └── PaymentStatusScreen.kt
+│   ├── reporting/                     ← NEW Lane 9
+│   │   ├── data/
+│   │   │   ├── remote/
+│   │   │   │   └── ReportApiService.kt
+│   │   │   ├── model/
+│   │   │   │   └── SubmitReportRequest.kt
+│   │   │   └── ReportRepositoryImpl.kt
+│   │   ├── domain/
+│   │   │   ├── ReportRepository.kt
+│   │   │   └── usecase/
+│   │   │       └── SubmitReportUseCase.kt
+│   │   └── presentation/
+│   │       ├── ReportViewModel.kt
+│   │       └── ReportBottomSheet.kt
+│   ├── chat/                          ← Modified Lane 10
+│   │   └── data/remote/
+│   │       └── KeyExchangeApiService.kt  ← NEW
+│   ├── auth/                          ← Modified Lane 9
+│   │   └── presentation/
+│   │       └── SuspendedScreen.kt        ← NEW
+│   └── ...existing features...
+└── local/
+    └── entity/
+        └── CachedMessage.kt           ← Modified Lane 10 (encryption fields)
+```
+
+---
+
+## Branching Strategy
+
+```
+main          ← Production. Protected. Only receives merges from dev after full QA.
+  └── dev     ← Integration branch. Receives merges from working after review.
+        └── working  ← Active development. Lanes merge here when stable.
+              └── lane/monetization-ui     (Lane 8)  ← NEW
+              └── lane/reporting-ui        (Lane 9)  ← NEW
+              └── lane/security-e2ee       (Lane 10) ← NEW
+```
+
+**Merge flow** (same as backend):
+1. Developer works on `lane/<name>`
+2. Opens PR: `lane/<name>` → `working`
+3. One other team member reviews
+4. After review + CI green → merge to `working`
+5. Sprint milestone complete → `working` → `dev` (full integration test)
+6. `dev` is stable + tested → `dev` → `main`
+
+---
+
+## Commit Convention (Conventional Commits)
+
+```
+feat(monetization): add SubscriptionScreen with Pro tier comparison
+feat(monetization): implement M-Pesa STK push polling flow
+feat(reporting): add ReportBottomSheet with reason picker
+feat(security): implement AES-256-GCM CryptoManager
+feat(chat): integrate E2EE encryption into WebSocket handler
+fix(monetization): handle phone number format edge cases
+test(security): add CryptoManager round-trip encryption tests
+chore(deps): add jetpack-security-crypto dependency
+```
+
+Format: `<type>(<scope>): <short description>`
+Types: `feat`, `fix`, `chore`, `test`, `docs`, `refactor`
+
+---
+
+*Last updated: 2026-07-23 · HustleHub Android Team · Android Community MUST*
+*Phase 2 lanes (Monetization, Reporting, Security/E2EE) defined.*


### PR DESCRIPTION
## 📝 What does this PR do?
This PR introduces a production-ready WhatsApp-style chat location sharing system with interactive native GoogleMap previews, robust Google Maps clustering architecture, Google Sign-In authentication, streamlined repository data handling using `runCatching` with improved error propagation, provider onboarding workflows, and Material 3 Expressive UI components (`CircularWavyProgressIndicator`).

---

## 🔄 Main Changes

### Added
- **`runCatching` & Streamlined Data Layer**: Standardized repository data fetching across data repositories using Kotlin `runCatching` blocks with typed error handling and clean exception propagation.
- **WhatsApp-style Location Picker (`ChatLocationPickerSheet`)**: Built live GPS location card with pulsing accuracy dot, MUST campus landmark quick-selection chips (*Main Gate, Library, Sci & Tech, Hostels, Student Center, Administration*), and interactive map modal selector.
- **Reverse Geocoding & Address Labels**: Added automatic address label extraction and reverse geocoding when selecting locations on the map or via current GPS position.
- **Native Vector Map Chat Previews (`LocationMessageContent`)**: Replaced static snapshot images in message bubbles with native vector `GoogleMap` Compose preview mini-cards with disabled gesture controls that open map navigation on tap.
- **Google Sign-In Authentication**: Integrated Google Sign-In flow with feedback snackbars in `LoginScreen` and `SignUpScreen`.
- **Geolocation & Location Selection for Services**: Added preset and manual map location selection modes for creating and editing services in `CreateServiceScreen`.
- **Provider Onboarding**: Added provider onboarding logic and dismissal card overlays on Profile and Home screens.
- **`HustleScaffold` & Responsive Dimensions**: Introduced `HustleScaffold` component and responsive scaling via `LocalDimensions`.
- **Expressive Loading Indicators**: Integrated Material 3 Expressive `CircularWavyProgressIndicator` across `ChatScreen`, `LoadingIndicator`, and `HustleButton`.

### Changed
- **Official Map Clustering**: Integrated `com.google.maps.android.compose.clustering.Clustering` composable (`maps-compose-utils` v8.3.0) with custom `ProviderMarkerContent` pills (*Provider Name, Category, Rating, and Category Neon Glow*) and glowing cluster count badges.
- **ViewModel Architecture**: Refactored `ChatViewModel` and `MapViewModel` location state management to handle reactive location updates cleanly.
- **Map Defaults & Search Radius**: Defaulted map filter availability to `null` and expanded service discovery radius to 50km.
- **TopAppBar Insets**: Cleaned up explicit zero window insets across TopAppBars to rely on standard Material 3 scaffold padding.

### Fixed
- **Compose Cluster Crash**: Resolved `IllegalStateException: Composed into the View which doesn't propagate ViewTreeSavedStateRegistryOwner!` on Compose 1.7+ by utilizing native view-tree bound clustering rendering.
- **Invisible Marker Bitmaps**: Replaced offscreen async `ComposeView` bitmap generation with view-tree attached map rendering so markers render reliably without transparent fallbacks.
- **Data Flow Exception Leaks**: Caught network/database exceptions inside repository calls using `runCatching` to prevent uncaught runtime crashes.

### Removed
- **Unused Renderer Code & Imports**: Removed broken offscreen `ComposeView` snapshot functions (`SafeComposeUiClusterRenderer`) and cleaned up unused imports across data and presentation layers.

---

## ✅ Type of change
- [x] New feature
- [x] Bug fix
- [x] UI update
- [x] Refactor / cleanup
- [x] Documentation

---

## 🧪 I have tested that...
- [x] The app builds without errors
- [x] My feature/fix works as expected
- [x] I didn't break anything else

---

## 🔍 Code quality
- [x] Quality checks passed (`./gradlew qualityCheck`)
- [x] Ktlint passed (`./gradlew ktlintCheck`)
- [x] Detekt passed (`./gradlew detekt`)
- [x] Android Lint passed (`./gradlew lint`)
- [x] My commit message follows convention (`feat:`, `fix:`, `chore:` etc.)

---

## 📸 Screenshots
*(Add screenshots of Chat Location Sheet, Map Markers, and CircularWavyProgressIndicator if available)*

---

## Closes #
<!-- Type the issue number this PR fixes, e.g.  Closes #42 -->
