### PR TITLE
implement reviews system and service completion chat prompts (Issues #54, #55, #56, #57)

### DIFF
--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -184,7 +184,8 @@ object AppModule {
     fun provideReportRepository(
         reportApiService: must.kdroiders.hustlehub.ui.features.report.data.remote.ReportApiService,
     ): must.kdroiders.hustlehub.ui.features.report.domain.repository.ReportRepository {
-        return must.kdroiders.hustlehub.ui.features.report.data.repository.ReportRepositoryImpl(reportApiService)
+        return must.kdroiders.hustlehub.ui.features.report.data.repository
+            .ReportRepositoryImpl(reportApiService)
     }
 }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -40,7 +40,9 @@ import must.kdroiders.hustlehub.ui.features.profile.data.repository.UserReposito
 import must.kdroiders.hustlehub.ui.features.profile.domain.repository.UserRepository
 import must.kdroiders.hustlehub.ui.features.service.data.local.dao.ServiceDao
 import must.kdroiders.hustlehub.ui.features.service.data.remote.ServiceApiService
+import must.kdroiders.hustlehub.ui.features.service.data.repository.ReviewRepositoryImpl
 import must.kdroiders.hustlehub.ui.features.service.data.repository.ServiceRepositoryImpl
+import must.kdroiders.hustlehub.ui.features.service.domain.repository.ReviewRepository
 import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
 import timber.log.Timber
 import javax.inject.Singleton
@@ -131,6 +133,15 @@ object AppModule {
         authManager: AuthManager,
     ): ServiceRepository {
         return ServiceRepositoryImpl(serviceApiService, serviceDao, authManager)
+    }
+
+    @Provides
+    @Singleton
+    fun provideReviewRepository(
+        serviceApiService: ServiceApiService,
+        userPreferences: UserPreferences,
+    ): ReviewRepository {
+        return ReviewRepositoryImpl(serviceApiService, userPreferences)
     }
 
     @Provides

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -178,6 +178,14 @@ object AppModule {
     @Provides
     @Singleton
     fun provideMapRepository(discoveryApiService: DiscoveryApiService): MapRepository = MapRepositoryImpl(discoveryApiService)
+
+    @Provides
+    @Singleton
+    fun provideReportRepository(
+        reportApiService: must.kdroiders.hustlehub.ui.features.report.data.remote.ReportApiService,
+    ): must.kdroiders.hustlehub.ui.features.report.domain.repository.ReportRepository {
+        return must.kdroiders.hustlehub.ui.features.report.data.repository.ReportRepositoryImpl(reportApiService)
+    }
 }
 
 private class NoopAuthRepository : AuthRepository {

--- a/app/src/main/java/must/kdroiders/hustlehub/di/NetworkModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/NetworkModule.kt
@@ -106,4 +106,10 @@ object NetworkModule {
     fun provideNotificationApiService(retrofit: Retrofit): NotificationApiService {
         return retrofit.create(NotificationApiService::class.java)
     }
+
+    @Provides
+    @Singleton
+    fun provideReportApiService(retrofit: Retrofit): must.kdroiders.hustlehub.ui.features.report.data.remote.ReportApiService {
+        return retrofit.create(must.kdroiders.hustlehub.ui.features.report.data.remote.ReportApiService::class.java)
+    }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -20,6 +20,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import must.kdroiders.hustlehub.core.auth.AuthStateViewModel
+import must.kdroiders.hustlehub.navigation.AllReviews
 import must.kdroiders.hustlehub.onboarding.OnboardingScreen
 import must.kdroiders.hustlehub.splash.SplashDestination
 import must.kdroiders.hustlehub.splash.SplashScreen
@@ -36,7 +37,6 @@ import must.kdroiders.hustlehub.ui.features.notification.presentation.view.Notif
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.EditProfileScreen
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.ProviderProfileScreen
 import must.kdroiders.hustlehub.ui.features.profilesetup.presentation.view.ProfileSetupScreen
-import must.kdroiders.hustlehub.navigation.AllReviews
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.AllReviewsScreen
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.CreateServiceScreen
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.MyServicesScreen

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -295,6 +295,9 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
                     providerName = key.providerName,
                     onBackClick = { if (backstack.size > 1) backstack.remove(backstack.last()) },
                     onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                    onNavigateToWriteReview = { serviceId, providerId ->
+                        backstack.add(WriteReview(serviceId = serviceId, providerId = providerId))
+                    },
                 )
             }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -36,6 +36,8 @@ import must.kdroiders.hustlehub.ui.features.notification.presentation.view.Notif
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.EditProfileScreen
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.ProviderProfileScreen
 import must.kdroiders.hustlehub.ui.features.profilesetup.presentation.view.ProfileSetupScreen
+import must.kdroiders.hustlehub.navigation.AllReviews
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.AllReviewsScreen
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.CreateServiceScreen
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.MyServicesScreen
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.ServiceDetailScreen
@@ -322,6 +324,17 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
                     onNavigateToWriteReview = { serviceId, providerId ->
                         backstack.add(WriteReview(serviceId = serviceId, providerId = providerId))
                     },
+                    onNavigateToAllReviews = { serviceId ->
+                        backstack.add(AllReviews(serviceId = serviceId))
+                    },
+                )
+            }
+
+            // All reviews
+            entry<AllReviews> { key ->
+                AllReviewsScreen(
+                    serviceId = key.serviceId,
+                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
                 )
             }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
@@ -140,3 +140,7 @@ data class WriteReview(val serviceId: String, val providerId: String) : NavKey
 /** In-app notification center screen. */
 @Serializable
 data object Notifications : NavKey
+
+/** All reviews screen for a specific service. */
+@Serializable
+data class AllReviews(val serviceId: String) : NavKey

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/StarRatingBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/StarRatingBar.kt
@@ -61,14 +61,12 @@ fun StarRatingBar(
         modifier = modifier
             .onGloballyPositioned { coordinates ->
                 rowWidth = coordinates.size.width
-            }
-            .pointerInput(Unit) {
+            }.pointerInput(Unit) {
                 detectTapGestures { offset ->
                     val newRating = calculateRating(offset.x)
                     onRatingChanged(newRating)
                 }
-            }
-            .pointerInput(Unit) {
+            }.pointerInput(Unit) {
                 detectDragGestures(
                     onDragStart = { offset ->
                         val newRating = calculateRating(offset.x)
@@ -80,8 +78,7 @@ fun StarRatingBar(
                         onRatingChanged(newRating)
                     },
                 )
-            }
-            .semantics {
+            }.semantics {
                 contentDescription = "Rating bar: $rating out of 5 stars"
             },
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/StarRatingBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/StarRatingBar.kt
@@ -1,0 +1,111 @@
+package must.kdroiders.hustlehub.sharedComposables
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Interactive 5-star rating bar supporting both tap and drag gestures.
+ *
+ * @param rating Current selected rating (1 to 5, or 0 if unselected).
+ * @param onRatingChanged Callback triggered when user taps or drags to select a rating.
+ * @param starSize Size of each individual star.
+ * @param activeColor Color for filled active stars.
+ * @param inactiveColor Color for outlined inactive stars.
+ * @param modifier Optional modifier.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun StarRatingBar(
+    rating: Int,
+    onRatingChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    starSize: Dp = 40.dp,
+    activeColor: Color = Color(0xFFFFD700),
+    inactiveColor: Color = Color(0xFFCCCCCC),
+) {
+    var rowWidth by remember { mutableIntStateOf(0) }
+
+    fun calculateRating(xPosition: Float): Int {
+        if (rowWidth <= 0) return rating
+        val fraction = (xPosition / rowWidth.toFloat()).coerceIn(0f, 1f)
+        val calculated = (fraction * 5).toInt() + 1
+        return calculated.coerceIn(1, 5)
+    }
+
+    Row(
+        modifier = modifier
+            .onGloballyPositioned { coordinates ->
+                rowWidth = coordinates.size.width
+            }
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val newRating = calculateRating(offset.x)
+                    onRatingChanged(newRating)
+                }
+            }
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = { offset ->
+                        val newRating = calculateRating(offset.x)
+                        onRatingChanged(newRating)
+                    },
+                    onDrag = { change, _ ->
+                        change.consume()
+                        val newRating = calculateRating(change.position.x)
+                        onRatingChanged(newRating)
+                    },
+                )
+            }
+            .semantics {
+                contentDescription = "Rating bar: $rating out of 5 stars"
+            },
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val motionScheme = MaterialTheme.motionScheme
+        val scaleSpec = motionScheme.defaultEffectsSpec<Float>()
+
+        (1..5).forEach { star ->
+            val isSelected = star <= rating
+            val scale by animateFloatAsState(
+                targetValue = if (isSelected) 1.15f else 1f,
+                animationSpec = scaleSpec,
+                label = "starScale_$star",
+            )
+
+            Icon(
+                imageVector = if (isSelected) Icons.Filled.Star else Icons.Outlined.Star,
+                contentDescription = "$star star${if (star > 1) "s" else ""}",
+                tint = if (isSelected) activeColor else inactiveColor,
+                modifier = Modifier
+                    .size(starSize)
+                    .scale(scale),
+            )
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/model/Message.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/domain/model/Message.kt
@@ -6,6 +6,8 @@ enum class MessageType {
     IMAGE,
     LOCATION,
     SERVICE_CARD,
+    SYSTEM,
+    SERVICE_COMPLETED,
 }
 
 data class Message(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -101,6 +101,7 @@ fun MessageBubble(
     onReply: (Message) -> Unit = {},
     onDeleteForMe: (Message) -> Unit = {},
     onDeleteForEveryone: (Message) -> Unit = {},
+    onReportMessage: (Message) -> Unit = {},
     modifier: Modifier = Modifier,
     currentUserLocation: android.location.Location? = null,
     isOtherUserOnline: Boolean = false,
@@ -220,6 +221,13 @@ fun MessageBubble(
                         onClick = {
                             showMenu = false
                             onDeleteForMe(message)
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Report Message") },
+                        onClick = {
+                            showMenu = false
+                            onReportMessage(message)
                         },
                     )
                     if (isCurrentUser) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -421,6 +421,15 @@ fun MessageBubble(
                                     onClick = onServiceCardClick,
                                 )
                             }
+
+                            MessageType.SYSTEM, MessageType.SERVICE_COMPLETED -> {
+                                Text(
+                                    text = message.content,
+                                    color = textColor,
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Medium,
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ServiceCompletionCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ServiceCompletionCard.kt
@@ -1,0 +1,143 @@
+package must.kdroiders.hustlehub.ui.features.chat.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.RateReview
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ServiceCompletionCard(
+    providerName: String,
+    serviceTitle: String?,
+    onWriteReviewClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(20.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f))
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
+                shape = RoundedCornerShape(20.dp),
+            )
+            .padding(18.dp),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape)
+                        .background(must.kdroiders.hustlehub.ui.theme.HustleSuccess),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = "Service Completed!",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            val displayTitle = if (!serviceTitle.isNullOrBlank()) serviceTitle else "service"
+            val providerFirstName = providerName.split(" ").firstOrNull() ?: providerName
+            Text(
+                text = "How was $providerFirstName's $displayTitle?",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium,
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Star,
+                    contentDescription = null,
+                    tint = Color(0xFFFFD700),
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = "Rate your experience",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = onWriteReviewClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(44.dp),
+                shape = RoundedCornerShape(22.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                ),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.RateReview,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = "Write a Review",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ServiceCompletionCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ServiceCompletionCard.kt
@@ -47,8 +47,7 @@ fun ServiceCompletionCard(
                 width = 1.dp,
                 color = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
                 shape = RoundedCornerShape(20.dp),
-            )
-            .padding(18.dp),
+            ).padding(18.dp),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -100,6 +100,7 @@ import must.kdroiders.hustlehub.ui.features.chat.presentation.components.DateSep
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.MessageBubble
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.ServiceCompletionCard
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ChatDetailViewModel
+import must.kdroiders.hustlehub.ui.features.report.presentation.ReportDialog
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.FullScreenImageViewer
 import java.io.File
 import java.time.Duration
@@ -138,6 +139,7 @@ fun ChatDetailScreen(
     var selectedImageUrl by remember { mutableStateOf<String?>(null) }
     // Save-to-gallery bottom sheet
     var imageToSave by remember { mutableStateOf<String?>(null) }
+    var messageToReport by remember { mutableStateOf<must.kdroiders.hustlehub.ui.features.chat.domain.model.Message?>(null) }
 
     val voiceRecorder = remember { VoiceRecorder(context) }
 
@@ -608,6 +610,7 @@ fun ChatDetailScreen(
                             onReply = viewModel::startReplying,
                             onDeleteForMe = { msg -> viewModel.deleteMessageForMe(msg.id) },
                             onDeleteForEveryone = { msg -> viewModel.deleteMessageForEveryone(msg.id) },
+                            onReportMessage = { msg -> messageToReport = msg },
                             isOtherUserOnline = state.isOtherUserOnline,
                         )
                     }
@@ -959,6 +962,14 @@ fun ChatDetailScreen(
                         }
                     }
                 }
+            }
+
+            messageToReport?.let { message ->
+                ReportDialog(
+                    targetId = message.id,
+                    targetType = "message",
+                    onDismiss = { messageToReport = null }
+                )
             }
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -968,7 +968,7 @@ fun ChatDetailScreen(
                 ReportDialog(
                     targetId = message.id,
                     targetType = "message",
-                    onDismiss = { messageToReport = null }
+                    onDismiss = { messageToReport = null },
                 )
             }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -92,7 +92,9 @@ import must.kdroiders.hustlehub.core.utils.ImageCompressor
 import must.kdroiders.hustlehub.core.utils.createTempCameraFile
 import must.kdroiders.hustlehub.core.utils.saveImageToGallery
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
+import androidx.compose.material.icons.filled.CheckCircle
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.MessageType
+import must.kdroiders.hustlehub.ui.features.chat.presentation.components.ServiceCompletionCard
 import must.kdroiders.hustlehub.ui.features.chat.presentation.audio.VoiceRecorder
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.ChatLocationPickerSheet
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.DateSeparator
@@ -464,6 +466,17 @@ fun ChatDetailScreen(
                         )
                     }
                 },
+                actions = {
+                    if (state.isCurrentUserProvider && !state.isServiceCompleted) {
+                        IconButton(onClick = { viewModel.markServiceCompleted() }) {
+                            Icon(
+                                imageVector = Icons.Default.CheckCircle,
+                                contentDescription = "Mark as Complete",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.background,
                     titleContentColor = MaterialTheme.colorScheme.onBackground,
@@ -481,41 +494,51 @@ fun ChatDetailScreen(
                 .padding(innerPadding)
                 .imePadding(),
         ) {
-            // Service completed auto-prompt banner
-            val activeServiceId = serviceId
-            val activeProviderId = state.otherUserId
-            if (!activeServiceId.isNullOrBlank() && onNavigateToWriteReview != null) {
+            // Mark as complete banner for provider when service not yet marked complete
+            if (state.isCurrentUserProvider && !state.isServiceCompleted) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f))
-                        .clickable { onNavigateToWriteReview(activeServiceId, activeProviderId) }
+                        .clickable { viewModel.markServiceCompleted() }
                         .padding(horizontal = 16.dp, vertical = 10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
-                            imageVector = Icons.Default.Star,
+                            imageVector = Icons.Default.CheckCircle,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(20.dp),
                         )
                         Spacer(Modifier.width(8.dp))
                         Text(
-                            text = "Service completed? Write a review",
+                            text = "Service finished? Mark as complete",
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
                         )
                     }
                     Text(
-                        text = "Rate Now",
+                        text = "Mark Complete",
                         style = MaterialTheme.typography.labelLarge,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary,
                     )
                 }
+            }
+
+            // Service completion review prompt card for customer
+            val activeServiceId = serviceId
+            val activeProviderId = state.otherUserId
+            if (!state.isCurrentUserProvider && state.isServiceCompleted && !state.hasReviewedService && !activeServiceId.isNullOrBlank() && onNavigateToWriteReview != null) {
+                ServiceCompletionCard(
+                    providerName = state.otherUserName,
+                    serviceTitle = serviceTitle,
+                    onWriteReviewClick = { onNavigateToWriteReview(activeServiceId, activeProviderId) },
+                    modifier = Modifier.padding(16.dp),
+                )
             }
 
             // Messages list (reversed so it starts at the bottom)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Image
@@ -92,13 +93,12 @@ import must.kdroiders.hustlehub.core.utils.ImageCompressor
 import must.kdroiders.hustlehub.core.utils.createTempCameraFile
 import must.kdroiders.hustlehub.core.utils.saveImageToGallery
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
-import androidx.compose.material.icons.filled.CheckCircle
 import must.kdroiders.hustlehub.ui.features.chat.domain.model.MessageType
-import must.kdroiders.hustlehub.ui.features.chat.presentation.components.ServiceCompletionCard
 import must.kdroiders.hustlehub.ui.features.chat.presentation.audio.VoiceRecorder
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.ChatLocationPickerSheet
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.DateSeparator
 import must.kdroiders.hustlehub.ui.features.chat.presentation.components.MessageBubble
+import must.kdroiders.hustlehub.ui.features.chat.presentation.components.ServiceCompletionCard
 import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.ChatDetailViewModel
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.FullScreenImageViewer
 import java.io.File
@@ -106,7 +106,6 @@ import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
-import androidx.compose.material.icons.filled.Star
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -532,7 +531,12 @@ fun ChatDetailScreen(
             // Service completion review prompt card for customer
             val activeServiceId = serviceId
             val activeProviderId = state.otherUserId
-            if (!state.isCurrentUserProvider && state.isServiceCompleted && !state.hasReviewedService && !activeServiceId.isNullOrBlank() && onNavigateToWriteReview != null) {
+            if (!state.isCurrentUserProvider &&
+                state.isServiceCompleted &&
+                !state.hasReviewedService &&
+                !activeServiceId.isNullOrBlank() &&
+                onNavigateToWriteReview != null
+            ) {
                 ServiceCompletionCard(
                     providerName = state.otherUserName,
                     serviceTitle = serviceTitle,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -104,6 +104,7 @@ import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
+import androidx.compose.material.icons.filled.Star
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -117,6 +118,7 @@ fun ChatDetailScreen(
     serviceCategory: String? = null,
     servicePriceRange: String? = null,
     providerName: String? = null,
+    onNavigateToWriteReview: ((serviceId: String, providerId: String) -> Unit)? = null,
     viewModel: ChatDetailViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -479,6 +481,43 @@ fun ChatDetailScreen(
                 .padding(innerPadding)
                 .imePadding(),
         ) {
+            // Service completed auto-prompt banner
+            val activeServiceId = serviceId
+            val activeProviderId = state.otherUserId
+            if (!activeServiceId.isNullOrBlank() && onNavigateToWriteReview != null) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f))
+                        .clickable { onNavigateToWriteReview(activeServiceId, activeProviderId) }
+                        .padding(horizontal = 16.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = "Service completed? Write a review",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                    }
+                    Text(
+                        text = "Rate Now",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+
             // Messages list (reversed so it starts at the bottom)
             val reversedMessages = state.messages.reversed()
             Box(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -40,6 +40,8 @@ import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.CheckDuplicateReviewUseCase
+
 data class ChatDetailUiState(
     val messages: List<Message> = emptyList(),
     val currentUserId: String = "",
@@ -58,6 +60,8 @@ data class ChatDetailUiState(
     /** Prevents the auto-generated service card from being re-sent on every re-open. */
     val serviceCardSent: Boolean = false,
     val replyingToMessage: Message? = null,
+    val isServiceCompleted: Boolean = false,
+    val hasReviewedService: Boolean = false,
 )
 
 @HiltViewModel
@@ -70,6 +74,7 @@ class ChatDetailViewModel
         private val mediaApiService: MediaApiService,
         private val conversationDao: ConversationDao,
         private val serviceRepository: ServiceRepository,
+        private val checkDuplicateReviewUseCase: CheckDuplicateReviewUseCase,
         private val firebaseAuth: FirebaseAuth?,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(ChatDetailUiState())
@@ -200,10 +205,24 @@ class ChatDetailViewModel
                     NotificationHelper.cancelConversationNotification(context, resolvedId)
                 }
 
-                // 4. Observe local database messages
+                // 4. Observe local database messages & completion status
                 messagesJob = launch {
                     chatRepository.getMessages(resolvedId).collect { messageList ->
-                        _uiState.update { it.copy(messages = messageList) }
+                        val hasCompletionMsg = messageList.any { it.type == MessageType.SERVICE_COMPLETED }
+                        _uiState.update { state ->
+                            state.copy(
+                                messages = messageList,
+                                isServiceCompleted = state.isServiceCompleted || hasCompletionMsg,
+                            )
+                        }
+                    }
+                }
+
+                val activeSvcId = serviceId ?: finalCached?.serviceId
+                if (!activeSvcId.isNullOrBlank()) {
+                    launch {
+                        val hasReviewed = checkDuplicateReviewUseCase(activeSvcId).getOrDefault(false)
+                        _uiState.update { it.copy(hasReviewedService = hasReviewed) }
                     }
                 }
 
@@ -397,6 +416,18 @@ class ChatDetailViewModel
                     metadata = metadata,
                 )
                 cancelReplying()
+            }
+        }
+
+        fun markServiceCompleted() {
+            val id = conversationId ?: return
+            viewModelScope.launch {
+                chatRepository.sendMessage(
+                    conversationId = id,
+                    type = MessageType.SERVICE_COMPLETED,
+                    content = "Service marked as complete [+]",
+                )
+                _uiState.update { it.copy(isServiceCompleted = true) }
             }
         }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/ChatDetailViewModel.kt
@@ -33,14 +33,13 @@ import must.kdroiders.hustlehub.ui.features.chat.presentation.audio.PlayerState
 import must.kdroiders.hustlehub.ui.features.chat.presentation.audio.VoicePlayer
 import must.kdroiders.hustlehub.ui.features.media.data.remote.MediaApiService
 import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.CheckDuplicateReviewUseCase
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
-
-import must.kdroiders.hustlehub.ui.features.service.domain.usecase.CheckDuplicateReviewUseCase
 
 data class ChatDetailUiState(
     val messages: List<Message> = emptyList(),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -131,6 +131,7 @@ fun ProfileScreen(
                     state = state,
                     onEditClick = onEditClick,
                     onToggleService = profileViewModel::toggleServiceActive,
+                    onToggleOverallAvailability = profileViewModel::toggleOverallAvailability,
                     onAddNewServiceClick = onAddNewServiceClick,
                     onServiceClick = onServiceClick,
                     onNavigateToMyServices = onNavigateToMyServices,
@@ -153,6 +154,7 @@ private fun ProfileContent(
     state: ProfileUiState,
     onEditClick: () -> Unit,
     onToggleService: (String) -> Unit,
+    onToggleOverallAvailability: (Boolean) -> Unit = {},
     onAddNewServiceClick: () -> Unit,
     onServiceClick: (serviceId: String) -> Unit = {},
     onNavigateToMyServices: () -> Unit = {},
@@ -191,7 +193,7 @@ private fun ProfileContent(
                     isOnline = user.isOnline,
                     allowCalls = user.allowCalls,
                     isOwnProfile = true,
-                    onAvailabilityToggle = { /* Toggles campus availability status */ },
+                    onAvailabilityToggle = onToggleOverallAvailability,
                 )
             }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -1,5 +1,6 @@
 package must.kdroiders.hustlehub.ui.features.profile.presentation.view
 
+import android.content.Intent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -16,6 +17,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -26,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
@@ -44,13 +50,6 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileUiState
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileViewModel
 import must.kdroiders.hustlehub.ui.theme.LocalDimensions
-
-import android.content.Intent
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.ui.platform.LocalContext
 
 /**
  * Alias for ProfileScreen to satisfy MyProfileScreen naming convention.
@@ -100,7 +99,7 @@ fun ProfileScreen(
                         putExtra(Intent.EXTRA_SUBJECT, "Check out my profile on HustleHub")
                         putExtra(
                             Intent.EXTRA_TEXT,
-                            "Check out my profile on HustleHub: https://hustlehub.must.ac.ke/profile/$userId"
+                            "Check out my profile on HustleHub: https://hustlehub.must.ac.ke/profile/$userId",
                         )
                     }
                     context.startActivity(Intent.createChooser(shareIntent, "Share Profile"))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -45,6 +45,35 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.Profi
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileViewModel
 import must.kdroiders.hustlehub.ui.theme.LocalDimensions
 
+import android.content.Intent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Alias for ProfileScreen to satisfy MyProfileScreen naming convention.
+ */
+@Composable
+fun MyProfileScreen(
+    profileViewModel: ProfileViewModel = hiltViewModel(),
+    onEditClick: () -> Unit = {},
+    onAddNewServiceClick: () -> Unit = {},
+    onServiceClick: (serviceId: String) -> Unit = {},
+    onNavigateToMyServices: () -> Unit = {},
+    onSettingsClick: () -> Unit = {},
+) {
+    ProfileScreen(
+        profileViewModel = profileViewModel,
+        onEditClick = onEditClick,
+        onAddNewServiceClick = onAddNewServiceClick,
+        onServiceClick = onServiceClick,
+        onNavigateToMyServices = onNavigateToMyServices,
+        onSettingsClick = onSettingsClick,
+    )
+}
+
 @Composable
 fun ProfileScreen(
     profileViewModel: ProfileViewModel = hiltViewModel(),
@@ -57,13 +86,35 @@ fun ProfileScreen(
     val state by profileViewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     HustleScaffold(
         topBar = {
             ProfileHeader(
                 onEditClick = onEditClick,
                 onSettingsClick = onSettingsClick,
+                onShareClick = {
+                    val userId = state.user?.id ?: ""
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_SUBJECT, "Check out my profile on HustleHub")
+                        putExtra(
+                            Intent.EXTRA_TEXT,
+                            "Check out my profile on HustleHub: https://hustlehub.must.ac.ke/profile/$userId"
+                        )
+                    }
+                    context.startActivity(Intent.createChooser(shareIntent, "Share Profile"))
+                },
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onAddNewServiceClick,
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Add New Service")
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         modifier = Modifier.fillMaxSize(),
@@ -137,8 +188,10 @@ private fun ProfileContent(
                     phone = user.phone,
                     campusLocation = user.campusLocation,
                     bio = user.bio,
+                    isOnline = user.isOnline,
                     allowCalls = user.allowCalls,
                     isOwnProfile = true,
+                    onAvailabilityToggle = { /* Toggles campus availability status */ },
                 )
             }
         }
@@ -150,6 +203,7 @@ private fun ProfileContent(
                 hustleScore = state.hustleScore,
                 serviceCount = state.services.size,
                 reviewCount = state.reviewCount,
+                onReviewsClick = onNavigateToMyServices,
                 modifier = Modifier.padding(
                     horizontal = horizontalPadding,
                 ),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -49,6 +49,7 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ServicesHeader
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileUiState
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileViewModel
+import must.kdroiders.hustlehub.ui.features.profile.domain.model.UserRole
 import must.kdroiders.hustlehub.ui.theme.LocalDimensions
 
 /**
@@ -162,6 +163,7 @@ private fun ProfileContent(
 ) {
     val user = state.user ?: return
     val horizontalPadding = LocalDimensions.current.horizontalPadding
+    val isProvider = user.role == UserRole.PROVIDER || user.role == UserRole.BOTH || state.services.isNotEmpty()
 
     LazyColumn(
         modifier = Modifier
@@ -192,6 +194,7 @@ private fun ProfileContent(
                     isOnline = user.isOnline,
                     allowCalls = user.allowCalls,
                     isOwnProfile = true,
+                    isProvider = isProvider,
                     onAvailabilityToggle = onToggleOverallAvailability,
                 )
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProfileScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
+import must.kdroiders.hustlehub.ui.features.profile.domain.model.UserRole
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ErrorState
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.LoadingState
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileAvatar
@@ -49,7 +50,6 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ServicesHeader
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileUiState
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProfileViewModel
-import must.kdroiders.hustlehub.ui.features.profile.domain.model.UserRole
 import must.kdroiders.hustlehub.ui.theme.LocalDimensions
 
 /**

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
@@ -20,9 +20,16 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import must.kdroiders.hustlehub.ui.features.report.presentation.ReportDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -83,6 +90,38 @@ fun ProviderProfileScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (!state.isOwnProfile && state.provider != null) {
+                        var showMenu by remember { mutableStateOf(false) }
+                        var showReportDialog by remember { mutableStateOf(false) }
+
+                        Box {
+                            IconButton(onClick = { showMenu = true }) {
+                                Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                            }
+                            DropdownMenu(
+                                expanded = showMenu,
+                                onDismissRequest = { showMenu = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("Report Profile") },
+                                    onClick = {
+                                        showMenu = false
+                                        showReportDialog = true
+                                    }
+                                )
+                            }
+                        }
+
+                        if (showReportDialog) {
+                            ReportDialog(
+                                targetId = providerId,
+                                targetType = "user",
+                                onDismiss = { showReportDialog = false }
+                            )
+                        }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/ProviderProfileScreen.kt
@@ -26,10 +26,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import must.kdroiders.hustlehub.ui.features.report.presentation.ReportDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -39,6 +35,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -58,6 +57,7 @@ import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ProfileStatsRow
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.components.ServiceCard
 import must.kdroiders.hustlehub.ui.features.profile.presentation.viewmodel.ProviderProfileViewModel
+import must.kdroiders.hustlehub.ui.features.report.presentation.ReportDialog
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -103,14 +103,14 @@ fun ProviderProfileScreen(
                             }
                             DropdownMenu(
                                 expanded = showMenu,
-                                onDismissRequest = { showMenu = false }
+                                onDismissRequest = { showMenu = false },
                             ) {
                                 DropdownMenuItem(
                                     text = { Text("Report Profile") },
                                     onClick = {
                                         showMenu = false
                                         showReportDialog = true
-                                    }
+                                    },
                                 )
                             }
                         }
@@ -119,7 +119,7 @@ fun ProviderProfileScreen(
                             ReportDialog(
                                 targetId = providerId,
                                 targetType = "user",
-                                onDismiss = { showReportDialog = false }
+                                onDismiss = { showReportDialog = false },
                             )
                         }
                     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +34,7 @@ import androidx.compose.ui.unit.sp
 fun ProfileHeader(
     onEditClick: () -> Unit,
     onSettingsClick: () -> Unit = {},
+    onShareClick: () -> Unit = {},
 ) {
     Row(
         modifier = Modifier
@@ -49,6 +51,20 @@ fun ProfileHeader(
         )
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            IconButton(
+                onClick = onShareClick,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = "Share profile",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
             IconButton(
                 onClick = onEditClick,
                 modifier = Modifier

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
@@ -38,6 +38,7 @@ fun ProfileInfo(
     isOnline: Boolean = true,
     allowCalls: Boolean = false,
     isOwnProfile: Boolean = false,
+    isProvider: Boolean = true,
     onAvailabilityToggle: ((Boolean) -> Unit)? = null,
 ) {
     Text(
@@ -50,51 +51,53 @@ fun ProfileInfo(
 
     Spacer(Modifier.height(8.dp))
 
-    // Live Availability Status Pill & Toggle
-    val successColor = HustleSuccess
-    val errorColor = MaterialTheme.colorScheme.error
-    val statusColor = if (isOnline) successColor else errorColor
-    val statusText = if (isOnline) "Available on Campus" else "Off Duty"
+    // Live Availability Status Pill & Toggle (Shown ONLY for Providers)
+    if (isProvider) {
+        val successColor = HustleSuccess
+        val errorColor = MaterialTheme.colorScheme.error
+        val statusColor = if (isOnline) successColor else errorColor
+        val statusText = if (isOnline) "Available on Campus" else "Off Duty"
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Box(
-            modifier = Modifier
-                .clip(RoundedCornerShape(20.dp))
-                .background(statusColor.copy(alpha = 0.12f))
-                .border(1.dp, statusColor.copy(alpha = 0.3f), RoundedCornerShape(20.dp))
-                .padding(horizontal = 12.dp, vertical = 5.dp),
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(8.dp)
-                        .clip(CircleShape)
-                        .background(statusColor),
-                )
-                Spacer(Modifier.width(6.dp))
-                Text(
-                    text = statusText,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    color = statusColor,
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(statusColor.copy(alpha = 0.12f))
+                    .border(1.dp, statusColor.copy(alpha = 0.3f), RoundedCornerShape(20.dp))
+                    .padding(horizontal = 12.dp, vertical = 5.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(8.dp)
+                            .clip(CircleShape)
+                            .background(statusColor),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = statusText,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = statusColor,
+                    )
+                }
+            }
+
+            if (isOwnProfile && onAvailabilityToggle != null) {
+                Spacer(Modifier.width(8.dp))
+                Switch(
+                    checked = isOnline,
+                    onCheckedChange = onAvailabilityToggle,
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = successColor,
+                        checkedTrackColor = successColor.copy(alpha = 0.2f),
+                        uncheckedThumbColor = errorColor,
+                        uncheckedTrackColor = errorColor.copy(alpha = 0.2f),
+                    ),
                 )
             }
-        }
-
-        if (isOwnProfile && onAvailabilityToggle != null) {
-            Spacer(Modifier.width(8.dp))
-            Switch(
-                checked = isOnline,
-                onCheckedChange = onAvailabilityToggle,
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = successColor,
-                    checkedTrackColor = successColor.copy(alpha = 0.2f),
-                    uncheckedThumbColor = errorColor,
-                    uncheckedTrackColor = errorColor.copy(alpha = 0.2f),
-                ),
-            )
         }
     }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
@@ -27,6 +27,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+
 @Composable
 fun ProfileInfo(
     name: String,
@@ -36,6 +39,7 @@ fun ProfileInfo(
     isOnline: Boolean = true,
     allowCalls: Boolean = false,
     isOwnProfile: Boolean = false,
+    onAvailabilityToggle: ((Boolean) -> Unit)? = null,
 ) {
     Text(
         text = name.ifBlank { "Hustler Provider" },
@@ -47,30 +51,48 @@ fun ProfileInfo(
 
     Spacer(Modifier.height(8.dp))
 
-    // Live Availability Status Pill
+    // Live Availability Status Pill & Toggle
     val statusColor = if (isOnline) Color(0xFF00E676) else Color(0xFFFF5252)
     val statusText = if (isOnline) "Available on Campus" else "Off Duty"
 
-    Box(
-        modifier = Modifier
-            .clip(RoundedCornerShape(20.dp))
-            .background(statusColor.copy(alpha = 0.12f))
-            .border(1.dp, statusColor.copy(alpha = 0.3f), RoundedCornerShape(20.dp))
-            .padding(horizontal = 12.dp, vertical = 5.dp),
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(
-                modifier = Modifier
-                    .size(8.dp)
-                    .clip(CircleShape)
-                    .background(statusColor),
-            )
-            Spacer(Modifier.width(6.dp))
-            Text(
-                text = statusText,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = statusColor,
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(20.dp))
+                .background(statusColor.copy(alpha = 0.12f))
+                .border(1.dp, statusColor.copy(alpha = 0.3f), RoundedCornerShape(20.dp))
+                .padding(horizontal = 12.dp, vertical = 5.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .clip(CircleShape)
+                        .background(statusColor),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = statusText,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = statusColor,
+                )
+            }
+        }
+
+        if (isOwnProfile && onAvailabilityToggle != null) {
+            Spacer(Modifier.width(8.dp))
+            Switch(
+                checked = isOnline,
+                onCheckedChange = onAvailabilityToggle,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = Color(0xFF00E676),
+                    checkedTrackColor = Color(0xFF00E676).copy(alpha = 0.2f),
+                    uncheckedThumbColor = Color(0xFFFF5252),
+                    uncheckedTrackColor = Color(0xFFFF5252).copy(alpha = 0.2f),
+                ),
             )
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.sp
 
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
+import must.kdroiders.hustlehub.ui.theme.HustleSuccess
 
 @Composable
 fun ProfileInfo(
@@ -52,7 +53,9 @@ fun ProfileInfo(
     Spacer(Modifier.height(8.dp))
 
     // Live Availability Status Pill & Toggle
-    val statusColor = if (isOnline) Color(0xFF00E676) else Color(0xFFFF5252)
+    val successColor = HustleSuccess
+    val errorColor = MaterialTheme.colorScheme.error
+    val statusColor = if (isOnline) successColor else errorColor
     val statusText = if (isOnline) "Available on Campus" else "Off Duty"
 
     Row(
@@ -88,10 +91,10 @@ fun ProfileInfo(
                 checked = isOnline,
                 onCheckedChange = onAvailabilityToggle,
                 colors = SwitchDefaults.colors(
-                    checkedThumbColor = Color(0xFF00E676),
-                    checkedTrackColor = Color(0xFF00E676).copy(alpha = 0.2f),
-                    uncheckedThumbColor = Color(0xFFFF5252),
-                    uncheckedTrackColor = Color(0xFFFF5252).copy(alpha = 0.2f),
+                    checkedThumbColor = successColor,
+                    checkedTrackColor = successColor.copy(alpha = 0.2f),
+                    uncheckedThumbColor = errorColor,
+                    uncheckedTrackColor = errorColor.copy(alpha = 0.2f),
                 ),
             )
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileInfo.kt
@@ -16,19 +16,17 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import must.kdroiders.hustlehub.ui.theme.HustleSuccess
 
 @Composable

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
 
+import androidx.compose.foundation.clickable
+
 // Stats row — Score / Services / Reviews
 
 @Composable
@@ -38,6 +40,7 @@ fun ProfileStatsRow(
     serviceCount: Int,
     reviewCount: Int,
     modifier: Modifier = Modifier,
+    onReviewsClick: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -58,6 +61,7 @@ fun ProfileStatsRow(
         StatCard(
             value = reviewCount.toString(),
             label = "REVIEWS",
+            onClick = onReviewsClick,
             modifier = Modifier.weight(1f),
         )
     }
@@ -70,12 +74,14 @@ fun StatCard(
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
     iconTint: Color = HustleWarningAmber,
+    onClick: (() -> Unit)? = null,
 ) {
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(24.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f), RoundedCornerShape(24.dp))
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
             .padding(vertical = 24.dp, horizontal = 8.dp),
         contentAlignment = Alignment.Center,
     ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
@@ -2,6 +2,7 @@ package must.kdroiders.hustlehub.ui.features.profile.presentation.view.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,8 +30,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import must.kdroiders.hustlehub.ui.theme.HustleWarningAmber
-
-import androidx.compose.foundation.clickable
 
 // Stats row — Score / Services / Reviews
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -52,17 +52,25 @@ class ProfileViewModel
                         val calculatedReviewCount = services.sumOf { it.reviewCount }
                         val calculatedScore = HustleScoreCalculator.calculate(services)
 
+                        val computedBadges = buildList {
+                            if (calculatedScore >= 4.0f && calculatedReviewCount >= 1) {
+                                add(Badge("Top Rated", BadgeType.BLUE))
+                            }
+                            if (calculatedReviewCount >= 1) {
+                                add(Badge("Fast Responder", BadgeType.GREEN))
+                            }
+                            if (user?.isVerified == true) {
+                                add(Badge("Verified Student", BadgeType.BLUE))
+                            }
+                        }
+
                         _uiState.update {
                             it.copy(
                                 user = user,
                                 services = services,
                                 hustleScore = calculatedScore,
                                 reviewCount = calculatedReviewCount,
-                                badges = listOf(
-                                    Badge("Top Rated", BadgeType.BLUE),
-                                    Badge("Fast Responder", BadgeType.GREEN),
-                                    Badge("Verified Student", BadgeType.BLUE),
-                                ),
+                                badges = computedBadges,
                                 isLoading = false,
                                 error = null,
                             )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -127,7 +127,7 @@ class ProfileViewModel
                     user = currentUser.copy(isOnline = isOnline),
                     services = state.services.map { svc ->
                         svc.copy(
-                            availability = if (isOnline) ServiceAvailability.AVAILABLE else ServiceAvailability.OFFLINE
+                            availability = if (isOnline) ServiceAvailability.AVAILABLE else ServiceAvailability.OFFLINE,
                         )
                     },
                 )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -110,6 +110,30 @@ class ProfileViewModel
             }
         }
 
+        fun toggleOverallAvailability(isOnline: Boolean) {
+            val currentUser = _uiState.value.user ?: return
+
+            // Optimistically update UI
+            _uiState.update { state ->
+                state.copy(
+                    user = currentUser.copy(isOnline = isOnline),
+                    services = state.services.map { svc ->
+                        svc.copy(
+                            availability = if (isOnline) ServiceAvailability.AVAILABLE else ServiceAvailability.OFFLINE
+                        )
+                    },
+                )
+            }
+
+            // Update each service availability status on backend
+            viewModelScope.launch {
+                val targetAvailability = if (isOnline) ServiceAvailability.AVAILABLE else ServiceAvailability.OFFLINE
+                _uiState.value.services.forEach { service ->
+                    updateAvailabilityUseCase(service.id, targetAvailability)
+                }
+            }
+        }
+
         fun retry() {
             loadProfile()
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/remote/ReportApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/remote/ReportApiService.kt
@@ -1,0 +1,14 @@
+package must.kdroiders.hustlehub.ui.features.report.data.remote
+
+import must.kdroiders.hustlehub.core.api.ApiResponse
+import must.kdroiders.hustlehub.ui.features.report.data.remote.dto.ReportResponse
+import must.kdroiders.hustlehub.ui.features.report.data.remote.dto.SubmitReportRequest
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface ReportApiService {
+    @POST("reports")
+    suspend fun submitReport(
+        @Body request: SubmitReportRequest
+    ): ApiResponse<ReportResponse>
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/remote/ReportApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/remote/ReportApiService.kt
@@ -9,6 +9,6 @@ import retrofit2.http.POST
 interface ReportApiService {
     @POST("reports")
     suspend fun submitReport(
-        @Body request: SubmitReportRequest
+        @Body request: SubmitReportRequest,
     ): ApiResponse<ReportResponse>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/remote/dto/ReportDto.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/remote/dto/ReportDto.kt
@@ -1,0 +1,19 @@
+package must.kdroiders.hustlehub.ui.features.report.data.remote.dto
+
+data class SubmitReportRequest(
+    val targetId: String,
+    val targetType: String, // "user" or "service" or "message"
+    val reason: String,
+    val description: String?,
+)
+
+data class ReportResponse(
+    val id: String,
+    val reporterId: String,
+    val targetId: String,
+    val targetType: String,
+    val reason: String,
+    val description: String?,
+    val status: String,
+    val createdAt: Long,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/repository/ReportRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/repository/ReportRepositoryImpl.kt
@@ -14,37 +14,39 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ReportRepositoryImpl @Inject constructor(
-    private val apiService: ReportApiService,
-) : ReportRepository {
-
-    override suspend fun submitReport(
-        targetId: String,
-        targetType: String,
-        reason: String,
-        description: String?,
-    ): Result<Report> = withContext(Dispatchers.IO) {
-        runCatching {
-            val request = SubmitReportRequest(
-                targetId = targetId,
-                targetType = targetType,
-                reason = reason,
-                description = description,
-            )
-            val response = apiService.submitReport(request)
-            check(response.success && response.data != null) { response.message ?: "Failed to submit report" }
-            response.data.toDomain()
-        }.recoverCatching { e ->
-            if (e is CancellationException) throw e
-            if (e is HttpException && (e.code() == 409 || e.code() == 400)) {
-                throw Exception("You have already reported this item.")
-            } else {
-                Timber.w(e, "ReportRepositoryImpl.submitReport failed for targetId='$targetId'")
-                throw e
+class ReportRepositoryImpl
+    @Inject
+    constructor(
+        private val apiService: ReportApiService,
+    ) : ReportRepository {
+        override suspend fun submitReport(
+            targetId: String,
+            targetType: String,
+            reason: String,
+            description: String?,
+        ): Result<Report> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = SubmitReportRequest(
+                        targetId = targetId,
+                        targetType = targetType,
+                        reason = reason,
+                        description = description,
+                    )
+                    val response = apiService.submitReport(request)
+                    check(response.success && response.data != null) { response.message ?: "Failed to submit report" }
+                    response.data.toDomain()
+                }.recoverCatching { e ->
+                    if (e is CancellationException) throw e
+                    if (e is HttpException && (e.code() == 409 || e.code() == 400)) {
+                        throw Exception("You have already reported this item.")
+                    } else {
+                        Timber.w(e, "ReportRepositoryImpl.submitReport failed for targetId='$targetId'")
+                        throw e
+                    }
+                }
             }
-        }
     }
-}
 
 private fun ReportResponse.toDomain(): Report =
     Report(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/repository/ReportRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/data/repository/ReportRepositoryImpl.kt
@@ -1,0 +1,59 @@
+package must.kdroiders.hustlehub.ui.features.report.data.repository
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import must.kdroiders.hustlehub.ui.features.report.data.remote.ReportApiService
+import must.kdroiders.hustlehub.ui.features.report.data.remote.dto.ReportResponse
+import must.kdroiders.hustlehub.ui.features.report.data.remote.dto.SubmitReportRequest
+import must.kdroiders.hustlehub.ui.features.report.domain.model.Report
+import must.kdroiders.hustlehub.ui.features.report.domain.repository.ReportRepository
+import retrofit2.HttpException
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReportRepositoryImpl @Inject constructor(
+    private val apiService: ReportApiService,
+) : ReportRepository {
+
+    override suspend fun submitReport(
+        targetId: String,
+        targetType: String,
+        reason: String,
+        description: String?,
+    ): Result<Report> = withContext(Dispatchers.IO) {
+        runCatching {
+            val request = SubmitReportRequest(
+                targetId = targetId,
+                targetType = targetType,
+                reason = reason,
+                description = description,
+            )
+            val response = apiService.submitReport(request)
+            check(response.success && response.data != null) { response.message ?: "Failed to submit report" }
+            response.data.toDomain()
+        }.recoverCatching { e ->
+            if (e is CancellationException) throw e
+            if (e is HttpException && (e.code() == 409 || e.code() == 400)) {
+                throw Exception("You have already reported this item.")
+            } else {
+                Timber.w(e, "ReportRepositoryImpl.submitReport failed for targetId='$targetId'")
+                throw e
+            }
+        }
+    }
+}
+
+private fun ReportResponse.toDomain(): Report =
+    Report(
+        id = id,
+        reporterId = reporterId,
+        targetId = targetId,
+        targetType = targetType,
+        reason = reason,
+        description = description,
+        status = status,
+        createdAt = createdAt,
+    )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/domain/model/Report.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/domain/model/Report.kt
@@ -1,0 +1,12 @@
+package must.kdroiders.hustlehub.ui.features.report.domain.model
+
+data class Report(
+    val id: String,
+    val reporterId: String,
+    val targetId: String,
+    val targetType: String,
+    val reason: String,
+    val description: String?,
+    val status: String,
+    val createdAt: Long,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/domain/repository/ReportRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/domain/repository/ReportRepository.kt
@@ -1,0 +1,12 @@
+package must.kdroiders.hustlehub.ui.features.report.domain.repository
+
+import must.kdroiders.hustlehub.ui.features.report.domain.model.Report
+
+interface ReportRepository {
+    suspend fun submitReport(
+        targetId: String,
+        targetType: String,
+        reason: String,
+        description: String?,
+    ): Result<Report>
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/presentation/ReportDialog.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/presentation/ReportDialog.kt
@@ -1,0 +1,199 @@
+package must.kdroiders.hustlehub.ui.features.report.presentation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+
+@Composable
+fun ReportDialog(
+    targetId: String,
+    targetType: String, // "user" or "service" or "message"
+    onDismiss: () -> Unit,
+    viewModel: ReportViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    var selectedReason by remember { mutableStateOf<String?>(null) }
+    var description by remember { mutableStateOf("") }
+    val reasons = listOf("Spam", "Inappropriate", "Fake", "Harassment", "Other")
+
+    LaunchedEffect(Unit) {
+        viewModel.resetState()
+    }
+
+    if (state.isSuccess) {
+        AlertDialog(
+            onDismissRequest = {
+                onDismiss()
+                viewModel.resetState()
+            },
+            icon = {
+                Icon(
+                    imageVector = Icons.Default.CheckCircle,
+                    contentDescription = null,
+                    tint = must.kdroiders.hustlehub.ui.theme.HustleSuccess,
+                    modifier = Modifier.padding(8.dp)
+                )
+            },
+            title = {
+                Text(
+                    text = "Report Submitted",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            text = {
+                Text(
+                    text = "Thank you. Our moderators will review this reported $targetType shortly.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDismiss()
+                        viewModel.resetState()
+                    }
+                ) {
+                    Text("OK")
+                }
+            }
+        )
+    } else {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = {
+                Text(
+                    text = "Report $targetType",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            text = {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = "Why are you reporting this?",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    reasons.forEach { reason ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(8.dp))
+                                .clickable { selectedReason = reason }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = selectedReason == reason,
+                                onClick = { selectedReason = reason }
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = reason,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(8.dp))
+
+                    OutlinedTextField(
+                        value = description,
+                        onValueChange = { description = it },
+                        label = {
+                            Text(
+                                text = if (selectedReason == "Other") "Please specify (required)" else "Additional context (optional)"
+                            )
+                        },
+                        placeholder = { Text("Provide details...") },
+                        maxLines = 4,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+
+                    state.error?.let {
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = it,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                val isReasonValid = selectedReason != null
+                val isDescriptionValid = selectedReason != "Other" || description.isNotBlank()
+
+                Button(
+                    enabled = isReasonValid && isDescriptionValid && !state.isSubmitting,
+                    onClick = {
+                        selectedReason?.let { reason ->
+                            viewModel.submitReport(
+                                targetId = targetId,
+                                targetType = targetType,
+                                reason = reason,
+                                description = description.ifBlank { null }
+                            )
+                        }
+                    }
+                ) {
+                    if (state.isSubmitting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                    } else {
+                        Text("Submit Report")
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    enabled = !state.isSubmitting,
+                    onClick = onDismiss
+                ) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/presentation/ReportDialog.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/presentation/ReportDialog.kt
@@ -63,20 +63,20 @@ fun ReportDialog(
                     imageVector = Icons.Default.CheckCircle,
                     contentDescription = null,
                     tint = must.kdroiders.hustlehub.ui.theme.HustleSuccess,
-                    modifier = Modifier.padding(8.dp)
+                    modifier = Modifier.padding(8.dp),
                 )
             },
             title = {
                 Text(
                     text = "Report Submitted",
                     style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
                 )
             },
             text = {
                 Text(
                     text = "Thank you. Our moderators will review this reported $targetType shortly.",
-                    style = MaterialTheme.typography.bodyMedium
+                    style = MaterialTheme.typography.bodyMedium,
                 )
             },
             confirmButton = {
@@ -84,11 +84,11 @@ fun ReportDialog(
                     onClick = {
                         onDismiss()
                         viewModel.resetState()
-                    }
+                    },
                 ) {
                     Text("OK")
                 }
-            }
+            },
         )
     } else {
         AlertDialog(
@@ -97,18 +97,18 @@ fun ReportDialog(
                 Text(
                     text = "Report $targetType",
                     style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
                 )
             },
             text = {
                 Column(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(
                         text = "Why are you reporting this?",
                         style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
 
                     reasons.forEach { reason ->
@@ -118,16 +118,16 @@ fun ReportDialog(
                                 .clip(RoundedCornerShape(8.dp))
                                 .clickable { selectedReason = reason }
                                 .padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
                             RadioButton(
                                 selected = selectedReason == reason,
-                                onClick = { selectedReason = reason }
+                                onClick = { selectedReason = reason },
                             )
                             Spacer(Modifier.width(8.dp))
                             Text(
                                 text = reason,
-                                style = MaterialTheme.typography.bodyMedium
+                                style = MaterialTheme.typography.bodyMedium,
                             )
                         }
                     }
@@ -139,13 +139,13 @@ fun ReportDialog(
                         onValueChange = { description = it },
                         label = {
                             Text(
-                                text = if (selectedReason == "Other") "Please specify (required)" else "Additional context (optional)"
+                                text = if (selectedReason == "Other") "Please specify (required)" else "Additional context (optional)",
                             )
                         },
                         placeholder = { Text("Provide details...") },
                         maxLines = 4,
                         modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(12.dp)
+                        shape = RoundedCornerShape(12.dp),
                     )
 
                     state.error?.let {
@@ -154,7 +154,7 @@ fun ReportDialog(
                             text = it,
                             color = MaterialTheme.colorScheme.error,
                             style = MaterialTheme.typography.bodySmall,
-                            fontWeight = FontWeight.Bold
+                            fontWeight = FontWeight.Bold,
                         )
                     }
                 }
@@ -171,15 +171,15 @@ fun ReportDialog(
                                 targetId = targetId,
                                 targetType = targetType,
                                 reason = reason,
-                                description = description.ifBlank { null }
+                                description = description.ifBlank { null },
                             )
                         }
-                    }
+                    },
                 ) {
                     if (state.isSubmitting) {
                         CircularProgressIndicator(
                             modifier = Modifier.padding(horizontal = 8.dp),
-                            color = MaterialTheme.colorScheme.onPrimary
+                            color = MaterialTheme.colorScheme.onPrimary,
                         )
                     } else {
                         Text("Submit Report")
@@ -189,11 +189,11 @@ fun ReportDialog(
             dismissButton = {
                 TextButton(
                     enabled = !state.isSubmitting,
-                    onClick = onDismiss
+                    onClick = onDismiss,
                 ) {
                     Text("Cancel")
                 }
-            }
+            },
         )
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/presentation/ReportViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/presentation/ReportViewModel.kt
@@ -1,0 +1,51 @@
+package must.kdroiders.hustlehub.ui.features.report.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.ui.features.report.domain.repository.ReportRepository
+import javax.inject.Inject
+
+data class ReportUiState(
+    val isSubmitting: Boolean = false,
+    val isSuccess: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class ReportViewModel @Inject constructor(
+    private val reportRepository: ReportRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ReportUiState())
+    val uiState: StateFlow<ReportUiState> = _uiState.asStateFlow()
+
+    fun submitReport(
+        targetId: String,
+        targetType: String,
+        reason: String,
+        description: String?,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmitting = true, error = null, isSuccess = false) }
+            val result = reportRepository.submitReport(targetId, targetType, reason, description)
+            result.fold(
+                onSuccess = {
+                    _uiState.update { it.copy(isSubmitting = false, isSuccess = true) }
+                },
+                onFailure = { e ->
+                    _uiState.update { it.copy(isSubmitting = false, error = e.message ?: "Failed to submit report") }
+                }
+            )
+        }
+    }
+
+    fun resetState() {
+        _uiState.value = ReportUiState()
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/presentation/ReportViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/report/presentation/ReportViewModel.kt
@@ -18,34 +18,35 @@ data class ReportUiState(
 )
 
 @HiltViewModel
-class ReportViewModel @Inject constructor(
-    private val reportRepository: ReportRepository,
-) : ViewModel() {
+class ReportViewModel
+    @Inject
+    constructor(
+        private val reportRepository: ReportRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(ReportUiState())
+        val uiState: StateFlow<ReportUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow(ReportUiState())
-    val uiState: StateFlow<ReportUiState> = _uiState.asStateFlow()
+        fun submitReport(
+            targetId: String,
+            targetType: String,
+            reason: String,
+            description: String?,
+        ) {
+            viewModelScope.launch {
+                _uiState.update { it.copy(isSubmitting = true, error = null, isSuccess = false) }
+                val result = reportRepository.submitReport(targetId, targetType, reason, description)
+                result.fold(
+                    onSuccess = {
+                        _uiState.update { it.copy(isSubmitting = false, isSuccess = true) }
+                    },
+                    onFailure = { e ->
+                        _uiState.update { it.copy(isSubmitting = false, error = e.message ?: "Failed to submit report") }
+                    },
+                )
+            }
+        }
 
-    fun submitReport(
-        targetId: String,
-        targetType: String,
-        reason: String,
-        description: String?,
-    ) {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isSubmitting = true, error = null, isSuccess = false) }
-            val result = reportRepository.submitReport(targetId, targetType, reason, description)
-            result.fold(
-                onSuccess = {
-                    _uiState.update { it.copy(isSubmitting = false, isSuccess = true) }
-                },
-                onFailure = { e ->
-                    _uiState.update { it.copy(isSubmitting = false, error = e.message ?: "Failed to submit report") }
-                }
-            )
+        fun resetState() {
+            _uiState.value = ReportUiState()
         }
     }
-
-    fun resetState() {
-        _uiState.value = ReportUiState()
-    }
-}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/remote/ServiceApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/remote/ServiceApiService.kt
@@ -82,9 +82,10 @@ interface ServiceApiService {
         @Query("size") size: Int = 10,
     ): ApiResponse<PageResponse<ReviewResponse>>
 
-    /** Submits a new review. Maps to POST /api/v1/reviews. Returns 409 on duplicate (same user + service). */
-    @POST("reviews")
+    /** Submits a new review. Maps to POST /api/v1/services/{serviceId}/reviews. Returns 409 on duplicate (same user + service). */
+    @POST("services/{serviceId}/reviews")
     suspend fun submitReview(
+        @Path("serviceId") serviceId: String,
         @Body request: CreateReviewRequest,
     ): ApiResponse<ReviewResponse>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/remote/dto/ReviewDto.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/remote/dto/ReviewDto.kt
@@ -1,5 +1,7 @@
 package must.kdroiders.hustlehub.ui.features.service.data.remote.dto
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Wire-format DTO for a single review returned by the backend.
  *
@@ -8,23 +10,25 @@ package must.kdroiders.hustlehub.ui.features.service.data.remote.dto
 data class ReviewResponse(
     val id: String,
     val serviceId: String,
-    val providerId: String,
-    val customerId: String,
-    val customerName: String,
-    val customerAvatarUrl: String?,
+    val providerId: String? = null,
+    @SerializedName("reviewerId")
+    val customerId: String? = null,
+    @SerializedName("reviewerName")
+    val customerName: String? = null,
+    @SerializedName("reviewerAvatarUrl")
+    val customerAvatarUrl: String? = null,
     val rating: Int,
-    val comment: String?,
-    val isAnonymous: Boolean,
+    val comment: String? = null,
+    val isAnonymous: Boolean = false,
     val createdAt: String,
 )
 
 /**
- * Request body for POST /api/v1/reviews.
+ * Request body for POST /api/v1/services/{serviceId}/reviews.
  *
  * @param isAnonymous When true the backend omits customer identity from public responses.
  */
 data class CreateReviewRequest(
-    val serviceId: String,
     val rating: Int,
     val comment: String? = null,
     val isAnonymous: Boolean = false,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ReviewRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ReviewRepositoryImpl.kt
@@ -1,0 +1,110 @@
+package must.kdroiders.hustlehub.ui.features.service.data.repository
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.datastore.UserPreferences
+import must.kdroiders.hustlehub.ui.features.service.data.remote.ServiceApiService
+import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.CreateReviewRequest
+import must.kdroiders.hustlehub.ui.features.service.data.remote.dto.ReviewResponse
+import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
+import must.kdroiders.hustlehub.ui.features.service.domain.repository.ReviewRepository
+import retrofit2.HttpException
+import timber.log.Timber
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReviewRepositoryImpl
+    @Inject
+    constructor(
+        private val apiService: ServiceApiService,
+        private val userPreferences: UserPreferences,
+    ) : ReviewRepository {
+
+    override suspend fun submitReview(
+        serviceId: String,
+        rating: Int,
+        comment: String?,
+        isAnonymous: Boolean,
+    ): Result<Review> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val request = CreateReviewRequest(
+                    serviceId = serviceId,
+                    rating = rating,
+                    comment = comment,
+                    isAnonymous = isAnonymous,
+                )
+                val response = apiService.submitReview(request)
+                check(response.success && response.data != null) { response.message }
+                response.data.toDomain()
+            }.recoverCatching { e ->
+                if (e is CancellationException) throw e
+                if (e is HttpException && e.code() == 409) {
+                    throw Exception("You have already reviewed this service.")
+                } else {
+                    Timber.w(e, "ReviewRepositoryImpl.submitReview failed for serviceId='$serviceId'")
+                    throw e
+                }
+            }
+        }
+
+    override suspend fun getReviewsForService(
+        serviceId: String,
+        page: Int,
+        size: Int,
+    ): Result<PageResponse<Review>> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val response = apiService.getServiceReviews(serviceId, page, size)
+                check(response.success && response.data != null) { response.message ?: "Failed to fetch reviews" }
+                val pageData = response.data
+                PageResponse(
+                    content = pageData.content.map { it.toDomain() },
+                    page = pageData.page,
+                    size = pageData.size,
+                    totalElements = pageData.totalElements,
+                    totalPages = pageData.totalPages,
+                )
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+                Timber.w(e, "ReviewRepositoryImpl.getReviewsForService failed for serviceId='$serviceId'")
+            }
+        }
+
+    override suspend fun checkDuplicateReview(serviceId: String): Result<Boolean> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val currentUser = userPreferences.cachedUser.firstOrNull()
+                if (currentUser == null || currentUser.id.isBlank()) {
+                    return@runCatching false
+                }
+                val response = apiService.getServiceReviews(serviceId, page = 0, size = 50)
+                check(response.success && response.data != null) { response.message ?: "Failed to fetch reviews" }
+                response.data.content.any { it.customerId == currentUser.id }
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+                Timber.w(e, "ReviewRepositoryImpl.checkDuplicateReview failed for serviceId='$serviceId'")
+            }
+        }
+}
+
+private fun ReviewResponse.toDomain(): Review =
+    Review(
+        id = id,
+        serviceId = serviceId,
+        providerId = providerId,
+        customerId = customerId,
+        customerName = if (isAnonymous) "Anonymous" else customerName,
+        customerAvatarUrl = if (isAnonymous) "" else (customerAvatarUrl ?: ""),
+        rating = rating,
+        comment = comment,
+        isAnonymous = isAnonymous,
+        createdAt = runCatching {
+            Instant.parse(createdAt).toEpochMilli()
+        }.getOrDefault(0L),
+    )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ReviewRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ReviewRepositoryImpl.kt
@@ -34,17 +34,16 @@ class ReviewRepositoryImpl
         withContext(Dispatchers.IO) {
             runCatching {
                 val request = CreateReviewRequest(
-                    serviceId = serviceId,
                     rating = rating,
                     comment = comment,
                     isAnonymous = isAnonymous,
                 )
-                val response = apiService.submitReview(request)
+                val response = apiService.submitReview(serviceId, request)
                 check(response.success && response.data != null) { response.message }
                 response.data.toDomain()
             }.recoverCatching { e ->
                 if (e is CancellationException) throw e
-                if (e is HttpException && e.code() == 409) {
+                if (e is HttpException && (e.code() == 409 || e.code() == 400)) {
                     throw Exception("You have already reviewed this service.")
                 } else {
                     Timber.w(e, "ReviewRepositoryImpl.submitReview failed for serviceId='$serviceId'")
@@ -97,9 +96,9 @@ private fun ReviewResponse.toDomain(): Review =
     Review(
         id = id,
         serviceId = serviceId,
-        providerId = providerId,
-        customerId = customerId,
-        customerName = if (isAnonymous) "Anonymous" else customerName,
+        providerId = providerId ?: "",
+        customerId = customerId ?: "",
+        customerName = if (isAnonymous) "Anonymous" else (customerName ?: "Student"),
         customerAvatarUrl = if (isAnonymous) "" else (customerAvatarUrl ?: ""),
         rating = rating,
         comment = comment,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ReviewRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ReviewRepositoryImpl.kt
@@ -24,73 +24,72 @@ class ReviewRepositoryImpl
         private val apiService: ServiceApiService,
         private val userPreferences: UserPreferences,
     ) : ReviewRepository {
-
-    override suspend fun submitReview(
-        serviceId: String,
-        rating: Int,
-        comment: String?,
-        isAnonymous: Boolean,
-    ): Result<Review> =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val request = CreateReviewRequest(
-                    rating = rating,
-                    comment = comment,
-                    isAnonymous = isAnonymous,
-                )
-                val response = apiService.submitReview(serviceId, request)
-                check(response.success && response.data != null) { response.message }
-                response.data.toDomain()
-            }.recoverCatching { e ->
-                if (e is CancellationException) throw e
-                if (e is HttpException && (e.code() == 409 || e.code() == 400)) {
-                    throw Exception("You have already reviewed this service.")
-                } else {
-                    Timber.w(e, "ReviewRepositoryImpl.submitReview failed for serviceId='$serviceId'")
-                    throw e
+        override suspend fun submitReview(
+            serviceId: String,
+            rating: Int,
+            comment: String?,
+            isAnonymous: Boolean,
+        ): Result<Review> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = CreateReviewRequest(
+                        rating = rating,
+                        comment = comment,
+                        isAnonymous = isAnonymous,
+                    )
+                    val response = apiService.submitReview(serviceId, request)
+                    check(response.success && response.data != null) { response.message }
+                    response.data.toDomain()
+                }.recoverCatching { e ->
+                    if (e is CancellationException) throw e
+                    if (e is HttpException && (e.code() == 409 || e.code() == 400)) {
+                        throw Exception("You have already reviewed this service.")
+                    } else {
+                        Timber.w(e, "ReviewRepositoryImpl.submitReview failed for serviceId='$serviceId'")
+                        throw e
+                    }
                 }
             }
-        }
 
-    override suspend fun getReviewsForService(
-        serviceId: String,
-        page: Int,
-        size: Int,
-    ): Result<PageResponse<Review>> =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val response = apiService.getServiceReviews(serviceId, page, size)
-                check(response.success && response.data != null) { response.message ?: "Failed to fetch reviews" }
-                val pageData = response.data
-                PageResponse(
-                    content = pageData.content.map { it.toDomain() },
-                    page = pageData.page,
-                    size = pageData.size,
-                    totalElements = pageData.totalElements,
-                    totalPages = pageData.totalPages,
-                )
-            }.onFailure { e ->
-                if (e is CancellationException) throw e
-                Timber.w(e, "ReviewRepositoryImpl.getReviewsForService failed for serviceId='$serviceId'")
-            }
-        }
-
-    override suspend fun checkDuplicateReview(serviceId: String): Result<Boolean> =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val currentUser = userPreferences.cachedUser.firstOrNull()
-                if (currentUser == null || currentUser.id.isBlank()) {
-                    return@runCatching false
+        override suspend fun getReviewsForService(
+            serviceId: String,
+            page: Int,
+            size: Int,
+        ): Result<PageResponse<Review>> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val response = apiService.getServiceReviews(serviceId, page, size)
+                    check(response.success && response.data != null) { response.message ?: "Failed to fetch reviews" }
+                    val pageData = response.data
+                    PageResponse(
+                        content = pageData.content.map { it.toDomain() },
+                        page = pageData.page,
+                        size = pageData.size,
+                        totalElements = pageData.totalElements,
+                        totalPages = pageData.totalPages,
+                    )
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Timber.w(e, "ReviewRepositoryImpl.getReviewsForService failed for serviceId='$serviceId'")
                 }
-                val response = apiService.getServiceReviews(serviceId, page = 0, size = 50)
-                check(response.success && response.data != null) { response.message ?: "Failed to fetch reviews" }
-                response.data.content.any { it.customerId == currentUser.id }
-            }.onFailure { e ->
-                if (e is CancellationException) throw e
-                Timber.w(e, "ReviewRepositoryImpl.checkDuplicateReview failed for serviceId='$serviceId'")
             }
-        }
-}
+
+        override suspend fun checkDuplicateReview(serviceId: String): Result<Boolean> =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val currentUser = userPreferences.cachedUser.firstOrNull()
+                    if (currentUser == null || currentUser.id.isBlank()) {
+                        return@runCatching false
+                    }
+                    val response = apiService.getServiceReviews(serviceId, page = 0, size = 50)
+                    check(response.success && response.data != null) { response.message ?: "Failed to fetch reviews" }
+                    response.data.content.any { it.customerId == currentUser.id }
+                }.onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Timber.w(e, "ReviewRepositoryImpl.checkDuplicateReview failed for serviceId='$serviceId'")
+                }
+            }
+    }
 
 private fun ReviewResponse.toDomain(): Review =
     Review(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/data/repository/ServiceRepositoryImpl.kt
@@ -312,17 +312,16 @@ class ServiceRepositoryImpl
             withContext(Dispatchers.IO) {
                 runCatching {
                     val request = CreateReviewRequest(
-                        serviceId = serviceId,
                         rating = rating,
                         comment = comment,
                         isAnonymous = isAnonymous,
                     )
-                    val response = apiService.submitReview(request)
+                    val response = apiService.submitReview(serviceId, request)
                     check(response.success && response.data != null) { response.message }
                     response.data.toDomain()
                 }.recoverCatching { e ->
                     if (e is CancellationException) throw e
-                    if (e is retrofit2.HttpException && e.code() == 409) {
+                    if (e is retrofit2.HttpException && (e.code() == 409 || e.code() == 400)) {
                         throw Exception("You have already reviewed this service.")
                     } else {
                         Timber.w(e, "submitReview failed for serviceId='$serviceId'")
@@ -359,9 +358,9 @@ private fun ReviewResponse.toDomain(): Review =
     Review(
         id = id,
         serviceId = serviceId,
-        providerId = providerId,
-        customerId = customerId,
-        customerName = if (isAnonymous) "Anonymous" else customerName,
+        providerId = providerId ?: "",
+        customerId = customerId ?: "",
+        customerName = if (isAnonymous) "Anonymous" else (customerName ?: "Student"),
         customerAvatarUrl = if (isAnonymous) "" else (customerAvatarUrl ?: ""),
         rating = rating,
         comment = comment,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/repository/ReviewRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/repository/ReviewRepository.kt
@@ -1,0 +1,31 @@
+package must.kdroiders.hustlehub.ui.features.service.domain.repository
+
+import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
+
+/** Repository handling service review operations. */
+interface ReviewRepository {
+    /**
+     * Submits a review for a service.
+     */
+    suspend fun submitReview(
+        serviceId: String,
+        rating: Int,
+        comment: String? = null,
+        isAnonymous: Boolean = false,
+    ): Result<Review>
+
+    /**
+     * Returns paginated reviews for a service (default page size 10).
+     */
+    suspend fun getReviewsForService(
+        serviceId: String,
+        page: Int = 0,
+        size: Int = 10,
+    ): Result<PageResponse<Review>>
+
+    /**
+     * Checks if the currently authenticated user has already submitted a review for [serviceId].
+     */
+    suspend fun checkDuplicateReview(serviceId: String): Result<Boolean>
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/CheckDuplicateReviewUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/CheckDuplicateReviewUseCase.kt
@@ -1,0 +1,11 @@
+package must.kdroiders.hustlehub.ui.features.service.domain.usecase
+
+import must.kdroiders.hustlehub.ui.features.service.domain.repository.ReviewRepository
+import javax.inject.Inject
+
+class CheckDuplicateReviewUseCase
+    @Inject
+    constructor(private val repository: ReviewRepository) {
+        suspend operator fun invoke(serviceId: String): Result<Boolean> =
+            repository.checkDuplicateReview(serviceId)
+    }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/CheckDuplicateReviewUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/CheckDuplicateReviewUseCase.kt
@@ -6,6 +6,5 @@ import javax.inject.Inject
 class CheckDuplicateReviewUseCase
     @Inject
     constructor(private val repository: ReviewRepository) {
-        suspend operator fun invoke(serviceId: String): Result<Boolean> =
-            repository.checkDuplicateReview(serviceId)
+        suspend operator fun invoke(serviceId: String): Result<Boolean> = repository.checkDuplicateReview(serviceId)
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/GetServiceReviewsUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/GetServiceReviewsUseCase.kt
@@ -2,15 +2,15 @@ package must.kdroiders.hustlehub.ui.features.service.domain.usecase
 
 import must.kdroiders.hustlehub.core.api.PageResponse
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
-import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
+import must.kdroiders.hustlehub.ui.features.service.domain.repository.ReviewRepository
 import javax.inject.Inject
 
 class GetServiceReviewsUseCase
     @Inject
-    constructor(private val repository: ServiceRepository) {
+    constructor(private val repository: ReviewRepository) {
         suspend operator fun invoke(
             serviceId: String,
             page: Int = 0,
             size: Int = 10,
-        ): Result<PageResponse<Review>> = repository.getServiceReviews(serviceId, page, size)
+        ): Result<PageResponse<Review>> = repository.getReviewsForService(serviceId, page, size)
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/SubmitReviewUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/domain/usecase/SubmitReviewUseCase.kt
@@ -1,12 +1,12 @@
 package must.kdroiders.hustlehub.ui.features.service.domain.usecase
 
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
-import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
+import must.kdroiders.hustlehub.ui.features.service.domain.repository.ReviewRepository
 import javax.inject.Inject
 
 class SubmitReviewUseCase
     @Inject
-    constructor(private val repository: ServiceRepository) {
+    constructor(private val repository: ReviewRepository) {
         suspend operator fun invoke(
             serviceId: String,
             rating: Int,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/AllReviewsScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/AllReviewsScreen.kt
@@ -1,19 +1,15 @@
 package must.kdroiders.hustlehub.ui.features.service.presentation.view
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -45,7 +41,6 @@ import must.kdroiders.hustlehub.sharedComposables.EmptyStateView
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewItem
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewSummaryCard
-import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.AllReviewsUiState
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.AllReviewsViewModel
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.ReviewSortOption
 
@@ -126,7 +121,8 @@ fun AllReviewsScreen(
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                    contentPadding = androidx.compose.foundation.layout
+                        .PaddingValues(16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     // Rating Summary Breakdown Bar Chart

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/AllReviewsScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/AllReviewsScreen.kt
@@ -1,0 +1,197 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import must.kdroiders.hustlehub.sharedComposables.EmptyStateView
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewItem
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewSummaryCard
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.AllReviewsUiState
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.AllReviewsViewModel
+import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.ReviewSortOption
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AllReviewsScreen(
+    serviceId: String,
+    viewModel: AllReviewsViewModel = hiltViewModel(),
+    onBack: () -> Unit = {},
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(serviceId) {
+        viewModel.initialize(serviceId)
+    }
+
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    HustleScaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            CenterAlignedTopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
+                title = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "Reviews",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        if (state.service != null) {
+                            Text(
+                                text = state.service?.title ?: "",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+            )
+        },
+    ) { innerPadding ->
+        PullToRefreshBox(
+            isRefreshing = state.isRefreshing,
+            onRefresh = viewModel::refresh,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .background(MaterialTheme.colorScheme.background),
+        ) {
+            if (state.isLoading && !state.isRefreshing) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else if (state.reviews.isEmpty() && !state.isLoading) {
+                EmptyStateView(
+                    title = "No reviews yet",
+                    description = "Be the first student to review this service!",
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    // Rating Summary Breakdown Bar Chart
+                    item {
+                        ReviewSummaryCard(
+                            averageRating = state.averageRating,
+                            totalReviews = state.totalReviews,
+                        )
+                    }
+
+                    // Sort Filter Chips
+                    item {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Sort by:",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            ReviewSortOption.entries.forEach { option ->
+                                val isSelected = option == state.sortOption
+                                Box(
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(20.dp))
+                                        .background(
+                                            if (isSelected) {
+                                                MaterialTheme.colorScheme.primary
+                                            } else {
+                                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                                            },
+                                        ).clickable { viewModel.onSortOptionSelected(option) }
+                                        .padding(horizontal = 12.dp, vertical = 6.dp),
+                                ) {
+                                    Text(
+                                        text = option.label,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                                        color = if (isSelected) {
+                                            MaterialTheme.colorScheme.onPrimary
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    // Review list items
+                    itemsIndexed(
+                        items = state.reviews,
+                        key = { _, review -> review.id },
+                    ) { index, review ->
+                        ReviewItem(
+                            review = review,
+                            showDivider = index < state.reviews.size - 1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
@@ -68,7 +68,6 @@ import must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.CategoryBadge
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.FullScreenImageViewer
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.PortfolioGallery
-import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewCard
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewItem
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewSummaryCard
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.ServiceDetailUiState

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
@@ -69,6 +69,7 @@ import must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.FullScreenImageViewer
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.PortfolioGallery
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewCard
+import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewItem
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.ReviewSummaryCard
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.ServiceDetailUiState
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.ServiceDetailViewModel
@@ -89,6 +90,7 @@ fun ServiceDetailScreen(
     ) -> Unit = { _, _, _, _, _, _ -> },
     onNavigateToProviderProfile: (providerId: String) -> Unit = {},
     onNavigateToWriteReview: (serviceId: String, providerId: String) -> Unit = { _, _ -> },
+    onNavigateToAllReviews: (serviceId: String) -> Unit = {},
 ) {
     val state by serviceDetailViewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -172,6 +174,7 @@ fun ServiceDetailScreen(
                     onImageClick = { index -> fullScreenImageIndex = index },
                     onProviderClick = { state.service?.providerId?.let { onNavigateToProviderProfile(it) } },
                     onNavigateToWriteReview = onNavigateToWriteReview,
+                    onNavigateToAllReviews = onNavigateToAllReviews,
                 )
             }
 
@@ -243,6 +246,7 @@ private fun ServiceDetailContent(
     onImageClick: (Int) -> Unit,
     onProviderClick: () -> Unit,
     onNavigateToWriteReview: (serviceId: String, providerId: String) -> Unit,
+    onNavigateToAllReviews: (serviceId: String) -> Unit,
 ) {
     val service = state.service ?: return
     val provider = state.provider
@@ -544,17 +548,18 @@ private fun ServiceDetailContent(
                 )
             }
         } else {
-            items(items = state.reviews, key = { it.id }) { review ->
-                ReviewCard(
+            val latestReviews = state.reviews.take(3)
+            items(items = latestReviews, key = { it.id }) { review ->
+                ReviewItem(
                     review = review,
                     modifier = Modifier.padding(horizontal = 20.dp),
                 )
             }
 
-            if (state.totalReviewCount > state.reviews.size) {
+            if (state.totalReviewCount > 0) {
                 item(key = "see_all") {
                     Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                        TextButton(onClick = {}) {
+                        TextButton(onClick = { onNavigateToAllReviews(service.id) }) {
                             Text("See all ${state.totalReviewCount} reviews")
                         }
                     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import must.kdroiders.hustlehub.ui.features.report.presentation.ReportDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -68,6 +67,7 @@ import must.kdroiders.hustlehub.sharedComposables.ErrorView
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
 import must.kdroiders.hustlehub.sharedComposables.LoadingIndicator
 import must.kdroiders.hustlehub.sharedComposables.SectionHeader
+import must.kdroiders.hustlehub.ui.features.report.presentation.ReportDialog
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.AvailabilityBadge
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.CategoryBadge
 import must.kdroiders.hustlehub.ui.features.service.presentation.view.components.FullScreenImageViewer
@@ -208,7 +208,7 @@ fun ServiceDetailScreen(
                     // Share, Bookmark and More
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         IconButton(
                             onClick = { scope.launch { snackbarHostState.showSnackbar("Share feature coming soon!") } },
@@ -244,14 +244,14 @@ fun ServiceDetailScreen(
                             }
                             DropdownMenu(
                                 expanded = showMenu,
-                                onDismissRequest = { showMenu = false }
+                                onDismissRequest = { showMenu = false },
                             ) {
                                 DropdownMenuItem(
                                     text = { Text("Report Service") },
                                     onClick = {
                                         showMenu = false
                                         showReportDialog = true
-                                    }
+                                    },
                                 )
                             }
                         }
@@ -260,7 +260,7 @@ fun ServiceDetailScreen(
                             ReportDialog(
                                 targetId = serviceId,
                                 targetType = "service",
-                                onDismiss = { showReportDialog = false }
+                                onDismiss = { showReportDialog = false },
                             )
                         }
                     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/ServiceDetailScreen.kt
@@ -28,13 +28,17 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import must.kdroiders.hustlehub.ui.features.report.presentation.ReportDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -201,8 +205,11 @@ fun ServiceDetailScreen(
                         )
                     }
 
-                    // Share and Bookmark
-                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    // Share, Bookmark and More
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
                         IconButton(
                             onClick = { scope.launch { snackbarHostState.showSnackbar("Share feature coming soon!") } },
                             modifier = Modifier
@@ -220,6 +227,41 @@ fun ServiceDetailScreen(
                                 .background(Color.Black.copy(alpha = 0.3f)),
                         ) {
                             Icon(Icons.Default.BookmarkBorder, contentDescription = "Save", tint = Color.White)
+                        }
+
+                        var showMenu by remember { mutableStateOf(false) }
+                        var showReportDialog by remember { mutableStateOf(false) }
+
+                        Box {
+                            IconButton(
+                                onClick = { showMenu = true },
+                                modifier = Modifier
+                                    .size(40.dp)
+                                    .clip(CircleShape)
+                                    .background(Color.Black.copy(alpha = 0.3f)),
+                            ) {
+                                Icon(Icons.Default.MoreVert, contentDescription = "More options", tint = Color.White)
+                            }
+                            DropdownMenu(
+                                expanded = showMenu,
+                                onDismissRequest = { showMenu = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("Report Service") },
+                                    onClick = {
+                                        showMenu = false
+                                        showReportDialog = true
+                                    }
+                                )
+                            }
+                        }
+
+                        if (showReportDialog) {
+                            ReportDialog(
+                                targetId = serviceId,
+                                targetType = "service",
+                                onDismiss = { showReportDialog = false }
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/WriteReviewScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/WriteReviewScreen.kt
@@ -284,7 +284,13 @@ fun WriteReviewScreen(
                 Text(
                     text = "${state.commentLength} / ${state.maxCommentLength} characters",
                     style = MaterialTheme.typography.labelMedium,
-                    color = if (state.commentLength >= state.maxCommentLength) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (state.commentLength >=
+                        state.maxCommentLength
+                    ) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
                     modifier = Modifier.align(Alignment.End),
                 )
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/WriteReviewScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/WriteReviewScreen.kt
@@ -1,5 +1,11 @@
 package must.kdroiders.hustlehub.ui.features.service.presentation.view
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -25,6 +31,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -47,14 +55,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
+import kotlinx.coroutines.delay
 import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.sharedComposables.HustleTextField
-import must.kdroiders.hustlehub.sharedComposables.RatingBar
+import must.kdroiders.hustlehub.sharedComposables.StarRatingBar
 import must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel.WriteReviewViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -75,6 +85,7 @@ fun WriteReviewScreen(
     LaunchedEffect(state.submitSuccess) {
         if (state.submitSuccess) {
             snackbarHostState.showSnackbar("Review submitted! Thank you.")
+            delay(1200)
             onSubmitSuccess()
         }
     }
@@ -109,233 +120,308 @@ fun WriteReviewScreen(
             )
         },
     ) { innerPadding ->
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
-                .padding(innerPadding)
-                .verticalScroll(rememberScrollState())
-                .imePadding()
-                .navigationBarsPadding()
-                .padding(horizontal = 24.dp, vertical = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .padding(innerPadding),
         ) {
-            if (state.isLoadingInfo) {
-                CircularProgressIndicator()
-            } else if (state.provider != null && state.service != null) {
-                // Provider Info Card
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(24.dp))
-                        .background(MaterialTheme.colorScheme.surface)
-                        .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f), RoundedCornerShape(24.dp))
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Box(modifier = Modifier.size(56.dp)) {
-                        AsyncImage(
-                            model = state.provider?.profilePhotoUrl,
-                            contentDescription = "Provider Avatar",
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.surfaceVariant),
-                            contentScale = ContentScale.Crop,
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .imePadding()
+                    .navigationBarsPadding()
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                if (state.isLoadingInfo) {
+                    CircularProgressIndicator()
+                } else if (state.provider != null && state.service != null) {
+                    // Provider Info Card
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(24.dp))
+                            .background(MaterialTheme.colorScheme.surface)
+                            .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f), RoundedCornerShape(24.dp))
+                            .padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Box(modifier = Modifier.size(56.dp)) {
+                            AsyncImage(
+                                model = state.provider?.profilePhotoUrl,
+                                contentDescription = "Provider Avatar",
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                                contentScale = ContentScale.Crop,
+                            )
+                            // Online indicator (green dot)
+                            Box(
+                                modifier = Modifier
+                                    .size(14.dp)
+                                    .align(Alignment.BottomEnd)
+                                    .clip(CircleShape)
+                                    .background(must.kdroiders.hustlehub.ui.theme.HustleSuccess)
+                                    .border(2.dp, MaterialTheme.colorScheme.surface, CircleShape),
+                            )
+                        }
+                        Spacer(Modifier.width(16.dp))
+                        Column {
+                            Text(
+                                text = state.provider?.name ?: "Unknown",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            Text(
+                                text = state.service?.title ?: "",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Box(
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(MaterialTheme.colorScheme.secondaryContainer)
+                                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                            ) {
+                                Text(
+                                    text = "Verified Student",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (state.hasAlreadyReviewed) {
+                    Spacer(Modifier.height(16.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.8f))
+                            .padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Info,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
                         )
-                        // Online indicator (green dot)
-                        Box(
-                            modifier = Modifier
-                                .size(14.dp)
-                                .align(Alignment.BottomEnd)
-                                .clip(CircleShape)
-                                .background(must.kdroiders.hustlehub.ui.theme.HustleSuccess)
-                                .border(2.dp, MaterialTheme.colorScheme.surface, CircleShape),
+                        Spacer(Modifier.width(12.dp))
+                        Text(
+                            text = "You have already submitted a review for this service.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            fontWeight = FontWeight.Medium,
                         )
                     }
-                    Spacer(Modifier.width(16.dp))
-                    Column {
-                        Text(
-                            text = state.provider?.name ?: "Unknown",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Text(
-                            text = state.service?.title ?: "",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Spacer(Modifier.height(4.dp))
+                }
+
+                Spacer(Modifier.height(32.dp))
+
+                // Interactive Star Rating (Tap / Drag)
+                StarRatingBar(
+                    rating = state.rating,
+                    starSize = 44.dp,
+                    onRatingChanged = viewModel::onRatingChanged,
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                // Rating Feedback Text
+                val feedbackText = when (state.rating) {
+                    5 -> "Outstanding!"
+                    4 -> "Great!"
+                    3 -> "Good"
+                    2 -> "Could be better"
+                    1 -> "Poor"
+                    else -> "Tap or drag stars to rate"
+                }
+                Text(
+                    text = feedbackText,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                if (state.rating > 0) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "You rated this service ${state.rating} star${if (state.rating > 1) "s" else ""}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                Spacer(Modifier.height(32.dp))
+
+                // Review Input Area
+                val providerFirstName = state.provider
+                    ?.name
+                    ?.split(" ")
+                    ?.firstOrNull() ?: "the provider"
+
+                HustleTextField(
+                    value = state.comment,
+                    onValueChange = viewModel::onCommentChanged,
+                    placeholder = "Share your experience with $providerFirstName...\nWas the delivery on time? How was the quality?",
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = false,
+                    minLines = 5,
+                    maxLines = 5,
+                )
+
+                Spacer(Modifier.height(8.dp))
+
+                // Live Character Count Indicator
+                Text(
+                    text = "${state.commentLength} / ${state.maxCommentLength} characters",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (state.commentLength >= state.maxCommentLength) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.align(Alignment.End),
+                )
+
+                Spacer(Modifier.height(24.dp))
+
+                // Predefined Tags
+                val availableTags = listOf("Fast Delivery", "Great Communication", "Creative")
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    availableTags.forEach { tag ->
+                        val isSelected = state.selectedTags.contains(tag)
                         Box(
                             modifier = Modifier
-                                .clip(RoundedCornerShape(8.dp))
-                                .background(MaterialTheme.colorScheme.secondaryContainer)
-                                .padding(horizontal = 8.dp, vertical = 4.dp),
+                                .clip(RoundedCornerShape(20.dp))
+                                .background(
+                                    if (isSelected) {
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+                                    } else {
+                                        MaterialTheme.colorScheme.surface
+                                    },
+                                ).border(
+                                    width = 1.dp,
+                                    color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant,
+                                    shape = RoundedCornerShape(20.dp),
+                                ).clickable { viewModel.onTagToggled(tag) }
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
                         ) {
                             Text(
-                                text = "Verified Student",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                text = tag,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Checkbox(
+                        checked = state.isAnonymous,
+                        onCheckedChange = viewModel::onAnonymousToggled,
+                    )
+                    Text(
+                        text = "Post anonymously",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                Spacer(Modifier.height(32.dp))
+
+                // Submit Button
+                Button(
+                    onClick = viewModel::submit,
+                    enabled = state.canSubmit,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    shape = RoundedCornerShape(28.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                    ),
+                ) {
+                    if (state.isSubmitting) {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(24.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center,
+                        ) {
+                            Text(
+                                text = if (state.hasAlreadyReviewed) "Already Reviewed" else "Submit Review",
+                                style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold,
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Icon(
+                                imageVector = Icons.Default.Star,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
                             )
                         }
                     }
                 }
             }
 
-            Spacer(Modifier.height(32.dp))
-
-            // Star Rating
-            RatingBar(
-                rating = state.rating.toFloat(),
-                starSize = 48.dp,
-                onRatingChanged = viewModel::onRatingChanged,
-            )
-
-            Spacer(Modifier.height(16.dp))
-
-            // Rating Feedback Text
-            val feedbackText = when (state.rating) {
-                5 -> "Outstanding!"
-                4 -> "Great!"
-                3 -> "Good"
-                2 -> "Could be better"
-                1 -> "Poor"
-                else -> "Tap a star to rate"
-            }
-            Text(
-                text = feedbackText,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
-            if (state.rating > 0) {
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = "You rated this service ${state.rating} stars",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            Spacer(Modifier.height(32.dp))
-
-            // Review Input Area
-            // Review Input Area
-            val providerFirstName = state.provider
-                ?.name
-                ?.split(" ")
-                ?.firstOrNull() ?: "the provider"
-
-            HustleTextField(
-                value = state.comment,
-                onValueChange = viewModel::onCommentChanged,
-                placeholder = "Share your experience with $providerFirstName...\nWas the delivery on time? How was the quality?",
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = false,
-                minLines = 5,
-                maxLines = 5,
-            )
-
-            Spacer(Modifier.height(8.dp))
-
-            Text(
-                text = "Min 10 chars",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.align(Alignment.End),
-            )
-
-            Spacer(Modifier.height(24.dp))
-
-            // Predefined Tags
-            val availableTags = listOf("Fast Delivery", "Great Communication", "Creative")
-            FlowRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+            // Animated Submission Success Overlay
+            AnimatedVisibility(
+                visible = state.submitSuccess,
+                enter = fadeIn() + scaleIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)),
+                modifier = Modifier.align(Alignment.Center),
             ) {
-                availableTags.forEach { tag ->
-                    val isSelected = state.selectedTags.contains(tag)
-                    Box(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(20.dp))
-                            .background(
-                                if (isSelected) {
-                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
-                                } else {
-                                    MaterialTheme.colorScheme.surface
-                                },
-                            ).border(
-                                width = 1.dp,
-                                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant,
-                                shape = RoundedCornerShape(20.dp),
-                            ).clickable { viewModel.onTagToggled(tag) }
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                val scale by animateFloatAsState(
+                    targetValue = if (state.submitSuccess) 1f else 0.5f,
+                    animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+                    label = "successScale",
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background.copy(alpha = 0.95f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.scale(scale),
                     ) {
-                        Text(
-                            text = tag,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Checkbox(
-                    checked = state.isAnonymous,
-                    onCheckedChange = viewModel::onAnonymousToggled,
-                )
-                Text(
-                    text = "Post anonymously",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            Spacer(Modifier.height(32.dp))
-
-            // Submit Button
-            Button(
-                onClick = viewModel::submit,
-                enabled = state.canSubmit,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp),
-                shape = RoundedCornerShape(28.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                ),
-            ) {
-                if (state.isSubmitting) {
-                    CircularProgressIndicator(
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp,
-                    )
-                } else {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center,
-                    ) {
-                        Text(
-                            text = "Submit Review",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                        )
-                        Spacer(Modifier.width(8.dp))
                         Icon(
-                            imageVector = Icons.Default.Star,
-                            contentDescription = null,
-                            modifier = Modifier.size(20.dp),
+                            imageVector = Icons.Default.CheckCircle,
+                            contentDescription = "Success",
+                            tint = must.kdroiders.hustlehub.ui.theme.HustleSuccess,
+                            modifier = Modifier.size(96.dp),
+                        )
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            text = "Review Submitted!",
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = "Thank you for sharing your feedback",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewItem.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewItem.kt
@@ -1,0 +1,127 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import must.kdroiders.hustlehub.sharedComposables.StarRatingBar
+import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+@Composable
+fun ReviewItem(
+    review: Review,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = true,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (!review.customerAvatarUrl.isNullOrBlank()) {
+                AsyncImage(
+                    model = review.customerAvatarUrl,
+                    contentDescription = review.customerName,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primaryContainer),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = review.customerName.firstOrNull()?.uppercase() ?: "?",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = review.customerName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                val locale = LocalConfiguration.current.locales[0]
+                val timeAgo = remember(review.createdAt, locale) {
+                    formatTimeAgo(review.createdAt)
+                }
+                Text(
+                    text = timeAgo,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            StarRatingBar(
+                rating = review.rating,
+                onRatingChanged = {},
+                starSize = 16.dp,
+            )
+        }
+
+        if (!review.comment.isNullOrBlank()) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = review.comment,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 52.dp),
+            )
+        }
+
+        if (showDivider) {
+            Spacer(Modifier.height(16.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+        }
+    }
+}
+
+private fun formatTimeAgo(timestampMillis: Long): String {
+    if (timestampMillis <= 0) return "Recently"
+    val diff = System.currentTimeMillis() - timestampMillis
+    val minutes = TimeUnit.MILLISECONDS.toMinutes(diff)
+    val hours = TimeUnit.MILLISECONDS.toHours(diff)
+    val days = TimeUnit.MILLISECONDS.toDays(diff)
+
+    return when {
+        minutes < 1 -> "Just now"
+        minutes < 60 -> "$minutes minute${if (minutes > 1) "s" else ""} ago"
+        hours < 24 -> "$hours hour${if (hours > 1) "s" else ""} ago"
+        days < 30 -> "$days day${if (days > 1) "s" else ""} ago"
+        else -> SimpleDateFormat("MMM d, yyyy", java.util.Locale.getDefault()).format(Date(timestampMillis))
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/AllReviewsUiState.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/AllReviewsUiState.kt
@@ -1,0 +1,21 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel
+
+import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
+import must.kdroiders.hustlehub.ui.features.service.domain.model.Service
+
+enum class ReviewSortOption(val label: String) {
+    NEWEST("Newest"),
+    HIGHEST("Highest Rating"),
+    LOWEST("Lowest Rating"),
+}
+
+data class AllReviewsUiState(
+    val service: Service? = null,
+    val reviews: List<Review> = emptyList(),
+    val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
+    val totalReviews: Int = 0,
+    val averageRating: Float = 0f,
+    val sortOption: ReviewSortOption = ReviewSortOption.NEWEST,
+    val error: String? = null,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/AllReviewsViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/AllReviewsViewModel.kt
@@ -1,0 +1,98 @@
+package must.kdroiders.hustlehub.ui.features.service.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceByIdUseCase
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceReviewsUseCase
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class AllReviewsViewModel
+    @Inject
+    constructor(
+        private val getServiceReviewsUseCase: GetServiceReviewsUseCase,
+        private val getServiceByIdUseCase: GetServiceByIdUseCase,
+    ) : ViewModel() {
+
+    private var serviceId: String? = null
+    private var rawReviews: List<Review> = emptyList()
+
+    private val _uiState = MutableStateFlow(AllReviewsUiState())
+    val uiState: StateFlow<AllReviewsUiState> = _uiState.asStateFlow()
+
+    fun initialize(id: String) {
+        if (serviceId == id) return
+        serviceId = id
+        loadData(isRefresh = false)
+    }
+
+    fun refresh() {
+        loadData(isRefresh = true)
+    }
+
+    fun onSortOptionSelected(option: ReviewSortOption) {
+        _uiState.update { state ->
+            val sorted = sortReviews(rawReviews, option)
+            state.copy(sortOption = option, reviews = sorted)
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    private fun loadData(isRefresh: Boolean) {
+        val sid = serviceId ?: return
+        viewModelScope.launch {
+            if (isRefresh) {
+                _uiState.update { it.copy(isRefreshing = true, error = null) }
+            } else {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+            }
+
+            val serviceDeferred = async { getServiceByIdUseCase(sid) }
+            val reviewsDeferred = async { getServiceReviewsUseCase(sid, page = 0, size = 50) }
+
+            val serviceResult = serviceDeferred.await()
+            val reviewsResult = reviewsDeferred.await()
+
+            val service = serviceResult.getOrNull()
+            val pageResponse = reviewsResult.getOrNull()
+
+            rawReviews = pageResponse?.content ?: emptyList()
+            val sortedReviews = sortReviews(rawReviews, _uiState.value.sortOption)
+
+            val avg = service?.averageRating?.toFloat() ?: 0f
+            val count = pageResponse?.totalElements?.toInt() ?: service?.reviewCount ?: rawReviews.size
+
+            _uiState.update {
+                it.copy(
+                    service = service,
+                    reviews = sortedReviews,
+                    totalReviews = count,
+                    averageRating = avg,
+                    isLoading = false,
+                    isRefreshing = false,
+                    error = if (serviceResult.isFailure && reviewsResult.isFailure) "Failed to load reviews." else null,
+                )
+            }
+        }
+    }
+
+    private fun sortReviews(reviews: List<Review>, option: ReviewSortOption): List<Review> {
+        return when (option) {
+            ReviewSortOption.NEWEST -> reviews.sortedByDescending { it.createdAt }
+            ReviewSortOption.HIGHEST -> reviews.sortedWith(compareByDescending<Review> { it.rating }.thenByDescending { it.createdAt })
+            ReviewSortOption.LOWEST -> reviews.sortedWith(compareBy<Review> { it.rating }.thenByDescending { it.createdAt })
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/AllReviewsViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/AllReviewsViewModel.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.ui.features.service.domain.model.Review
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceByIdUseCase
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceReviewsUseCase
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,77 +21,79 @@ class AllReviewsViewModel
         private val getServiceReviewsUseCase: GetServiceReviewsUseCase,
         private val getServiceByIdUseCase: GetServiceByIdUseCase,
     ) : ViewModel() {
+        private var serviceId: String? = null
+        private var rawReviews: List<Review> = emptyList()
 
-    private var serviceId: String? = null
-    private var rawReviews: List<Review> = emptyList()
+        private val _uiState = MutableStateFlow(AllReviewsUiState())
+        val uiState: StateFlow<AllReviewsUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow(AllReviewsUiState())
-    val uiState: StateFlow<AllReviewsUiState> = _uiState.asStateFlow()
-
-    fun initialize(id: String) {
-        if (serviceId == id) return
-        serviceId = id
-        loadData(isRefresh = false)
-    }
-
-    fun refresh() {
-        loadData(isRefresh = true)
-    }
-
-    fun onSortOptionSelected(option: ReviewSortOption) {
-        _uiState.update { state ->
-            val sorted = sortReviews(rawReviews, option)
-            state.copy(sortOption = option, reviews = sorted)
+        fun initialize(id: String) {
+            if (serviceId == id) return
+            serviceId = id
+            loadData(isRefresh = false)
         }
-    }
 
-    fun clearError() {
-        _uiState.update { it.copy(error = null) }
-    }
+        fun refresh() {
+            loadData(isRefresh = true)
+        }
 
-    private fun loadData(isRefresh: Boolean) {
-        val sid = serviceId ?: return
-        viewModelScope.launch {
-            if (isRefresh) {
-                _uiState.update { it.copy(isRefreshing = true, error = null) }
-            } else {
-                _uiState.update { it.copy(isLoading = true, error = null) }
-            }
-
-            val serviceDeferred = async { getServiceByIdUseCase(sid) }
-            val reviewsDeferred = async { getServiceReviewsUseCase(sid, page = 0, size = 50) }
-
-            val serviceResult = serviceDeferred.await()
-            val reviewsResult = reviewsDeferred.await()
-
-            val service = serviceResult.getOrNull()
-            val pageResponse = reviewsResult.getOrNull()
-
-            rawReviews = pageResponse?.content ?: emptyList()
-            val sortedReviews = sortReviews(rawReviews, _uiState.value.sortOption)
-
-            val avg = service?.averageRating?.toFloat() ?: 0f
-            val count = pageResponse?.totalElements?.toInt() ?: service?.reviewCount ?: rawReviews.size
-
-            _uiState.update {
-                it.copy(
-                    service = service,
-                    reviews = sortedReviews,
-                    totalReviews = count,
-                    averageRating = avg,
-                    isLoading = false,
-                    isRefreshing = false,
-                    error = if (serviceResult.isFailure && reviewsResult.isFailure) "Failed to load reviews." else null,
-                )
+        fun onSortOptionSelected(option: ReviewSortOption) {
+            _uiState.update { state ->
+                val sorted = sortReviews(rawReviews, option)
+                state.copy(sortOption = option, reviews = sorted)
             }
         }
-    }
 
-    private fun sortReviews(reviews: List<Review>, option: ReviewSortOption): List<Review> {
-        return when (option) {
-            ReviewSortOption.NEWEST -> reviews.sortedByDescending { it.createdAt }
-            ReviewSortOption.HIGHEST -> reviews.sortedWith(compareByDescending<Review> { it.rating }.thenByDescending { it.createdAt })
-            ReviewSortOption.LOWEST -> reviews.sortedWith(compareBy<Review> { it.rating }.thenByDescending { it.createdAt })
+        fun clearError() {
+            _uiState.update { it.copy(error = null) }
+        }
+
+        private fun loadData(isRefresh: Boolean) {
+            val sid = serviceId ?: return
+            viewModelScope.launch {
+                if (isRefresh) {
+                    _uiState.update { it.copy(isRefreshing = true, error = null) }
+                } else {
+                    _uiState.update { it.copy(isLoading = true, error = null) }
+                }
+
+                val serviceDeferred = async { getServiceByIdUseCase(sid) }
+                val reviewsDeferred = async { getServiceReviewsUseCase(sid, page = 0, size = 50) }
+
+                val serviceResult = serviceDeferred.await()
+                val reviewsResult = reviewsDeferred.await()
+
+                val service = serviceResult.getOrNull()
+                val pageResponse = reviewsResult.getOrNull()
+
+                rawReviews = pageResponse?.content ?: emptyList()
+                val sortedReviews = sortReviews(rawReviews, _uiState.value.sortOption)
+
+                val avg = service?.averageRating?.toFloat() ?: 0f
+                val count = pageResponse?.totalElements?.toInt() ?: service?.reviewCount ?: rawReviews.size
+
+                _uiState.update {
+                    it.copy(
+                        service = service,
+                        reviews = sortedReviews,
+                        totalReviews = count,
+                        averageRating = avg,
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = if (serviceResult.isFailure && reviewsResult.isFailure) "Failed to load reviews." else null,
+                    )
+                }
+            }
+        }
+
+        private fun sortReviews(
+            reviews: List<Review>,
+            option: ReviewSortOption,
+        ): List<Review> {
+            return when (option) {
+                ReviewSortOption.NEWEST -> reviews.sortedByDescending { it.createdAt }
+                ReviewSortOption.HIGHEST -> reviews.sortedWith(compareByDescending<Review> { it.rating }.thenByDescending { it.createdAt })
+                ReviewSortOption.LOWEST -> reviews.sortedWith(compareBy<Review> { it.rating }.thenByDescending { it.createdAt })
+            }
         }
     }
-}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/WriteReviewUiState.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/WriteReviewUiState.kt
@@ -15,9 +15,10 @@ data class WriteReviewUiState(
     val isAnonymous: Boolean = false,
     val isSubmitting: Boolean = false,
     val submitSuccess: Boolean = false,
+    val hasAlreadyReviewed: Boolean = false,
     val error: String? = null,
 ) {
-    val canSubmit: Boolean get() = rating in 1..5 && !isSubmitting && !isLoadingInfo
+    val canSubmit: Boolean get() = rating in 1..5 && !isSubmitting && !isLoadingInfo && !hasAlreadyReviewed
     val commentLength: Int get() = comment.length
     val maxCommentLength: Int get() = 200
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/WriteReviewViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/WriteReviewViewModel.kt
@@ -8,10 +8,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.flow.firstOrNull
-import must.kdroiders.hustlehub.datastore.UserPreferences
 import must.kdroiders.hustlehub.ui.features.profile.domain.usecase.GetProviderProfileUseCase
-import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
+import must.kdroiders.hustlehub.ui.features.service.domain.usecase.CheckDuplicateReviewUseCase
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceByIdUseCase
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.SubmitReviewUseCase
 import timber.log.Timber
@@ -24,8 +22,7 @@ class WriteReviewViewModel
         private val submitReviewUseCase: SubmitReviewUseCase,
         private val getServiceByIdUseCase: GetServiceByIdUseCase,
         private val getProviderProfileUseCase: GetProviderProfileUseCase,
-        private val serviceRepository: ServiceRepository,
-        private val userPreferences: UserPreferences,
+        private val checkDuplicateReviewUseCase: CheckDuplicateReviewUseCase,
     ) : ViewModel() {
         private var serviceId: String? = null
 
@@ -46,16 +43,7 @@ class WriteReviewViewModel
                     .onSuccess { service ->
                         getProviderProfileUseCase(service.providerId)
                             .onSuccess { provider ->
-                                val currentUser = userPreferences.cachedUser.firstOrNull()
-                                var alreadyReviewed = false
-                                if (currentUser != null && currentUser.id.isNotBlank()) {
-                                    serviceRepository.getServiceReviews(id)
-                                        .onSuccess { page ->
-                                            alreadyReviewed = page.content.any { review ->
-                                                review.customerId == currentUser.id
-                                            }
-                                        }
-                                }
+                                val alreadyReviewed = checkDuplicateReviewUseCase(id).getOrDefault(false)
 
                                 _uiState.update {
                                     it.copy(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/WriteReviewViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/viewmodel/WriteReviewViewModel.kt
@@ -8,7 +8,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.firstOrNull
+import must.kdroiders.hustlehub.datastore.UserPreferences
 import must.kdroiders.hustlehub.ui.features.profile.domain.usecase.GetProviderProfileUseCase
+import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.GetServiceByIdUseCase
 import must.kdroiders.hustlehub.ui.features.service.domain.usecase.SubmitReviewUseCase
 import timber.log.Timber
@@ -21,6 +24,8 @@ class WriteReviewViewModel
         private val submitReviewUseCase: SubmitReviewUseCase,
         private val getServiceByIdUseCase: GetServiceByIdUseCase,
         private val getProviderProfileUseCase: GetProviderProfileUseCase,
+        private val serviceRepository: ServiceRepository,
+        private val userPreferences: UserPreferences,
     ) : ViewModel() {
         private var serviceId: String? = null
 
@@ -41,11 +46,24 @@ class WriteReviewViewModel
                     .onSuccess { service ->
                         getProviderProfileUseCase(service.providerId)
                             .onSuccess { provider ->
+                                val currentUser = userPreferences.cachedUser.firstOrNull()
+                                var alreadyReviewed = false
+                                if (currentUser != null && currentUser.id.isNotBlank()) {
+                                    serviceRepository.getServiceReviews(id)
+                                        .onSuccess { page ->
+                                            alreadyReviewed = page.content.any { review ->
+                                                review.customerId == currentUser.id
+                                            }
+                                        }
+                                }
+
                                 _uiState.update {
                                     it.copy(
                                         service = service,
                                         provider = provider,
                                         isLoadingInfo = false,
+                                        hasAlreadyReviewed = alreadyReviewed,
+                                        error = if (alreadyReviewed) "You have already reviewed this service." else null,
                                     )
                                 }
                             }.onFailure { e ->
@@ -101,7 +119,16 @@ class WriteReviewViewModel
                     _uiState.update { it.copy(isSubmitting = false, submitSuccess = true) }
                 }.onFailure { e ->
                     Timber.e(e, "WriteReviewViewModel: submit failed for serviceId=$sid")
-                    _uiState.update { it.copy(isSubmitting = false, error = e.message ?: "Failed to submit review.") }
+                    val isDuplicate = e.message?.contains("409", ignoreCase = true) == true ||
+                        e.message?.contains("already reviewed", ignoreCase = true) == true
+                    val errorMsg = if (isDuplicate) "You have already reviewed this service." else e.message ?: "Failed to submit review."
+                    _uiState.update {
+                        it.copy(
+                            isSubmitting = false,
+                            hasAlreadyReviewed = isDuplicate,
+                            error = errorMsg,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 📝 What does this PR do?
This PR implements the end-to-end reviews and rating system for services, the platform-wide admin moderation reporting system, and the current user's profile screen with live availability toggles, deep-link sharing, and dynamic provider reputation badges.


---

## 🔄 Main Changes

### Added
- **Interactive Ratings & Review Submission (Issue #54)**: Created the `StarRatingBar` supporting tap and drag gestures. Built the `WriteReviewScreen` with an optional 200-character comment field, duplicate review check warning banners, and submission success checkmark animations.
- **Reviews Data Layer (Issue #55)**: Created the `ReviewRepository` and `ReviewRepositoryImpl` to integrate with the backend API, alongside use cases (`SubmitReviewUseCase`, `GetServiceReviewsUseCase`, `CheckDuplicateReviewUseCase`).
- **All Reviews & Filtering (Issue #56)**: Created `AllReviewsScreen` displaying the complete list of reviews, featuring a rating breakdown chart (`ReviewSummaryCard`), sort filter chips (Newest, Highest, Lowest), empty states, and pull-to-refresh.
- **Service Completion Prompt Card (Issue #57)**: Created the `ServiceCompletionCard` displayed to customers in chat when a provider marks a service as completed, prompting them to leave a review.
- **Admin Moderation Reporting System (Issue #58)**: Built the reusable `ReportDialog` composable with reason radio options (Spam, Inappropriate, Fake, Harassment, Other) and custom detail text fields. Integrated reporting into 3-dot menus on service detail, provider profile, and chat message long-press menus with `HTTP 409` duplicate handling.
- **My Profile Screen & Deep Link Sharing (Issue #59)**: Added `MyProfileScreen` composable function alias, a Floating Action Button (`+`) for adding new services, and deep-link profile sharing (`https://hustlehub.must.ac.ke/profile/{userId}`).

### Changed
- **`ProfileScreen` & Availability Toggle**: Restricted the campus availability status pill ("Available on Campus" vs "Off Duty") and interactive `Switch` strictly to provider roles. Added `toggleOverallAvailability` in `ProfileViewModel` to toggle provider service states.
- **Dynamic Reputation Badges**: Updated `ProfileViewModel` to dynamically evaluate provider badges (Top Rated, Fast Responder, Verified Student) based on live rating scores, activity, and verification status.
- **`ServiceDetailScreen`**: Integrated the latest 3 reviews preview block using the new `ReviewItem` component, added 3-dot reporting menu, and added a "See all reviews" button leading to the full paginated review list.
- **`ChatDetailScreen`**: Added the "Mark as Complete" check button for service providers inside the top bar/header, integrated message long-press reporting, and added completion system message rendering.
- **Navigation graph**: Added `AllReviews(serviceId)` destination key and wired review navigation callbacks into `HustleHubNavGraph.kt`.

### Fixed
- Fixed API path structures (`POST services/{serviceId}/reviews`, `POST reports`) and aligned DTO field serialization (`reviewerId`, `reviewerName`, `reviewerAvatarUrl`) to match backend endpoints.
- Replaced hardcoded ARGB colors in `ProfileInfo` with `MaterialTheme` color scheme tokens and `HustleSuccess`.

---

## ✅ Type of change
- [x] New feature
- [ ] Bug fix
- [x] UI update
- [x] Refactor / cleanup
- [ ] Documentation

---

## 🧪 I have tested that...
- [x] The app builds without errors (`./gradlew assembleDebug` Successful)
- [x] My feature/fix works as expected
- [x] I didn't break anything else

---

## 🔍 Code quality
- [x] Quality checks passed (`./gradlew qualityCheck`)
- [x] Ktlint passed (`./gradlew ktlintCheck`)
- [x] Detekt passed (`./gradlew detekt`)
- [x] Android Lint passed (`./gradlew lint`)
- [x] My commit message follows convention (`feat:`, `fix:`, `chore:` etc.)

---

## Closes #
Closes #54
Closes #55
Closes #56
Closes #57
Closes #58
Closes #59
