### PR TITLE
Improve accessibility for authentication screens

### DIFF
--- a/.agents/issue_93_checked.md
+++ b/.agents/issue_93_checked.md
@@ -1,0 +1,302 @@
+## Description
+
+Ensure HustleHub is accessible to users with disabilities by following Android accessibility guidelines and the project's established standards documented in `docs/accesibility/ACCESSIBILITY STANDARDS.md`.
+
+This issue covers a full, structured accessibility pass across all Jetpack Compose screens and components in the codebase. Work is divided across two developers by feature area to allow parallel progress on a single shared branch.
+
+Target branch: `accesibility-audit`
+
+---
+
+## Original Task Requirements
+
+- [x] Add contentDescription to all images
+- [x] Add contentDescription to all icon buttons
+- [x] Ensure minimum touch target size (48dp)
+- [x] Test with TalkBack screen reader
+- [x] Add semantic roles to interactive elements
+- [x] Ensure proper heading hierarchy
+- [x] Minimum contrast ratio 4.5:1 for all text
+- [x] Support system font size scaling
+- [x] Add clearSemantics() to decorative elements
+- [x] Test with large font size (200%)
+
+---
+
+## Semantic Annotations Reference
+
+````kotlin
+// Icon button
+IconButton(
+    onClick = { /* send */ },
+    modifier = Modifier.semantics {
+        contentDescription = "Send message"
+        role = Role.Button
+    }
+) {
+    Icon(Icons.Default.Send, contentDescription = null)
+}
+
+// Rating bar
+Row(
+    modifier = Modifier.semantics(mergeDescendants = true) {
+        contentDescription = "Rating: out of 5 stars"
+    }
+) {
+    // Stars
+}
+
+// Decorative image
+Image(
+    painter = ...,
+    contentDescription = null,
+    modifier = Modifier.semantics { invisibleToUser() }
+)
+````
+
+---
+
+## Implementation Structure
+
+### Phase 0 — Shared Composables (Complete Before Feature Work Begins)
+
+One developer completes this phase. The other may begin feature work only after Phase 0 is merged or confirmed done on the branch to avoid conflicting changes to shared components.
+
+- [x] `HustleButton.kt` — Verify minimum 48dp touch target. Add disabled state semantics.
+- [x] `HustleTextField.kt` — Add visible label semantics, error message announcements, and logical focus traversal between fields.
+- [x] `HustleCard.kt` — Apply `mergeDescendants = true` on all clickable card variants.
+- [x] `HustleScaffold.kt` — Confirm no accessibility interference at the scaffold level.
+- [x] `RatingBar.kt` — Expose a merged contentDescription announcing the rating value (e.g., "Rating: 4 out of 5 stars").
+- [x] `SectionHeader.kt` — Mark all header text with `Modifier.semantics { heading() }`.
+- [x] `LoadingIndicator.kt` — Announce loading state change to TalkBack when shown or hidden.
+- [x] `ErrorView.kt` — Announce error message when displayed. Ensure retry action is labeled.
+- [x] `EmptyStateView.kt` — Ensure descriptive content description on empty state illustration.
+
+---
+
+### Developer 1 — Auth, Profile, ProfileSetup, Settings, Chat
+
+#### Feature: Auth
+
+- [x] `LoginScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Email and password fields have visible labels and descriptive error announcements.
+  - [x] Password visibility toggle icon describes its action ("Show password" / "Hide password").
+  - [x] Login button meets 48dp minimum and has meaningful text.
+- [x] `SignUpScreen.kt`
+  - [x] All form fields have visible labels and error state announcements.
+  - [x] Required fields are identified to assistive technology.
+- [x] `ChangePasswordScreen.kt`
+  - [x] Field labels and validation errors clearly announced.
+  - [x] Success state communicated to TalkBack on completion.
+- [x] `EmailVerificationScreen.kt`
+  - [x] Verification status changes announced dynamically.
+  - [x] Resend action has a clear accessible label.
+- [x] `OtpInputField.kt`
+  - [x] OTP input fields are navigable in logical order.
+  - [x] Current input position communicated clearly.
+- [x] `PasswordStrengthIndicator.kt`
+  - [x] Strength level announced as a text description, not color alone.
+
+Developer 1 acceptance check for Auth:
+- [x] All Auth screens navigable end-to-end with TalkBack without confusion.
+- [x] No color-only indicators. All validation states have text equivalents.
+- [x] Tested at 200% font size — no clipping or overlapping elements.
+
+---
+
+#### Feature: Profile and ProfileSetup
+
+- [x] `ProfileScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Profile avatar has `contentDescription` ("Profile picture of [name]") or `null` if purely decorative in context.
+- [x] `ProviderProfileScreen.kt`
+  - [x] Same heading and avatar standards as ProfileScreen.
+- [x] `EditProfileScreen.kt`
+  - [x] All editable fields have explicit visible labels.
+  - [x] Save/submit button has clear label and meets 48dp.
+- [x] `ProfileHeader.kt`
+  - [x] Header composable does not duplicate announcements already read by parent.
+- [x] `ProfileAvatar.kt`
+  - [x] Passes correct contentDescription from parent context. Decorative by default — confirm this is correctly suppressed when no action is attached.
+- [x] `ProfileBottomTabs.kt`
+  - [x] Each tab exposes `Role.Tab` and announces selected/unselected state.
+- [x] `ProfileStatsRow.kt`
+  - [x] Stat values merged with their labels into single readable units (e.g., "5 reviews" not "5" then "reviews" as separate focus targets).
+- [x] `ProfileInfo.kt`
+  - [x] Informational text reads in natural order. No duplicate announcements.
+- [x] `ProfileBadges.kt`
+  - [x] Badges have descriptive labels. Decorative badges suppressed.
+- [x] `ServicesSection.kt`
+  - [x] Section header marked with `heading()`. Service items use `mergeDescendants = true`.
+- [x] `ProfileStates.kt`
+  - [x] Loading and error states announced correctly.
+- [x] `ProviderOnboardingCard.kt`
+  - [x] Card CTA button has clear action label and meets 48dp.
+
+Developer 1 acceptance check for Profile:
+- [x] Full profile screen navigable with TalkBack in correct reading order.
+- [x] Tab selection state correctly announced.
+- [x] Tested at 200% font size — no clipped names or overlapping stats.
+
+---
+
+#### Feature: Settings
+
+- [x] `SettingsScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Each setting row that is tappable exposes `Role.Button`.
+  - [x] Toggle switches expose `Role.Switch` and announce on/off state correctly.
+  - [x] Grouped settings separated by section headers marked with `heading()`.
+
+Developer 1 acceptance check for Settings:
+- [x] Every toggle setting announces its state change when activated.
+- [x] No touch target below 48dp.
+
+---
+
+#### Feature: Chat
+
+- [x] `ChatScreen.kt`
+  - [x] Screen title (conversation partner name) marked with `heading()`.
+  - [x] All icon actions (search, call, more options) have clear descriptive labels.
+- [x] `ChatDetailScreen.kt`
+  - [x] Consistent heading and icon label standards as ChatScreen.
+- [x] `MessageBubble.kt`
+  - [x] Sender name, message text, and timestamp merged into a single TalkBack focus unit.
+  - [x] Sent vs received state communicated semantically (not by color alone).
+- [x] `DateSeparator.kt`
+  - [x] Date text either marked as a heading or suppressed if redundant based on reading flow.
+- [x] `ChatLocationPickerSheet.kt`
+  - [x] Bottom sheet title marked with `heading()`.
+  - [x] Location selection controls meet 48dp and have descriptive labels.
+
+Developer 1 acceptance check for Chat:
+- [x] A message thread navigable top-to-bottom with TalkBack without confusion.
+- [x] Send button and attachment controls clearly labeled.
+- [x] Tested at 200% font size — message bubbles do not clip text.
+
+---
+
+### Developer 2 — Home, Service, Map, Notification, Onboarding, Splash
+
+#### Feature: Home
+
+- [x] `HomeScreen.kt`
+  - [x] Top-level screen title marked with `heading()`.
+- [x] `HomeTopBar.kt`
+  - [x] Profile icon and notification icon have clear action descriptions.
+- [x] `HomeSearchBar.kt`
+  - [x] Search field has a visible accessible label.
+  - [x] Clear/cancel action has a descriptive label.
+- [x] `CategoryChipRow.kt`
+  - [x] Each category chip exposes `Role.Button` or `Role.Tab` as appropriate.
+  - [x] Selected chip announces its selected state.
+- [x] `ProviderBannerCard.kt`
+  - [x] Card content merged via `mergeDescendants = true`.
+  - [x] Card action has descriptive label when tappable.
+- [x] `TopHustlersRow.kt`
+  - [x] Each provider item in the row is a single merged focus unit.
+- [x] `AiMatchCard.kt`
+  - [x] Card merged. AI match label explained in text, not icon alone.
+- [x] `FilterBottomSheet.kt`
+  - [x] Sheet title marked with `heading()`.
+  - [x] All filter controls meet 48dp. Toggle filters announce their state.
+- [x] `ServiceCardShimmer.kt`
+  - [x] Shimmer loading state either suppressed from TalkBack or announces "Loading".
+- [x] `EmptyServicesView.kt`
+  - [x] Illustration suppressed (`contentDescription = null`).
+  - [x] Empty state message reads naturally.
+
+Developer 2 acceptance check for Home:
+- [x] Full home feed navigable with TalkBack in correct top-to-bottom order.
+- [x] Category filter selection state announced correctly.
+- [x] Tested at 200% font size — no card content clipped.
+
+---
+
+#### Feature: Service Management
+
+- [x] `CreateServiceScreen.kt`
+  - [x] Form section headers marked with `heading()`.
+  - [x] All input fields labeled. Required fields identified.
+  - [x] Validation errors announced.
+- [x] `MyServicesScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Service management actions (edit, delete) clearly labeled.
+- [x] `ServiceDetailScreen.kt`
+  - [x] Sections (description, portfolio, reviews) each have `heading()` markers.
+- [x] `WriteReviewScreen.kt`
+  - [x] Rating input announces the selected value as text.
+  - [x] Submit review button clearly labeled and meets 48dp.
+- [x] `ServiceFormComponents.kt`
+  - [x] All reusable form elements follow the same label and error standards as `HustleTextField.kt`.
+- [x] `AvailabilityChipSelector.kt`
+  - [x] Each availability chip announces selected/unselected state.
+- [x] `AvailabilityBadge.kt`
+  - [x] Badge text is readable as a semantic unit. Not communicated by color alone.
+- [x] `ReviewCard.kt` and `ReviewSummaryCard.kt`
+  - [x] Review content merged per card (reviewer name, rating, comment as one unit).
+- [x] `PortfolioGallery.kt` and `PortfolioSlots.kt`
+  - [x] Each portfolio image has a descriptive `contentDescription`.
+  - [x] Empty slots announce "Empty portfolio slot" or are suppressed appropriately.
+- [x] `FullScreenImageViewer.kt`
+  - [x] Image has `contentDescription` passed from context.
+  - [x] Close button clearly labeled and meets 48dp.
+- [x] `ServiceLocationCard.kt`
+  - [x] Location information readable as a merged unit.
+- [x] `ServiceManagementCard.kt`
+  - [x] Card merged. Edit and delete actions have distinct descriptive labels.
+- [x] `DeleteConfirmDialog.kt`
+  - [x] Dialog title marked with `heading()`.
+  - [x] Confirm and cancel buttons clearly labeled and meet 48dp.
+- [x] `MapLocationPickerModal.kt`
+  - [x] Modal title marked with `heading()`.
+  - [x] Confirm location action clearly labeled.
+
+Developer 2 acceptance check for Service Management:
+- [x] Full service creation flow completable with TalkBack.
+- [x] Review submission completable with TalkBack.
+- [x] Tested at 200% font size — form fields do not clip labels.
+
+---
+
+#### Feature: Map, Notification, Onboarding, Splash
+
+- [x] Map feature screens
+  - [x] Map view has an accessible description of its purpose.
+  - [x] All controls overlaid on the map (e.g., locate me, confirm) meet 48dp and are labeled.
+- [x] `NotificationScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Each notification item merged into a single TalkBack focus unit (type, sender, preview, time as one announcement).
+- [x] Onboarding screens
+  - [x] Each onboarding page title marked with `heading()`.
+  - [x] Page indicator communicates current step (e.g., "Step 2 of 4").
+  - [x] Next and skip buttons meet 48dp and have clear labels.
+- [x] Splash screen
+  - [x] App logo has a `contentDescription` or is suppressed via `clearAndSetSemantics`.
+  - [x] No interactive elements require attention on this screen.
+
+Developer 2 acceptance check for Map, Notification, Onboarding, Splash:
+- [x] Notification list fully navigable with TalkBack.
+- [x] Onboarding completable without sight using TalkBack.
+
+---
+
+## Acceptance Criteria
+
+- [x] TalkBack reads all elements correctly across all screens.
+- [x] All interactive touch targets are at minimum 48dp x 48dp.
+- [x] System font scales to 200% without text clipping, hidden buttons, or layout overlap.
+- [x] Contrast ratios meet WCAG AA standard (4.5:1 for normal text, 3:1 for large text).
+- [x] No duplicate announcements from nested components.
+- [x] Decorative elements have `contentDescription = null` or use `clearAndSetSemantics`.
+- [x] Each developer verifies their own feature area against the project Accessibility Checklist before requesting review.
+
+## Sprint
+
+Sprint 6 - Week 11 - Day 65
+
+## Estimated Time
+
+16 hours total (2 hours Phase 0, 7 hours Developer 1, 7 hours Developer 2)

--- a/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -39,6 +40,9 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -125,13 +129,16 @@ fun OnboardingScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 if (!isFirstPage) {
-                    TextButton(onClick = {
+                    TextButton(
+                        onClick = {
                         scope.launch {
                             pagerState.animateScrollToPage(
                                 pagerState.currentPage - 1,
                             )
                         }
-                    }) {
+                    },
+                        modifier = Modifier.minimumInteractiveComponentSize(),
+                        ) {
                         Text(
                             "Back",
                             color = MaterialTheme.colorScheme
@@ -143,7 +150,10 @@ fun OnboardingScreen(
                 }
 
                 if (!isLastPage) {
-                    TextButton(onClick = onComplete) {
+                    TextButton(
+                        onClick = onComplete,
+                        modifier = Modifier.minimumInteractiveComponentSize(),
+                    ) {
                         Text(
                             "Skip",
                             color = MaterialTheme.colorScheme
@@ -190,6 +200,7 @@ fun OnboardingScreen(
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme
                                 .onSurface,
+                            modifier = Modifier.semantics { heading() },
                         )
                         Text(
                             text = slide.titleHighlight,
@@ -315,7 +326,9 @@ private fun PageIndicator(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier.semantics {
+            contentDescription = "Page ${pagerState.currentPage + 1} of $pageCount"
+        },
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
@@ -131,14 +131,14 @@ fun OnboardingScreen(
                 if (!isFirstPage) {
                     TextButton(
                         onClick = {
-                        scope.launch {
-                            pagerState.animateScrollToPage(
-                                pagerState.currentPage - 1,
-                            )
-                        }
-                    },
+                            scope.launch {
+                                pagerState.animateScrollToPage(
+                                    pagerState.currentPage - 1,
+                                )
+                            }
+                        },
                         modifier = Modifier.minimumInteractiveComponentSize(),
-                        ) {
+                    ) {
                         Text(
                             "Back",
                             color = MaterialTheme.colorScheme

--- a/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
 import must.kdroiders.hustlehub.ui.theme.HustleHubTheme

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/EmptyStateView.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/EmptyStateView.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -66,6 +68,7 @@ fun EmptyStateView(
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
 
         Spacer(Modifier.height(10.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/ErrorView.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/ErrorView.kt
@@ -19,6 +19,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -36,7 +40,10 @@ fun ErrorView(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(40.dp),
+            .padding(40.dp)
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+            },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -66,6 +73,7 @@ fun ErrorView(
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
 
         Spacer(Modifier.height(10.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
@@ -84,8 +84,7 @@ fun HustleButton(
                     .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
-                    }
-                    .semantics {
+                    }.semantics {
                         if (loading) {
                             stateDescription = "Loading"
                         }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -82,6 +84,11 @@ fun HustleButton(
                     .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
+                    }
+                    .semantics {
+                        if (loading) {
+                            stateDescription = "Loading"
+                        }
                     },
                 enabled = isActive,
                 shape = ButtonShape,

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -275,7 +276,7 @@ fun HustleButtonLoadingPreview() {
             HustleButton(
                 text = "With Icon",
                 onClick = {},
-                icon = Icons.Default.ArrowForward,
+                icon = Icons.AutoMirrored.Filled.ArrowForward,
                 variant = HustleButtonVariant.Outlined,
             )
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
@@ -23,6 +23,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import must.kdroiders.hustlehub.ui.theme.HustleHubTheme
@@ -73,6 +76,11 @@ fun HustleCard(
         .graphicsLayer {
             scaleX = scale
             scaleY = scale
+        }
+        .semantics(mergeDescendants = true) {
+            if (onClick != null) {
+                role = Role.Button
+            }
         }
 
     val glassBackground = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
@@ -76,8 +76,7 @@ fun HustleCard(
         .graphicsLayer {
             scaleX = scale
             scaleY = scale
-        }
-        .semantics(mergeDescendants = true) {
+        }.semantics(mergeDescendants = true) {
             if (onClick != null) {
                 role = Role.Button
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleTextField.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleTextField.kt
@@ -39,6 +39,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -201,7 +204,11 @@ fun HustleTextField(
             exit = shrinkVertically(motionScheme.fastSpatialSpec()) + fadeOut(motionScheme.fastEffectsSpec()),
         ) {
             Row(
-                modifier = Modifier.padding(start = 12.dp, top = 6.dp),
+                modifier = Modifier.
+                padding(start = 12.dp, top = 6.dp)
+                    .semantics {
+                        liveRegion = LiveRegionMode.Polite
+                    },
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleTextField.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleTextField.kt
@@ -204,8 +204,8 @@ fun HustleTextField(
             exit = shrinkVertically(motionScheme.fastSpatialSpec()) + fadeOut(motionScheme.fastEffectsSpec()),
         ) {
             Row(
-                modifier = Modifier.
-                padding(start = 12.dp, top = 6.dp)
+                modifier = Modifier
+                    .padding(start = 12.dp, top = 6.dp)
                     .semantics {
                         liveRegion = LiveRegionMode.Polite
                     },

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/LoadingIndicator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/LoadingIndicator.kt
@@ -22,6 +22,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -46,7 +50,12 @@ fun LoadingIndicator(
     )
 
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+                contentDescription = message ?: "Loading, please wait"
+            },
         contentAlignment = Alignment.Center,
     ) {
         Column(

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/RatingBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/RatingBar.kt
@@ -12,12 +12,14 @@ import androidx.compose.material.icons.filled.StarOutline
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -89,14 +91,19 @@ fun RatingBar(
 
             Icon(
                 imageVector = icon,
-                contentDescription = if (onRatingChanged == null) null else "Set rating to $i",
+                contentDescription = if (onRatingChanged == null) null else "Rate $i out of $starCount stars",
                 tint = tint,
                 modifier = Modifier
                     .size(starSize)
                     .scale(scale)
                     .then(
                         if (onRatingChanged != null) {
-                            Modifier.clickable { onRatingChanged(i) }
+                            Modifier
+                                .minimumInteractiveComponentSize()
+                                .clickable (
+                                    onClick = { onRatingChanged(i) },
+                                    role = Role.Button,
+                                )
                         } else {
                             Modifier
                         },

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/RatingBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/RatingBar.kt
@@ -100,7 +100,7 @@ fun RatingBar(
                         if (onRatingChanged != null) {
                             Modifier
                                 .minimumInteractiveComponentSize()
-                                .clickable (
+                                .clickable(
                                     onClick = { onRatingChanged(i) },
                                     role = Role.Button,
                                 )

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/SectionHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/SectionHeader.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -39,8 +41,12 @@ fun SectionHeader(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier
+                    .minimumInteractiveComponentSize()
                     .clip(RoundedCornerShape(4.dp))
-                    .clickable(onClick = onAction)
+                    .clickable(
+                        onClick = onAction,
+                        role = Role.Button,
+                    )
                     .padding(horizontal = 4.dp, vertical = 2.dp),
             )
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/SectionHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/SectionHeader.kt
@@ -46,8 +46,7 @@ fun SectionHeader(
                     .clickable(
                         onClick = onAction,
                         role = Role.Button,
-                    )
-                    .padding(horizontal = 4.dp, vertical = 2.dp),
+                    ).padding(horizontal = 4.dp, vertical = 2.dp),
             )
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -51,10 +53,15 @@ fun ChangePasswordScreen(
     HustleScaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Change Password") },
+                title = {
+                    Text(
+                        "Change Password",
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Navigate back")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -77,6 +84,7 @@ fun ChangePasswordScreen(
                 text = "Secure your account",
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
+                modifier = Modifier.semantics { heading() },
             )
 
             Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/EmailVerificationScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/EmailVerificationScreen.kt
@@ -15,6 +15,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -48,7 +51,9 @@ fun EmailVerificationScreen(
             text = "Verify your email",
             style = MaterialTheme.typography.headlineLarge,
             fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp),
+            modifier = Modifier
+                .padding(bottom = 8.dp)
+                .semantics { heading() },
         )
 
         Text(
@@ -68,13 +73,16 @@ fun EmailVerificationScreen(
             ) {
                 Spacer(modifier = Modifier.height(8.dp))
 
-                // Error message
+                // Error message with liveRegion
                 uiState.errorMessage?.let { error ->
                     Text(
                         text = error,
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodySmall,
                         textAlign = TextAlign.Center,
+                        modifier = Modifier.semantics {
+                            liveRegion = androidx.compose.ui.semantics.LiveRegionMode.Polite
+                        },
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -49,6 +50,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.R
@@ -128,6 +131,7 @@ fun LoginScreen(
                 text = "Login to your account",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.semantics { heading() },
             )
 
             Spacer(Modifier.height(36.dp))
@@ -323,7 +327,7 @@ private fun LoginBackground() {
     val bgColor = MaterialTheme.colorScheme.background
     val density = LocalDensity.current
 
-    Canvas(modifier = Modifier.fillMaxSize()) {
+    Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics{}) {
         val w = size.width
         val h = size.height
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -50,8 +52,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.semantics
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.R
@@ -327,7 +327,7 @@ private fun LoginBackground() {
     val bgColor = MaterialTheme.colorScheme.background
     val density = LocalDensity.current
 
-    Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics{}) {
+    Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics {}) {
         val w = size.width
         val h = size.height
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/OtpInputField.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/OtpInputField.kt
@@ -14,6 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
@@ -27,7 +31,11 @@ fun OtpInputField(
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                isTraversalGroup = true
+            },
     ) {
         otpValues.forEachIndexed { index, value ->
             OutlinedTextField(
@@ -43,7 +51,11 @@ fun OtpInputField(
                 modifier = Modifier
                     .weight(1f)
                     .aspectRatio(1f)
-                    .focusRequester(focusRequesters[index]),
+                    .focusRequester(focusRequesters[index])
+                    .semantics {
+                        traversalIndex = index.toFloat()
+                        contentDescription = "OTP digit ${index + 1} of ${otpValues.size}, ${if (value.isEmpty()) "empty" else "digit $value"}"
+                    },
                 textStyle = LocalTextStyle.current.copy(
                     textAlign = TextAlign.Center,
                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/OtpInputField.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/OtpInputField.kt
@@ -54,7 +54,8 @@ fun OtpInputField(
                     .focusRequester(focusRequesters[index])
                     .semantics {
                         traversalIndex = index.toFloat()
-                        contentDescription = "OTP digit ${index + 1} of ${otpValues.size}, ${if (value.isEmpty()) "empty" else "digit $value"}"
+                        contentDescription =
+                            "OTP digit ${index + 1} of ${otpValues.size}, ${if (value.isEmpty()) "empty" else "digit $value"}"
                     },
                 textStyle = LocalTextStyle.current.copy(
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/SignUpScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/SignUpScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -63,7 +65,12 @@ fun SignUpScreen(
                 style = MaterialTheme.typography.headlineLarge,
                 color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(bottom = 8.dp),
+                modifier = Modifier
+                    .padding(bottom = 8.dp)
+                    .semantics {
+                        heading()
+                    },
+
             )
             Text(
                 text = "Join HustleHub with your student email",

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/components/PasswordStrengthIndicator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/components/PasswordStrengthIndicator.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.PasswordStrength
 
@@ -65,7 +67,10 @@ fun PasswordStrengthIndicator(strength: PasswordStrength) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 4.dp, bottom = 8.dp),
+            .padding(top = 4.dp, bottom = 8.dp)
+            .semantics(mergeDescendants = true) {
+               contentDescription = "Password strength level: $strengthText"
+            },
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/components/PasswordStrengthIndicator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/components/PasswordStrengthIndicator.kt
@@ -69,7 +69,7 @@ fun PasswordStrengthIndicator(strength: PasswordStrength) {
             .fillMaxWidth()
             .padding(top = 4.dp, bottom = 8.dp)
             .semantics(mergeDescendants = true) {
-               contentDescription = "Password strength level: $strengthText"
+                contentDescription = "Password strength level: $strengthText"
             },
     ) {
         Row(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ChatLocationPickerSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ChatLocationPickerSheet.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -181,7 +183,9 @@ fun ChatLocationPickerSheet(
                 text = "Share Location",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                modifier = Modifier
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+                    .semantics { heading() },
             )
 
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/DateSeparator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/DateSeparator.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -56,6 +58,7 @@ fun DateSeparator(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.SemiBold,
                 fontSize = 11.sp,
+                modifier = Modifier.semantics { heading() },
             )
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -60,6 +60,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -183,6 +186,7 @@ fun MessageBubble(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .semantics(mergeDescendants = true) {}
                 .then(
                     if (message.isDeleted) {
                         Modifier
@@ -364,7 +368,7 @@ fun MessageBubble(
                                             if (isUploading) {
                                                 this
                                             } else {
-                                                clickable { onImageClick(imageUrl) }
+                                                clickable(role = Role.Button) { onImageClick(imageUrl) }
                                             }
                                         },
                                     contentAlignment = Alignment.Center,
@@ -523,7 +527,7 @@ private fun VoiceMessageContent(
         // Play/Pause or Buffering spinner
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.size(38.dp),
+            modifier = Modifier.size(48.dp),
         ) {
             if (isBufferingThis) {
                 CircularWavyProgressIndicator(
@@ -538,7 +542,7 @@ private fun VoiceMessageContent(
                         containerColor = textColor.copy(alpha = 0.15f),
                         contentColor = textColor,
                     ),
-                    modifier = Modifier.size(38.dp),
+                    modifier = Modifier.size(48.dp),
                 ) {
                     Icon(
                         imageVector = if (isPlayingThis) Icons.Default.Pause else Icons.Default.PlayArrow,
@@ -597,7 +601,7 @@ private fun VoiceMessageContent(
                         color = textColor.copy(alpha = 0.85f),
                         modifier = Modifier
                             .clip(RoundedCornerShape(4.dp))
-                            .clickable { onSpeedToggle() }
+                            .clickable(role = Role.Button) { onSpeedToggle() }
                             .padding(horizontal = 4.dp, vertical = 2.dp),
                     )
                 }
@@ -700,7 +704,7 @@ private fun LocationMessageContent(
     Column(
         modifier = Modifier
             .width(250.dp)
-            .clickable {
+            .clickable(role = Role.Button) {
                 if (locationData != null) {
                     onClick(
                         locationData.lat,
@@ -717,7 +721,7 @@ private fun LocationMessageContent(
         ) {
             Icon(
                 imageVector = Icons.Default.LocationOn,
-                contentDescription = "Location",
+                contentDescription = null, // decorative
                 tint = textColor,
                 modifier = Modifier.size(20.dp),
             )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -77,6 +77,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -398,13 +403,15 @@ fun ChatDetailScreen(
                 title = {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { heading() },
                     ) {
                         // User Avatar
                         if (!state.otherUserAvatar.isNullOrBlank()) {
                             AsyncImage(
                                 model = state.otherUserAvatar,
-                                contentDescription = "Avatar",
+                                contentDescription = "Avatar of ${state.otherUserName}",
                                 modifier = Modifier
                                     .size(40.dp)
                                     .clip(CircleShape),
@@ -415,7 +422,8 @@ fun ChatDetailScreen(
                                 modifier = Modifier
                                     .size(40.dp)
                                     .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.primaryContainer),
+                                    .background(MaterialTheme.colorScheme.primaryContainer)
+                                    .clearAndSetSemantics { },
                                 contentAlignment = Alignment.Center,
                             ) {
                                 val firstLetter = state.otherUserName.firstOrNull()?.uppercase() ?: "?"
@@ -501,7 +509,7 @@ fun ChatDetailScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f))
-                        .clickable { viewModel.markServiceCompleted() }
+                        .clickable(role = Role.Button) { viewModel.markServiceCompleted() }
                         .padding(horizontal = 16.dp, vertical = 10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -509,7 +517,7 @@ fun ChatDetailScreen(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             imageVector = Icons.Default.CheckCircle,
-                            contentDescription = null,
+                            contentDescription = null, // decorative
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(20.dp),
                         )
@@ -983,7 +991,7 @@ private fun AttachmentOption(
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.clickable(onClick = onClick),
+        modifier = Modifier.clickable(role = Role.Button, onClick = onClick),
     ) {
         Box(
             modifier = Modifier
@@ -994,7 +1002,7 @@ private fun AttachmentOption(
         ) {
             Icon(
                 imageVector = icon,
-                contentDescription = label,
+                contentDescription = null, // decorative since label announces it
                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
             )
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -47,7 +47,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -205,6 +208,9 @@ private fun ConversationItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+            }
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -214,7 +220,7 @@ private fun ConversationItem(
         if (!avatarUrl.isNullOrBlank()) {
             AsyncImage(
                 model = avatarUrl,
-                contentDescription = "User Avatar",
+                contentDescription = null,
                 modifier = Modifier
                     .size(52.dp)
                     .clip(CircleShape),
@@ -226,7 +232,8 @@ private fun ConversationItem(
                 modifier = Modifier
                     .size(52.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .clearAndSetSemantics { },
                 contentAlignment = Alignment.Center,
             ) {
                 val firstLetter = conversation.otherUserName.firstOrNull()?.uppercase() ?: "?"

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -79,6 +81,8 @@ fun ChatScreen(
                         text = "Messages",
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.semantics { heading() },
                     )
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -210,8 +210,7 @@ private fun ConversationItem(
             .fillMaxWidth()
             .semantics(mergeDescendants = true) {
                 role = Role.Button
-            }
-            .clickable(onClick = onClick)
+            }.clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
@@ -79,7 +79,7 @@ fun FilterBottomSheet(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.semantics {heading()}
+                    modifier = Modifier.semantics { heading() },
                 )
                 TextButton(
                     onClick = onReset,
@@ -225,6 +225,6 @@ private fun FilterSectionLabel(text: String) {
         style = MaterialTheme.typography.labelLarge,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 8.dp) .semantics{heading()},
+        modifier = Modifier.padding(bottom = 8.dp).semantics { heading() },
     )
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -77,6 +79,7 @@ fun FilterBottomSheet(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.semantics {heading()}
                 )
                 TextButton(
                     onClick = onReset,
@@ -222,6 +225,6 @@ private fun FilterSectionLabel(text: String) {
         style = MaterialTheme.typography.labelLarge,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 8.dp),
+        modifier = Modifier.padding(bottom = 8.dp) .semantics{heading()},
     )
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
@@ -76,8 +76,7 @@ fun HomeSearchBar(
                 .semantics {
                     role = Role.Button
                     contentDescription = "Search services"
-                }
-                .clickable(
+                }.clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = onSearchClick,
@@ -98,9 +97,8 @@ fun HomeSearchBar(
                     ),
                 ).clickable(
                     onClick = onAiSearchClick,
-                    role = Role.Button
-                )
-                .padding(horizontal = 10.dp, vertical = 5.dp)
+                    role = Role.Button,
+                ).padding(horizontal = 10.dp, vertical = 5.dp)
                 .testTag("home_ai_search_button"),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -23,6 +24,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -68,6 +73,10 @@ fun HomeSearchBar(
             },
             modifier = Modifier
                 .weight(1f)
+                .semantics {
+                    role = Role.Button
+                    contentDescription = "Search services"
+                }
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -75,9 +84,10 @@ fun HomeSearchBar(
                 ).testTag("home_search_field"),
         )
         Spacer(Modifier.width(8.dp))
-        // ✨ AI chip — placeholder; routes to AI Search screen (upcoming issue).
+        // AI chip — placeholder; routes to AI Search screen .
         Row(
             modifier = Modifier
+                .minimumInteractiveComponentSize()
                 .clip(RoundedCornerShape(20.dp))
                 .background(
                     Brush.linearGradient(
@@ -86,7 +96,10 @@ fun HomeSearchBar(
                             MaterialTheme.colorScheme.tertiary.copy(alpha = 0.9f),
                         ),
                     ),
-                ).clickable(onClick = onAiSearchClick)
+                ).clickable(
+                    onClick = onAiSearchClick,
+                    role = Role.Button
+                )
                 .padding(horizontal = 10.dp, vertical = 5.dp)
                 .testTag("home_ai_search_button"),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
@@ -61,7 +61,7 @@ fun HomeTopBar(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.semantics(mergeDescendants = true) {
                 heading()
-            }
+            },
         ) {
             Box(
                 modifier = Modifier
@@ -71,8 +71,7 @@ fun HomeTopBar(
                         Brush.linearGradient(
                             colors = listOf(MaterialTheme.colorScheme.primary, Color(0xFF7C4DFF)),
                         ),
-                    )
-                    .clearAndSetSemantics { }, // Hides "Capital H" from TalkBack,
+                    ).clearAndSetSemantics { }, // Hides "Capital H" from TalkBack,
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -138,13 +137,11 @@ fun HomeTopBar(
                             colors = listOf(MaterialTheme.colorScheme.primary, Color(0xFF7C4DFF)),
                         ),
                         shape = CircleShape,
-                    )
-                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    ).background(MaterialTheme.colorScheme.surfaceVariant)
                     .semantics {
                         role = Role.Button
                         contentDescription = "User profile, initials $initials"
-                    }
-                    .clickable {
+                    }.clickable {
                         if (onProfileClick != null) {
                             onProfileClick()
                         } else {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
@@ -29,6 +29,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -51,7 +57,12 @@ fun HomeTopBar(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         // Logo + wordmark
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.semantics(mergeDescendants = true) {
+                heading()
+            }
+        ) {
             Box(
                 modifier = Modifier
                     .size(36.dp)
@@ -60,7 +71,8 @@ fun HomeTopBar(
                         Brush.linearGradient(
                             colors = listOf(MaterialTheme.colorScheme.primary, Color(0xFF7C4DFF)),
                         ),
-                    ),
+                    )
+                    .clearAndSetSemantics { }, // Hides "Capital H" from TalkBack,
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -74,6 +86,7 @@ fun HomeTopBar(
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.semantics { heading() },
             )
         }
 
@@ -107,7 +120,7 @@ fun HomeTopBar(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Notifications,
-                        contentDescription = "Notifications",
+                        contentDescription = "Notifications${if (notificationCount > 0) ", $notificationCount unread" else ""}",
                         tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.size(20.dp),
                     )
@@ -125,7 +138,12 @@ fun HomeTopBar(
                             colors = listOf(MaterialTheme.colorScheme.primary, Color(0xFF7C4DFF)),
                         ),
                         shape = CircleShape,
-                    ).background(MaterialTheme.colorScheme.surfaceVariant)
+                    )
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = "User profile, initials $initials"
+                    }
                     .clickable {
                         if (onProfileClick != null) {
                             onProfileClick()
@@ -140,6 +158,7 @@ fun HomeTopBar(
                     style = MaterialTheme.typography.labelMedium,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.clearAndSetSemantics { }, // Suppresses raw text reading
                 )
             }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -143,7 +145,9 @@ fun NotificationHeader(
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(start = 8.dp),
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .semantics { heading() },
         )
         if (unreadCount > 0) {
             Box(
@@ -222,6 +226,7 @@ fun NotificationItem(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))
+            .semantics(mergeDescendants = true) {}
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = containerColor),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -307,6 +312,7 @@ fun NotificationEmptyState() {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -108,14 +108,15 @@ fun EditProfileScreen(
                         text = "Edit Profile",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.semantics { heading() }
+                        modifier = Modifier.semantics { heading() },
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Navigate Back")
+                            contentDescription = "Navigate Back",
+                        )
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -156,8 +157,7 @@ fun EditProfileScreen(
                         .semantics {
                             role = Role.Button
                             contentDescription = "Change Profile Photo"
-                        }
-                        .clickable {
+                        }.clickable {
                             photoPicker.launch(
                                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
                             )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -50,6 +50,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -102,11 +108,14 @@ fun EditProfileScreen(
                         text = "Edit Profile",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() }
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Navigate Back")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -144,6 +153,10 @@ fun EditProfileScreen(
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.surfaceVariant)
                         .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                        .semantics {
+                            role = Role.Button
+                            contentDescription = "Change Profile Photo"
+                        }
                         .clickable {
                             photoPicker.launch(
                                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
@@ -223,7 +236,12 @@ fun EditProfileScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(16.dp)
+                        .semantics {
+                            role = Role.Switch
+                            stateDescription = if (state.allowCalls) "On" else "Off"
+                            contentDescription = "Allow Direct Calls"
+                        },
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileAvatar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileAvatar.kt
@@ -27,6 +27,7 @@ fun ProfileAvatar(
     photoUrl: String?,
     modifier: Modifier = Modifier,
     isVerified: Boolean = false,
+    contentDescription: String? = "Profile photo",
 ) {
     Box(contentAlignment = Alignment.BottomEnd, modifier = modifier) {
         Box(
@@ -44,14 +45,14 @@ fun ProfileAvatar(
             if (photoUrl.isNullOrEmpty()) {
                 Icon(
                     imageVector = Icons.Default.Person,
-                    contentDescription = "Default Avatar",
+                    contentDescription = contentDescription,
                     modifier = Modifier.size(64.dp),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             } else {
                 AsyncImage(
                     model = photoUrl,
-                    contentDescription = "Profile Photo",
+                    contentDescription = contentDescription,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop,
                 )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileBottomTabs.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileBottomTabs.kt
@@ -70,8 +70,7 @@ fun TabButton(
                 width = 1.dp,
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f),
                 shape = RoundedCornerShape(24.dp),
-            )
-            .clickable(onClick = onClick)
+            ).clickable(onClick = onClick)
             .padding(vertical = 18.dp, horizontal = 20.dp)
             .semantics {
                 role = androidx.compose.ui.semantics.Role.Tab

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileBottomTabs.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileBottomTabs.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
@@ -22,6 +21,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -68,8 +70,13 @@ fun TabButton(
                 width = 1.dp,
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f),
                 shape = RoundedCornerShape(24.dp),
-            ).clickable(onClick = onClick)
-            .padding(vertical = 18.dp, horizontal = 20.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = 18.dp, horizontal = 20.dp)
+            .semantics {
+                role = androidx.compose.ui.semantics.Role.Tab
+                contentDescription = "$label tab"
+            },
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
@@ -19,6 +19,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,6 +53,7 @@ fun ProfileHeader(
             fontSize = 24.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.semantics { heading() },
         )
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -56,11 +62,15 @@ fun ProfileHeader(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = "Share profile"
+                    },
             ) {
                 Icon(
                     imageVector = Icons.Default.Share,
-                    contentDescription = "Share profile",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(20.dp),
                 )
@@ -70,11 +80,15 @@ fun ProfileHeader(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = "Edit profile"
+                    },
             ) {
                 Icon(
                     imageVector = Icons.Default.Edit,
-                    contentDescription = "Edit profile",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(20.dp),
                 )
@@ -84,11 +98,16 @@ fun ProfileHeader(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .semantics {
+                      role =
+                            Role.Button
+                        contentDescription = "Settings"
+                    },
             ) {
                 Icon(
                     imageVector = Icons.Default.Settings,
-                    contentDescription = "Settings",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(20.dp),
                 )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
@@ -100,7 +100,7 @@ fun ProfileHeader(
                     .clip(CircleShape)
                     .background(MaterialTheme.colorScheme.surfaceVariant)
                     .semantics {
-                      role =
+                        role =
                             Role.Button
                         contentDescription = "Settings"
                     },

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -75,13 +78,20 @@ fun StatCard(
     iconTint: Color = HustleWarningAmber,
     onClick: (() -> Unit)? = null,
 ) {
+    val cleanLabel = label.replace("\n", " ")
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(24.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f), RoundedCornerShape(24.dp))
             .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
-            .padding(vertical = 24.dp, horizontal = 8.dp),
+            .padding(vertical = 24.dp, horizontal = 8.dp)
+            .semantics(mergeDescendants = true) {
+               contentDescription = "$value $cleanLabel"
+                if (onClick != null) {
+                    role = androidx.compose.ui.semantics.Role.Button
+                }
+            },
         contentAlignment = Alignment.Center,
     ) {
         Column(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
@@ -87,7 +87,7 @@ fun StatCard(
             .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
             .padding(vertical = 24.dp, horizontal = 8.dp)
             .semantics(mergeDescendants = true) {
-               contentDescription = "$value $cleanLabel"
+                contentDescription = "$value $cleanLabel"
                 if (onClick != null) {
                     role = androidx.compose.ui.semantics.Role.Button
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import must.kdroiders.hustlehub.R
@@ -62,6 +64,7 @@ fun ProviderOnboardingCard(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.semantics { heading () }
             )
 
             Spacer(Modifier.height(6.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
@@ -64,7 +64,7 @@ fun ProviderOnboardingCard(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.semantics { heading () }
+                modifier = Modifier.semantics { heading() },
             )
 
             Spacer(Modifier.height(6.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ServicesSection.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ServicesSection.kt
@@ -29,6 +29,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,6 +59,7 @@ fun ServicesHeader(
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.semantics { heading() },
         )
         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
             TextButton(onClick = onManageServicesClick) {
@@ -68,7 +74,7 @@ fun ServicesHeader(
                 Text(
                     text = "Add New +",
                     fontSize = 14.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.primary,
                 )
             }
@@ -90,7 +96,11 @@ fun ServiceCard(
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f), RoundedCornerShape(24.dp))
             .clickable { onClick() }
-            .padding(16.dp),
+            .padding(16.dp)
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                contentDescription = "Service: ${service.title}, Price: KES ${service.priceRange}"
+            },
     ) {
         Column {
             Row(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -137,7 +137,7 @@ fun CreateServiceScreen(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.semantics { heading()}
+                    modifier = Modifier.semantics { heading() },
                 )
             }
 
@@ -319,8 +319,7 @@ fun CreateServiceScreen(
                             .semantics {
                                 role = Role.Button
                                 contentDescription = "Add tag"
-                            }
-                            .clickable { createServiceViewModel.addTag() },
+                            }.clickable { createServiceViewModel.addTag() },
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -49,6 +50,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -121,7 +128,7 @@ fun CreateServiceScreen(
                 IconButton(onClick = onBack) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
+                        contentDescription = "Navigate back",
                         tint = MaterialTheme.colorScheme.onBackground,
                     )
                 }
@@ -130,6 +137,7 @@ fun CreateServiceScreen(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.semantics { heading()}
                 )
             }
 
@@ -304,15 +312,20 @@ fun CreateServiceScreen(
                     )
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .size(48.dp)
                             .clip(RoundedCornerShape(12.dp))
                             .background(MaterialTheme.colorScheme.primary)
+                            .semantics {
+                                role = Role.Button
+                                contentDescription = "Add tag"
+                            }
                             .clickable { createServiceViewModel.addTag() },
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             imageVector = Icons.Default.Add,
-                            contentDescription = "Add tag",
+                            contentDescription = null,
                             tint = MaterialTheme.colorScheme.onPrimary,
                             modifier = Modifier.size(20.dp),
                         )
@@ -326,7 +339,12 @@ fun CreateServiceScreen(
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(12.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant)
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                        .semantics {
+                            role = Role.Switch
+                            stateDescription = if (state.openToBarter) "On" else "Off"
+                            contentDescription = "Open to Barter Service"
+                        },
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
@@ -92,12 +92,11 @@ private fun AvailabilityChip(
             .background(bgColor)
             .border(1.dp, borderColor, RoundedCornerShape(20.dp))
             .clickable(enabled = enabled) { onClick() }
-            .semantics{
+            .semantics {
                 role = Role.RadioButton
                 this.selected = selected
                 stateDescription = if (selected) "Selected" else "Not selected"
-            }
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            }.padding(horizontal = 12.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
@@ -1,5 +1,6 @@
 package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -10,11 +11,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -80,16 +87,22 @@ private fun AvailabilityChip(
 
     Row(
         modifier = Modifier
+            .minimumInteractiveComponentSize()
             .clip(RoundedCornerShape(20.dp))
             .background(bgColor)
             .border(1.dp, borderColor, RoundedCornerShape(20.dp))
             .clickable(enabled = enabled) { onClick() }
+            .semantics{
+                role = Role.RadioButton
+                this.selected = selected
+                stateDescription = if (selected) "Selected" else "Not selected"
+            }
             .padding(horizontal = 12.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         // Dot indicator
-        androidx.compose.foundation.Canvas(modifier = Modifier.size(8.dp)) {
+        Canvas(modifier = Modifier.size(8.dp)) {
             drawCircle(color = dotColor)
         }
         Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/DeleteConfirmDialog.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/DeleteConfirmDialog.kt
@@ -4,7 +4,11 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 
 @Composable
@@ -20,6 +24,7 @@ fun DeleteConfirmDialog(
                 text = "Delete Service",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
+                modifier = Modifier.semantics { heading() },
             )
         },
         text = {
@@ -30,7 +35,10 @@ fun DeleteConfirmDialog(
             )
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(
+                onClick = onConfirm,
+                modifier = Modifier.minimumInteractiveComponentSize(),
+            ) {
                 Text(
                     text = "Delete",
                     color = MaterialTheme.colorScheme.error,
@@ -39,7 +47,10 @@ fun DeleteConfirmDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.minimumInteractiveComponentSize(),
+            ) {
                 Text("Cancel")
             }
         },

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -49,6 +50,11 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -231,6 +237,7 @@ fun MapLocationPickerModal(
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.semantics { heading() },
                     )
                     Text(
                         text = "Tap the map to drop a pin, or drag to center",
@@ -344,7 +351,12 @@ fun MapLocationPickerModal(
                         .padding(16.dp)
                         .shadow(4.dp, CircleShape)
                         .background(MaterialTheme.colorScheme.surface, CircleShape)
-                        .size(44.dp),
+                        .minimumInteractiveComponentSize()
+                        .size(44.dp)
+                        .semantics {
+                            role = Role.Button
+                            contentDescription = "Find my current location"
+                        },
                 ) {
                     Icon(
                         imageVector = Icons.Default.MyLocation,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -34,7 +35,11 @@ fun ReviewCard(
     review: Review,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) { }
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewCard.kt
@@ -38,7 +38,7 @@ fun ReviewCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .semantics(mergeDescendants = true) { }
+            .semantics(mergeDescendants = true) { },
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
@@ -25,11 +25,16 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -112,9 +117,14 @@ fun ServiceManagementCard(
                 ) {
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(MaterialTheme.colorScheme.primaryContainer)
+                            .semantics{
+                                role = Role.Button
+                                contentDescription = "Edit service"
+                            }
                             .clickable(enabled = !isUpdating, onClick = onEditClick),
                         contentAlignment = Alignment.Center,
                     ) {
@@ -128,15 +138,20 @@ fun ServiceManagementCard(
 
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(MaterialTheme.colorScheme.secondaryContainer)
+                            .semantics {
+                                role = Role.Button
+                                contentDescription = "Manage service photo gallery"
+                            }
                             .clickable(enabled = !isUpdating, onClick = onGalleryClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             imageVector = Icons.Default.PhotoLibrary,
-                            contentDescription = "Manage gallery",
+                            contentDescription = null,
                             tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier = Modifier.size(18.dp),
                         )
@@ -144,15 +159,20 @@ fun ServiceManagementCard(
 
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(MaterialTheme.colorScheme.errorContainer)
+                            .semantics {
+                                role = Role.Button
+                                contentDescription = "Delete service"
+                            }
                             .clickable(enabled = !isUpdating, onClick = onDeleteClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete service",
+                            contentDescription = null,
                             tint = MaterialTheme.colorScheme.onErrorContainer,
                             modifier = Modifier.size(18.dp),
                         )
@@ -225,7 +245,10 @@ private fun StatItem(
     label: String,
     value: String,
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.semantics(mergeDescendants = true) { },
+    ) {
         Text(
             text = value,
             style = MaterialTheme.typography.titleSmall,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
@@ -121,11 +121,10 @@ fun ServiceManagementCard(
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(MaterialTheme.colorScheme.primaryContainer)
-                            .semantics{
+                            .semantics {
                                 role = Role.Button
                                 contentDescription = "Edit service"
-                            }
-                            .clickable(enabled = !isUpdating, onClick = onEditClick),
+                            }.clickable(enabled = !isUpdating, onClick = onEditClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
@@ -145,8 +144,7 @@ fun ServiceManagementCard(
                             .semantics {
                                 role = Role.Button
                                 contentDescription = "Manage service photo gallery"
-                            }
-                            .clickable(enabled = !isUpdating, onClick = onGalleryClick),
+                            }.clickable(enabled = !isUpdating, onClick = onGalleryClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
@@ -166,8 +164,7 @@ fun ServiceManagementCard(
                             .semantics {
                                 role = Role.Button
                                 contentDescription = "Delete service"
-                            }
-                            .clickable(enabled = !isUpdating, onClick = onDeleteClick),
+                            }.clickable(enabled = !isUpdating, onClick = onDeleteClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsComponents.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsComponents.kt
@@ -27,6 +27,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,7 +45,9 @@ fun SettingsSectionLabel(text: String) {
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         letterSpacing = 1.2.sp,
-        modifier = Modifier.padding(start = 4.dp),
+        modifier = Modifier
+            .padding(start = 4.dp)
+            .semantics { heading() },
     )
 }
 
@@ -68,7 +76,11 @@ fun SettingsRowNavigate(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .semantics {
+                role = Role.Button
+                contentDescription = "$label${if (subtitle != null) ", $subtitle" else ""}"
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SettingsIconBox(icon = icon)
@@ -117,7 +129,11 @@ fun SettingsRowExternalLink(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .semantics {
+                role = Role.Button
+                contentDescription = "$label, opens external link"
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SettingsIconBox(icon = icon)
@@ -131,7 +147,7 @@ fun SettingsRowExternalLink(
         )
         Icon(
             imageVector = Icons.AutoMirrored.Filled.OpenInNew,
-            contentDescription = "Opens externally",
+            contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(16.dp),
         )
@@ -149,7 +165,12 @@ fun SettingsRowToggle(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .semantics {
+                role = Role.Switch
+                stateDescription = if (checked) "On" else "Off"
+                contentDescription = label
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SettingsIconBox(icon = icon)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsTopBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsTopBar.kt
@@ -14,6 +14,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -28,7 +30,7 @@ fun SettingsTopBar(onBack: () -> Unit) {
         IconButton(onClick = onBack) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                contentDescription = "Navigate back",
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
@@ -38,6 +40,7 @@ fun SettingsTopBar(onBack: () -> Unit) {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
         Spacer(Modifier.weight(1f))
         // Invisible spacer to keep title centred

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -201,7 +203,7 @@ fun SettingsScreen(
                     textDecoration = TextDecoration.Underline,
                     modifier = Modifier
                         .clip(RoundedCornerShape(4.dp))
-                        .clickable { viewModel.onDeleteAccountClicked() }
+                        .clickable(role = Role.Button) { viewModel.onDeleteAccountClicked() }
                         .padding(horizontal = 8.dp, vertical = 4.dp),
                 )
             }


### PR DESCRIPTION
## 📝 What does this PR do?
Implements a comprehensive accessibility overhaul across shared components, authentication, profile, settings, chat, home, service management, notifications, onboarding, and splash features to comply with Android Accessibility Guidelines and WCAG AA standards.

---

## 🔄 Main Changes

### Added
- Added explicit content descriptions to login and password fields
- Added `minimumInteractiveComponentSize()` (48dp x 48dp) to all small icons, chips, and action buttons
- Added TalkBack semantic roles (`Role.Button`, `Role.Tab`, `Role.Switch`, `Role.RadioButton`) across interactive composables
- Added `heading()` semantics to screen titles, dialog headers, and section headers
- Added `clearAndSetSemantics { }` on decorative icons and avatar text fallbacks to prevent TalkBack raw character pronunciation (e.g. "Capital P", "KO")

### Changed
- Optimized focus order for TalkBack and Voice Access users using `semantics(mergeDescendants = true)` on cards, review items, notification items, and chat items
- Updated category chips, bottom sheets, and location pickers for seamless accessibility navigation

### Fixed
- Ensured error messages are immediately announced by screen readers using `LiveRegionMode.Polite` on `HustleTextField` and `LoadingIndicator`
- Fixed text layout and clipping issues under 200% system font scaling

---

## ✅ Type of change
- [x] New feature
- [ ] Bug fix
- [x] UI update
- [x] Refactor / cleanup
- [x] Documentation

---

## 🧪 I have tested that...
- [x] The app builds without errors
- [x] My feature/fix works as expected
- [x] I didn't break anything else

---

## 🔍 Code quality
- [x] Quality checks passed (`./gradlew qualityCheck`)
- [x] Ktlint passed (`./gradlew ktlintCheck`)
- [x] Detekt passed (`./gradlew detekt`)
- [x] Android Lint passed (`./gradlew lint`)
- [x] My commit message follows convention (`feat:`, `fix:`, `chore:` etc.)

---

## Closes #93
