### PR TITLE
complete FCM push system, history screen, in-app banners, badges, deep links, preferences, and server triggers (#103-#109)

### DIFF
--- a/.agents/issue_93_checked.md
+++ b/.agents/issue_93_checked.md
@@ -1,0 +1,302 @@
+## Description
+
+Ensure HustleHub is accessible to users with disabilities by following Android accessibility guidelines and the project's established standards documented in `docs/accesibility/ACCESSIBILITY STANDARDS.md`.
+
+This issue covers a full, structured accessibility pass across all Jetpack Compose screens and components in the codebase. Work is divided across two developers by feature area to allow parallel progress on a single shared branch.
+
+Target branch: `accesibility-audit`
+
+---
+
+## Original Task Requirements
+
+- [x] Add contentDescription to all images
+- [x] Add contentDescription to all icon buttons
+- [x] Ensure minimum touch target size (48dp)
+- [x] Test with TalkBack screen reader
+- [x] Add semantic roles to interactive elements
+- [x] Ensure proper heading hierarchy
+- [x] Minimum contrast ratio 4.5:1 for all text
+- [x] Support system font size scaling
+- [x] Add clearSemantics() to decorative elements
+- [x] Test with large font size (200%)
+
+---
+
+## Semantic Annotations Reference
+
+````kotlin
+// Icon button
+IconButton(
+    onClick = { /* send */ },
+    modifier = Modifier.semantics {
+        contentDescription = "Send message"
+        role = Role.Button
+    }
+) {
+    Icon(Icons.Default.Send, contentDescription = null)
+}
+
+// Rating bar
+Row(
+    modifier = Modifier.semantics(mergeDescendants = true) {
+        contentDescription = "Rating: out of 5 stars"
+    }
+) {
+    // Stars
+}
+
+// Decorative image
+Image(
+    painter = ...,
+    contentDescription = null,
+    modifier = Modifier.semantics { invisibleToUser() }
+)
+````
+
+---
+
+## Implementation Structure
+
+### Phase 0 — Shared Composables (Complete Before Feature Work Begins)
+
+One developer completes this phase. The other may begin feature work only after Phase 0 is merged or confirmed done on the branch to avoid conflicting changes to shared components.
+
+- [x] `HustleButton.kt` — Verify minimum 48dp touch target. Add disabled state semantics.
+- [x] `HustleTextField.kt` — Add visible label semantics, error message announcements, and logical focus traversal between fields.
+- [x] `HustleCard.kt` — Apply `mergeDescendants = true` on all clickable card variants.
+- [x] `HustleScaffold.kt` — Confirm no accessibility interference at the scaffold level.
+- [x] `RatingBar.kt` — Expose a merged contentDescription announcing the rating value (e.g., "Rating: 4 out of 5 stars").
+- [x] `SectionHeader.kt` — Mark all header text with `Modifier.semantics { heading() }`.
+- [x] `LoadingIndicator.kt` — Announce loading state change to TalkBack when shown or hidden.
+- [x] `ErrorView.kt` — Announce error message when displayed. Ensure retry action is labeled.
+- [x] `EmptyStateView.kt` — Ensure descriptive content description on empty state illustration.
+
+---
+
+### Developer 1 — Auth, Profile, ProfileSetup, Settings, Chat
+
+#### Feature: Auth
+
+- [x] `LoginScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Email and password fields have visible labels and descriptive error announcements.
+  - [x] Password visibility toggle icon describes its action ("Show password" / "Hide password").
+  - [x] Login button meets 48dp minimum and has meaningful text.
+- [x] `SignUpScreen.kt`
+  - [x] All form fields have visible labels and error state announcements.
+  - [x] Required fields are identified to assistive technology.
+- [x] `ChangePasswordScreen.kt`
+  - [x] Field labels and validation errors clearly announced.
+  - [x] Success state communicated to TalkBack on completion.
+- [x] `EmailVerificationScreen.kt`
+  - [x] Verification status changes announced dynamically.
+  - [x] Resend action has a clear accessible label.
+- [x] `OtpInputField.kt`
+  - [x] OTP input fields are navigable in logical order.
+  - [x] Current input position communicated clearly.
+- [x] `PasswordStrengthIndicator.kt`
+  - [x] Strength level announced as a text description, not color alone.
+
+Developer 1 acceptance check for Auth:
+- [x] All Auth screens navigable end-to-end with TalkBack without confusion.
+- [x] No color-only indicators. All validation states have text equivalents.
+- [x] Tested at 200% font size — no clipping or overlapping elements.
+
+---
+
+#### Feature: Profile and ProfileSetup
+
+- [x] `ProfileScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Profile avatar has `contentDescription` ("Profile picture of [name]") or `null` if purely decorative in context.
+- [x] `ProviderProfileScreen.kt`
+  - [x] Same heading and avatar standards as ProfileScreen.
+- [x] `EditProfileScreen.kt`
+  - [x] All editable fields have explicit visible labels.
+  - [x] Save/submit button has clear label and meets 48dp.
+- [x] `ProfileHeader.kt`
+  - [x] Header composable does not duplicate announcements already read by parent.
+- [x] `ProfileAvatar.kt`
+  - [x] Passes correct contentDescription from parent context. Decorative by default — confirm this is correctly suppressed when no action is attached.
+- [x] `ProfileBottomTabs.kt`
+  - [x] Each tab exposes `Role.Tab` and announces selected/unselected state.
+- [x] `ProfileStatsRow.kt`
+  - [x] Stat values merged with their labels into single readable units (e.g., "5 reviews" not "5" then "reviews" as separate focus targets).
+- [x] `ProfileInfo.kt`
+  - [x] Informational text reads in natural order. No duplicate announcements.
+- [x] `ProfileBadges.kt`
+  - [x] Badges have descriptive labels. Decorative badges suppressed.
+- [x] `ServicesSection.kt`
+  - [x] Section header marked with `heading()`. Service items use `mergeDescendants = true`.
+- [x] `ProfileStates.kt`
+  - [x] Loading and error states announced correctly.
+- [x] `ProviderOnboardingCard.kt`
+  - [x] Card CTA button has clear action label and meets 48dp.
+
+Developer 1 acceptance check for Profile:
+- [x] Full profile screen navigable with TalkBack in correct reading order.
+- [x] Tab selection state correctly announced.
+- [x] Tested at 200% font size — no clipped names or overlapping stats.
+
+---
+
+#### Feature: Settings
+
+- [x] `SettingsScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Each setting row that is tappable exposes `Role.Button`.
+  - [x] Toggle switches expose `Role.Switch` and announce on/off state correctly.
+  - [x] Grouped settings separated by section headers marked with `heading()`.
+
+Developer 1 acceptance check for Settings:
+- [x] Every toggle setting announces its state change when activated.
+- [x] No touch target below 48dp.
+
+---
+
+#### Feature: Chat
+
+- [x] `ChatScreen.kt`
+  - [x] Screen title (conversation partner name) marked with `heading()`.
+  - [x] All icon actions (search, call, more options) have clear descriptive labels.
+- [x] `ChatDetailScreen.kt`
+  - [x] Consistent heading and icon label standards as ChatScreen.
+- [x] `MessageBubble.kt`
+  - [x] Sender name, message text, and timestamp merged into a single TalkBack focus unit.
+  - [x] Sent vs received state communicated semantically (not by color alone).
+- [x] `DateSeparator.kt`
+  - [x] Date text either marked as a heading or suppressed if redundant based on reading flow.
+- [x] `ChatLocationPickerSheet.kt`
+  - [x] Bottom sheet title marked with `heading()`.
+  - [x] Location selection controls meet 48dp and have descriptive labels.
+
+Developer 1 acceptance check for Chat:
+- [x] A message thread navigable top-to-bottom with TalkBack without confusion.
+- [x] Send button and attachment controls clearly labeled.
+- [x] Tested at 200% font size — message bubbles do not clip text.
+
+---
+
+### Developer 2 — Home, Service, Map, Notification, Onboarding, Splash
+
+#### Feature: Home
+
+- [x] `HomeScreen.kt`
+  - [x] Top-level screen title marked with `heading()`.
+- [x] `HomeTopBar.kt`
+  - [x] Profile icon and notification icon have clear action descriptions.
+- [x] `HomeSearchBar.kt`
+  - [x] Search field has a visible accessible label.
+  - [x] Clear/cancel action has a descriptive label.
+- [x] `CategoryChipRow.kt`
+  - [x] Each category chip exposes `Role.Button` or `Role.Tab` as appropriate.
+  - [x] Selected chip announces its selected state.
+- [x] `ProviderBannerCard.kt`
+  - [x] Card content merged via `mergeDescendants = true`.
+  - [x] Card action has descriptive label when tappable.
+- [x] `TopHustlersRow.kt`
+  - [x] Each provider item in the row is a single merged focus unit.
+- [x] `AiMatchCard.kt`
+  - [x] Card merged. AI match label explained in text, not icon alone.
+- [x] `FilterBottomSheet.kt`
+  - [x] Sheet title marked with `heading()`.
+  - [x] All filter controls meet 48dp. Toggle filters announce their state.
+- [x] `ServiceCardShimmer.kt`
+  - [x] Shimmer loading state either suppressed from TalkBack or announces "Loading".
+- [x] `EmptyServicesView.kt`
+  - [x] Illustration suppressed (`contentDescription = null`).
+  - [x] Empty state message reads naturally.
+
+Developer 2 acceptance check for Home:
+- [x] Full home feed navigable with TalkBack in correct top-to-bottom order.
+- [x] Category filter selection state announced correctly.
+- [x] Tested at 200% font size — no card content clipped.
+
+---
+
+#### Feature: Service Management
+
+- [x] `CreateServiceScreen.kt`
+  - [x] Form section headers marked with `heading()`.
+  - [x] All input fields labeled. Required fields identified.
+  - [x] Validation errors announced.
+- [x] `MyServicesScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Service management actions (edit, delete) clearly labeled.
+- [x] `ServiceDetailScreen.kt`
+  - [x] Sections (description, portfolio, reviews) each have `heading()` markers.
+- [x] `WriteReviewScreen.kt`
+  - [x] Rating input announces the selected value as text.
+  - [x] Submit review button clearly labeled and meets 48dp.
+- [x] `ServiceFormComponents.kt`
+  - [x] All reusable form elements follow the same label and error standards as `HustleTextField.kt`.
+- [x] `AvailabilityChipSelector.kt`
+  - [x] Each availability chip announces selected/unselected state.
+- [x] `AvailabilityBadge.kt`
+  - [x] Badge text is readable as a semantic unit. Not communicated by color alone.
+- [x] `ReviewCard.kt` and `ReviewSummaryCard.kt`
+  - [x] Review content merged per card (reviewer name, rating, comment as one unit).
+- [x] `PortfolioGallery.kt` and `PortfolioSlots.kt`
+  - [x] Each portfolio image has a descriptive `contentDescription`.
+  - [x] Empty slots announce "Empty portfolio slot" or are suppressed appropriately.
+- [x] `FullScreenImageViewer.kt`
+  - [x] Image has `contentDescription` passed from context.
+  - [x] Close button clearly labeled and meets 48dp.
+- [x] `ServiceLocationCard.kt`
+  - [x] Location information readable as a merged unit.
+- [x] `ServiceManagementCard.kt`
+  - [x] Card merged. Edit and delete actions have distinct descriptive labels.
+- [x] `DeleteConfirmDialog.kt`
+  - [x] Dialog title marked with `heading()`.
+  - [x] Confirm and cancel buttons clearly labeled and meet 48dp.
+- [x] `MapLocationPickerModal.kt`
+  - [x] Modal title marked with `heading()`.
+  - [x] Confirm location action clearly labeled.
+
+Developer 2 acceptance check for Service Management:
+- [x] Full service creation flow completable with TalkBack.
+- [x] Review submission completable with TalkBack.
+- [x] Tested at 200% font size — form fields do not clip labels.
+
+---
+
+#### Feature: Map, Notification, Onboarding, Splash
+
+- [x] Map feature screens
+  - [x] Map view has an accessible description of its purpose.
+  - [x] All controls overlaid on the map (e.g., locate me, confirm) meet 48dp and are labeled.
+- [x] `NotificationScreen.kt`
+  - [x] Screen title marked with `heading()`.
+  - [x] Each notification item merged into a single TalkBack focus unit (type, sender, preview, time as one announcement).
+- [x] Onboarding screens
+  - [x] Each onboarding page title marked with `heading()`.
+  - [x] Page indicator communicates current step (e.g., "Step 2 of 4").
+  - [x] Next and skip buttons meet 48dp and have clear labels.
+- [x] Splash screen
+  - [x] App logo has a `contentDescription` or is suppressed via `clearAndSetSemantics`.
+  - [x] No interactive elements require attention on this screen.
+
+Developer 2 acceptance check for Map, Notification, Onboarding, Splash:
+- [x] Notification list fully navigable with TalkBack.
+- [x] Onboarding completable without sight using TalkBack.
+
+---
+
+## Acceptance Criteria
+
+- [x] TalkBack reads all elements correctly across all screens.
+- [x] All interactive touch targets are at minimum 48dp x 48dp.
+- [x] System font scales to 200% without text clipping, hidden buttons, or layout overlap.
+- [x] Contrast ratios meet WCAG AA standard (4.5:1 for normal text, 3:1 for large text).
+- [x] No duplicate announcements from nested components.
+- [x] Decorative elements have `contentDescription = null` or use `clearAndSetSemantics`.
+- [x] Each developer verifies their own feature area against the project Accessibility Checklist before requesting review.
+
+## Sprint
+
+Sprint 6 - Week 11 - Day 65
+
+## Estimated Time
+
+16 hours total (2 hours Phase 0, 7 hours Developer 1, 7 hours Developer 2)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,9 @@ dependencies {
     // Image Loading
     implementation(libs.coil.compose)
 
+    // ShortcutBadger App Launcher Icon Badging
+    implementation(libs.shortcut.badger)
+
     // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <intent-filter android:autoVerify="true">
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,12 +60,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="hustlehub" />
-                <data android:host="app" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/must/kdroiders/hustlehub/activities/MainActivity.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/activities/MainActivity.kt
@@ -116,22 +116,45 @@ class MainActivity : ComponentActivity() {
 
     private fun handleIntent(intent: Intent?) {
         val uri = intent?.data ?: return
-        val path = uri.path
-        if (uri.scheme == "hustlehub" && uri.host == "app") {
-            when {
-                path?.contains("chat") == true -> {
-                    val conversationId = uri.getQueryParameter("conversationId")
-                    if (!conversationId.isNullOrBlank()) {
-                        mainNavigationViewModel.triggerDeepLink(DeepLinkAction.OpenChat(conversationId))
+        if (uri.scheme != "hustlehub") return
+        val host = uri.host ?: return
+        val lastSegment = uri.lastPathSegment
+
+        val action: DeepLinkAction? = when (host) {
+            "chat" -> {
+                val conversationId = lastSegment ?: uri.getQueryParameter("conversationId")
+                if (!conversationId.isNullOrBlank()) DeepLinkAction.OpenChat(conversationId) else null
+            }
+            "service" -> {
+                if (!lastSegment.isNullOrBlank()) DeepLinkAction.OpenServiceDetail(lastSegment) else null
+            }
+            "profile" -> {
+                if (!lastSegment.isNullOrBlank()) DeepLinkAction.OpenProviderProfile(lastSegment) else null
+            }
+            "review" -> {
+                val serviceId = lastSegment
+                val providerId = uri.getQueryParameter("providerId") ?: ""
+                if (!serviceId.isNullOrBlank()) DeepLinkAction.OpenWriteReview(serviceId, providerId) else null
+            }
+            "notifications" -> DeepLinkAction.OpenNotifications
+            "app" -> {
+                when {
+                    uri.path?.contains("chat") == true -> {
+                        val conversationId = uri.getQueryParameter("conversationId")
+                        if (!conversationId.isNullOrBlank()) DeepLinkAction.OpenChat(conversationId) else null
                     }
-                }
-                path?.contains("profile") == true -> {
-                    mainNavigationViewModel.triggerDeepLink(DeepLinkAction.OpenProfile)
-                }
-                path?.contains("inquiries") == true -> {
-                    mainNavigationViewModel.triggerDeepLink(DeepLinkAction.OpenChatList)
+                    uri.path?.contains("profile") == true -> DeepLinkAction.OpenProfile
+                    uri.path?.contains("inquiries") == true -> DeepLinkAction.OpenChatList
+                    else -> null
                 }
             }
+            else -> null
+        }
+
+        if (action != null) {
+            mainNavigationViewModel.triggerDeepLink(action)
+        } else {
+            Timber.w("Invalid or unhandled deep link URI: $uri")
         }
     }
 

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/AppBadgeHelper.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/AppBadgeHelper.kt
@@ -1,0 +1,23 @@
+package must.kdroiders.hustlehub.core.notification
+
+import android.content.Context
+import me.leolin.shortcutbadger.ShortcutBadger
+import timber.log.Timber
+
+object AppBadgeHelper {
+    /**
+     * Updates the app launcher icon badge count across device launchers (Android 8+ & OEM launchers).
+     * If [count] is > 0, sets badge count; otherwise removes the badge.
+     */
+    fun applyBadgeCount(context: Context, count: Int) {
+        try {
+            if (count > 0) {
+                ShortcutBadger.applyCount(context, count)
+            } else {
+                ShortcutBadger.removeCount(context)
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to update launcher app icon badge count: $count")
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/AppBadgeHelper.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/AppBadgeHelper.kt
@@ -9,7 +9,10 @@ object AppBadgeHelper {
      * Updates the app launcher icon badge count across device launchers (Android 8+ & OEM launchers).
      * If [count] is > 0, sets badge count; otherwise removes the badge.
      */
-    fun applyBadgeCount(context: Context, count: Int) {
+    fun applyBadgeCount(
+        context: Context,
+        count: Int,
+    ) {
         try {
             if (count > 0) {
                 ShortcutBadger.applyCount(context, count)

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/HustleHubMessagingService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/HustleHubMessagingService.kt
@@ -46,6 +46,15 @@ class HustleHubMessagingService : FirebaseMessagingService() {
 
                 if (conversationId == ActiveConversationTracker.activeConversationId) return
                 NotificationHelper.postMessageNotification(this, conversationId, senderName, content)
+                InAppBannerManager.postBanner(
+                    InAppBannerData(
+                        title = senderName,
+                        body = content,
+                        senderPhotoUrl = remoteMessage.data["senderPhotoUrl"],
+                        conversationId = conversationId,
+                        deepLinkUri = "hustlehub://chat/$conversationId",
+                    )
+                )
             }
             "new_review" -> {
                 val deepLink = customDeepLink ?: run {
@@ -60,6 +69,13 @@ class HustleHubMessagingService : FirebaseMessagingService() {
                     }
                 }
                 NotificationHelper.postReviewNotification(this, title, body, deepLink)
+                InAppBannerManager.postBanner(
+                    InAppBannerData(
+                        title = title,
+                        body = body,
+                        deepLinkUri = deepLink,
+                    )
+                )
             }
             "inquiry" -> {
                 val deepLink = customDeepLink ?: run {
@@ -71,6 +87,13 @@ class HustleHubMessagingService : FirebaseMessagingService() {
                     }
                 }
                 NotificationHelper.postInquiryNotification(this, title, body, deepLink)
+                InAppBannerManager.postBanner(
+                    InAppBannerData(
+                        title = title,
+                        body = body,
+                        deepLinkUri = deepLink,
+                    )
+                )
             }
             else -> {
                 Timber.d("Received unknown FCM message type: $type")

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/HustleHubMessagingService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/HustleHubMessagingService.kt
@@ -36,6 +36,8 @@ class HustleHubMessagingService : FirebaseMessagingService() {
         val title = remoteMessage.data["title"] ?: remoteMessage.notification?.title ?: "HustleHub"
         val body = remoteMessage.data["body"] ?: remoteMessage.notification?.body ?: ""
 
+        val customDeepLink = remoteMessage.data["deepLink"] ?: remoteMessage.data["targetUri"]
+
         when (type) {
             "new_message" -> {
                 val conversationId = remoteMessage.data["conversationId"] ?: return
@@ -46,10 +48,29 @@ class HustleHubMessagingService : FirebaseMessagingService() {
                 NotificationHelper.postMessageNotification(this, conversationId, senderName, content)
             }
             "new_review" -> {
-                NotificationHelper.postReviewNotification(this, title, body)
+                val deepLink = customDeepLink ?: run {
+                    val serviceId = remoteMessage.data["serviceId"]
+                    val providerId = remoteMessage.data["providerId"]
+                    if (!serviceId.isNullOrBlank() && !providerId.isNullOrBlank()) {
+                        "hustlehub://review/$serviceId?providerId=$providerId"
+                    } else if (!serviceId.isNullOrBlank()) {
+                        "hustlehub://service/$serviceId"
+                    } else {
+                        "hustlehub://notifications"
+                    }
+                }
+                NotificationHelper.postReviewNotification(this, title, body, deepLink)
             }
             "inquiry" -> {
-                NotificationHelper.postInquiryNotification(this, title, body)
+                val deepLink = customDeepLink ?: run {
+                    val conversationId = remoteMessage.data["conversationId"]
+                    if (!conversationId.isNullOrBlank()) {
+                        "hustlehub://chat/$conversationId"
+                    } else {
+                        "hustlehub://notifications"
+                    }
+                }
+                NotificationHelper.postInquiryNotification(this, title, body, deepLink)
             }
             else -> {
                 Timber.d("Received unknown FCM message type: $type")

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/HustleHubMessagingService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/HustleHubMessagingService.kt
@@ -27,8 +27,6 @@ class HustleHubMessagingService : FirebaseMessagingService() {
         }
     }
 
-
-
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         super.onMessageReceived(remoteMessage)
 
@@ -53,7 +51,7 @@ class HustleHubMessagingService : FirebaseMessagingService() {
                         senderPhotoUrl = remoteMessage.data["senderPhotoUrl"],
                         conversationId = conversationId,
                         deepLinkUri = "hustlehub://chat/$conversationId",
-                    )
+                    ),
                 )
             }
             "new_review" -> {
@@ -74,7 +72,7 @@ class HustleHubMessagingService : FirebaseMessagingService() {
                         title = title,
                         body = body,
                         deepLinkUri = deepLink,
-                    )
+                    ),
                 )
             }
             "inquiry" -> {
@@ -92,7 +90,7 @@ class HustleHubMessagingService : FirebaseMessagingService() {
                         title = title,
                         body = body,
                         deepLinkUri = deepLink,
-                    )
+                    ),
                 )
             }
             else -> {

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/HustleHubMessagingService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/HustleHubMessagingService.kt
@@ -1,5 +1,7 @@
 package must.kdroiders.hustlehub.core.notification
 
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,9 +20,14 @@ class HustleHubMessagingService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         CoroutineScope(Dispatchers.IO).launch {
-            userRepository.updateFcmToken(token)
+            val currentUser = runCatching { Firebase.auth.currentUser }.getOrNull()
+            if (currentUser != null) {
+                userRepository.updateFcmToken(token)
+            }
         }
     }
+
+
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         super.onMessageReceived(remoteMessage)

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/InAppBannerData.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/InAppBannerData.kt
@@ -1,0 +1,12 @@
+package must.kdroiders.hustlehub.core.notification
+
+import java.util.UUID
+
+data class InAppBannerData(
+    val id: String = UUID.randomUUID().toString(),
+    val title: String,
+    val body: String,
+    val senderPhotoUrl: String? = null,
+    val conversationId: String? = null,
+    val deepLinkUri: String? = null,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/InAppBannerManager.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/InAppBannerManager.kt
@@ -1,0 +1,45 @@
+package must.kdroiders.hustlehub.core.notification
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+object InAppBannerManager {
+    private val queue = ArrayDeque<InAppBannerData>()
+    private val _activeBanner = MutableStateFlow<InAppBannerData?>(null)
+    val activeBanner: StateFlow<InAppBannerData?> = _activeBanner.asStateFlow()
+
+    fun postBanner(banner: InAppBannerData) {
+        // Skip if user is actively viewing that specific conversation screen
+        if (!banner.conversationId.isNullOrBlank() &&
+            banner.conversationId == ActiveConversationTracker.activeConversationId
+        ) {
+            return
+        }
+
+        synchronized(queue) {
+            if (_activeBanner.value == null) {
+                _activeBanner.value = banner
+            } else {
+                queue.addLast(banner)
+            }
+        }
+    }
+
+    fun dismissCurrentBanner() {
+        synchronized(queue) {
+            if (queue.isNotEmpty()) {
+                _activeBanner.value = queue.removeFirst()
+            } else {
+                _activeBanner.value = null
+            }
+        }
+    }
+
+    fun clearQueue() {
+        synchronized(queue) {
+            queue.clear()
+            _activeBanner.value = null
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/InAppNotificationBanner.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/InAppNotificationBanner.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -36,7 +35,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.customActions
@@ -102,10 +100,9 @@ fun InAppNotificationBanner(
                             CustomAccessibilityAction("Dismiss notification") {
                                 onDismiss()
                                 true
-                            }
+                            },
                         )
-                    }
-                    .clickable { onTap(currentBanner) },
+                    }.clickable { onTap(currentBanner) },
                 colors = CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                 ),

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/InAppNotificationBanner.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/InAppNotificationBanner.kt
@@ -1,0 +1,177 @@
+package must.kdroiders.hustlehub.core.notification
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import kotlinx.coroutines.delay
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InAppNotificationBanner(
+    banner: InAppBannerData?,
+    onTap: (InAppBannerData) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = banner != null,
+        enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+        exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut(),
+        modifier = modifier,
+    ) {
+        val currentBanner = banner ?: return@AnimatedVisibility
+
+        LaunchedEffect(currentBanner.id) {
+            delay(4000L)
+            onDismiss()
+        }
+
+        val dismissState = rememberSwipeToDismissBoxState(
+            confirmValueChange = { dismissValue ->
+                if (dismissValue == SwipeToDismissBoxValue.StartToEnd || dismissValue == SwipeToDismissBoxValue.EndToStart) {
+                    onDismiss()
+                    true
+                } else {
+                    false
+                }
+            },
+        )
+
+        SwipeToDismissBox(
+            state = dismissState,
+            backgroundContent = {},
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(16.dp))
+                    .semantics(mergeDescendants = true) {
+                        role = Role.Button
+                        onClick(label = "Open notification") {
+                            onTap(currentBanner)
+                            true
+                        }
+                        customActions = listOf(
+                            CustomAccessibilityAction("Dismiss notification") {
+                                onDismiss()
+                                true
+                            }
+                        )
+                    }
+                    .clickable { onTap(currentBanner) },
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+            ) {
+                Row(
+                    modifier = Modifier.padding(14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (!currentBanner.senderPhotoUrl.isNullOrBlank()) {
+                        AsyncImage(
+                            model = currentBanner.senderPhotoUrl,
+                            contentDescription = "Sender profile photo",
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape),
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.primaryContainer),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.Chat,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = currentBanner.title,
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = "HustleHub",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = currentBanner.body,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/core/notification/NotificationHelper.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/core/notification/NotificationHelper.kt
@@ -49,7 +49,7 @@ object NotificationHelper {
         try {
             val intent = Intent(context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                data = Uri.parse("hustlehub://app/chat?conversationId=$conversationId")
+                data = Uri.parse("hustlehub://chat/$conversationId")
             }
             val pendingIntent = PendingIntent.getActivity(
                 context,
@@ -80,11 +80,12 @@ object NotificationHelper {
         context: Context,
         title: String,
         body: String,
+        deepLinkUri: String = "hustlehub://notifications",
     ) {
         try {
             val intent = Intent(context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                data = Uri.parse("hustlehub://app/profile")
+                data = Uri.parse(deepLinkUri)
             }
             val pendingIntent = PendingIntent.getActivity(
                 context,
@@ -115,11 +116,12 @@ object NotificationHelper {
         context: Context,
         title: String,
         body: String,
+        deepLinkUri: String = "hustlehub://notifications",
     ) {
         try {
             val intent = Intent(context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                data = Uri.parse("hustlehub://app/inquiries")
+                data = Uri.parse(deepLinkUri)
             }
             val pendingIntent = PendingIntent.getActivity(
                 context,

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -48,7 +48,6 @@ import timber.log.Timber
 import javax.inject.Provider
 import javax.inject.Singleton
 
-
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
@@ -78,8 +77,6 @@ object AppModule {
             NoopAuthRepository()
         }
     }
-
-
 
     @Provides
     @Singleton
@@ -230,4 +227,3 @@ private class NoopAuthRepository : AuthRepository {
 
     override suspend fun logout() {}
 }
-

--- a/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/di/AppModule.kt
@@ -45,7 +45,9 @@ import must.kdroiders.hustlehub.ui.features.service.data.repository.ServiceRepos
 import must.kdroiders.hustlehub.ui.features.service.domain.repository.ReviewRepository
 import must.kdroiders.hustlehub.ui.features.service.domain.repository.ServiceRepository
 import timber.log.Timber
+import javax.inject.Provider
 import javax.inject.Singleton
+
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -66,13 +68,18 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideAuthRepository(firebaseAuth: FirebaseAuth?): AuthRepository {
+    fun provideAuthRepository(
+        firebaseAuth: FirebaseAuth?,
+        userRepositoryProvider: Provider<UserRepository>,
+    ): AuthRepository {
         return if (firebaseAuth != null) {
-            AuthRepositoryImpl(firebaseAuth)
+            AuthRepositoryImpl(firebaseAuth, userRepositoryProvider)
         } else {
             NoopAuthRepository()
         }
     }
+
+
 
     @Provides
     @Singleton
@@ -221,5 +228,6 @@ private class NoopAuthRepository : AuthRepository {
 
     override fun getCurrentUser() = null
 
-    override fun logout() {}
+    override suspend fun logout() {}
 }
+

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/BottomNavigationBar.kt
@@ -80,7 +80,7 @@ private val bottomTabs = listOf(
 fun HustleBottomBar(
     currentKey: NavKey,
     onTabSelected: (NavKey) -> Unit,
-    totalUnreadCount: Int = 1,
+    unreadMessageCount: Int = 0,
     modifier: Modifier = Modifier,
 ) {
     NavigationBar(
@@ -96,12 +96,12 @@ fun HustleBottomBar(
                 onClick = { onTabSelected(item.key) },
                 icon = {
                     val isChatTab = item.key == BottomChat
-                    if (isChatTab && totalUnreadCount > 0) {
+                    if (isChatTab && unreadMessageCount > 0) {
                         BadgedBox(
                             badge = {
                                 Badge {
                                     Text(
-                                        text = if (totalUnreadCount > 99) "99+" else totalUnreadCount.toString(),
+                                        text = if (unreadMessageCount > 99) "99+" else unreadMessageCount.toString(),
                                     )
                                 }
                             },

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -108,25 +108,36 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
 
     LaunchedEffect(mainNavigationViewModel) {
         mainNavigationViewModel?.deepLinkEvent?.collect { action ->
-            if (action is DeepLinkAction.OpenChat) {
-                val currentTop = backstack.lastOrNull()
-                if (currentTop is ChatDetail && currentTop.chatId == action.conversationId) {
-                    return@collect
+            if (backstack.none { it is MainShell }) {
+                backstack.clear()
+                backstack.add(MainShell)
+            }
+            when (action) {
+                is DeepLinkAction.OpenChat -> {
+                    val currentTop = backstack.lastOrNull()
+                    if (currentTop is ChatDetail && currentTop.chatId == action.conversationId) return@collect
+                    backstack.add(ChatDetail(chatId = action.conversationId))
                 }
-                // Make sure MainShell is present under ChatDetail
-                if (backstack.none { it is MainShell }) {
-                    backstack.clear()
-                    backstack.add(MainShell)
+                is DeepLinkAction.OpenServiceDetail -> {
+                    val currentTop = backstack.lastOrNull()
+                    if (currentTop is ServiceDetail && currentTop.serviceId == action.serviceId) return@collect
+                    backstack.add(ServiceDetail(serviceId = action.serviceId))
                 }
-                backstack.add(ChatDetail(chatId = action.conversationId))
-            } else {
-                // For other actions (OpenProfile, OpenChatList), make sure we return to MainShell
-                if (backstack.none { it is MainShell }) {
-                    backstack.clear()
-                    backstack.add(MainShell)
-                } else {
-                    // Pop any detail screens on top of MainShell
-                    while (backstack.isNotEmpty() && backstack.last() != MainShell) {
+                is DeepLinkAction.OpenProviderProfile -> {
+                    val currentTop = backstack.lastOrNull()
+                    if (currentTop is ProviderProfile && currentTop.providerId == action.providerId) return@collect
+                    backstack.add(ProviderProfile(providerId = action.providerId))
+                }
+                is DeepLinkAction.OpenWriteReview -> {
+                    backstack.add(WriteReview(serviceId = action.serviceId, providerId = action.providerId))
+                }
+                is DeepLinkAction.OpenNotifications -> {
+                    if (backstack.lastOrNull() !is Notifications) {
+                        backstack.add(Notifications)
+                    }
+                }
+                is DeepLinkAction.OpenProfile, is DeepLinkAction.OpenChatList -> {
+                    while (backstack.size > 1 && backstack.last() != MainShell) {
                         backstack.remove(backstack.last())
                     }
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -159,284 +159,284 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
         NavDisplay(
             backStack = backstack,
             onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-        transitionSpec = {
-            (slideInHorizontally(slideSpec) { it } + fadeIn(fadeSpec)) togetherWith
-                (slideOutHorizontally(slideSpec) { -it } + fadeOut(fadeSpec))
-        },
-        popTransitionSpec = {
-            (slideInHorizontally(slideSpec) { -it } + fadeIn(fadeSpec)) togetherWith
-                (slideOutHorizontally(slideSpec) { it } + fadeOut(fadeSpec))
-        },
-        entryProvider = entryProvider {
-            // Splash
-            entry<Splash> {
-                SplashScreen(
-                    onNavigate = { destination ->
-                        val key: NavKey = when (destination) {
-                            SplashDestination.Home -> MainShell
-                            SplashDestination.Login -> Login()
-                            SplashDestination.Onboarding -> Onboarding
-                            SplashDestination.ProfileSetup -> ProfileSetup
-                        }
-                        backstack.clear()
-                        backstack.add(key)
-                    },
-                )
-            }
-
-            // Auth
-            entry<Login> { key ->
-                val context = LocalContext.current
-                val activity = context as? ComponentActivity
-                val loginViewModel: LoginViewModel = if (activity != null) {
-                    hiltViewModel(viewModelStoreOwner = activity)
-                } else {
-                    hiltViewModel()
+            transitionSpec = {
+                (slideInHorizontally(slideSpec) { it } + fadeIn(fadeSpec)) togetherWith
+                    (slideOutHorizontally(slideSpec) { -it } + fadeOut(fadeSpec))
+            },
+            popTransitionSpec = {
+                (slideInHorizontally(slideSpec) { -it } + fadeIn(fadeSpec)) togetherWith
+                    (slideOutHorizontally(slideSpec) { it } + fadeOut(fadeSpec))
+            },
+            entryProvider = entryProvider {
+                // Splash
+                entry<Splash> {
+                    SplashScreen(
+                        onNavigate = { destination ->
+                            val key: NavKey = when (destination) {
+                                SplashDestination.Home -> MainShell
+                                SplashDestination.Login -> Login()
+                                SplashDestination.Onboarding -> Onboarding
+                                SplashDestination.ProfileSetup -> ProfileSetup
+                            }
+                            backstack.clear()
+                            backstack.add(key)
+                        },
+                    )
                 }
 
-                // Observe Google sign-in navigation events from the shared ViewModel
-                LaunchedEffect(loginViewModel) {
-                    loginViewModel.navigateToHome.collect { _ ->
-                        backstack.clear()
-                        backstack.add(MainShell)
+                // Auth
+                entry<Login> { key ->
+                    val context = LocalContext.current
+                    val activity = context as? ComponentActivity
+                    val loginViewModel: LoginViewModel = if (activity != null) {
+                        hiltViewModel(viewModelStoreOwner = activity)
+                    } else {
+                        hiltViewModel()
+                    }
+
+                    // Observe Google sign-in navigation events from the shared ViewModel
+                    LaunchedEffect(loginViewModel) {
+                        loginViewModel.navigateToHome.collect { _ ->
+                            backstack.clear()
+                            backstack.add(MainShell)
+                        }
+                    }
+
+                    LoginScreen(
+                        prefilledEmail = key.email,
+                        onLoginSuccess = { _ ->
+                            backstack.clear()
+                            backstack.add(MainShell)
+                        },
+                        onNavigateToSignUp = {
+                            backstack.add(SignUp)
+                        },
+                        onNavigateToEmailVerification = { email ->
+                            backstack.add(EmailVerification(email = email))
+                        },
+                        onGoogleSignInClick = onGoogleSignInClick,
+                        loginViewModel = loginViewModel,
+                    )
+                }
+
+                entry<EmailVerification> { key ->
+                    EmailVerificationScreen(
+                        email = key.email,
+                        onVerified = {
+                            backstack.clear()
+                            backstack.add(Login(email = key.email))
+                        },
+                    )
+                }
+
+                entry<SignUp> {
+                    SignUpScreen(
+                        onNavigateToLogin = {
+                            if (backstack.isNotEmpty()) backstack.remove(backstack.last())
+                            if (backstack.isEmpty()) backstack.add(Login())
+                        },
+                        onSignUpSuccess = { email ->
+                            backstack.add(EmailVerification(email = email))
+                        },
+                        onGoogleSignInClick = onGoogleSignInClick,
+                    )
+                }
+
+                // Onboarding
+                entry<Onboarding> {
+                    OnboardingScreen(
+                        onFinished = {
+                            backstack.clear()
+                            backstack.add(Login())
+                        },
+                    )
+                }
+
+                // Profile setup
+                entry<ProfileSetup> {
+                    ProfileSetupScreen(
+                        onSetupComplete = {
+                            backstack.clear()
+                            backstack.add(MainShell)
+                        },
+                    )
+                }
+
+                // Main shell
+                entry<MainShell> {
+                    MainShellScreen(
+                        onNavigateToProfileSetup = { backstack.add(ProfileSetup) },
+                        onNavigateToSettings = { backstack.add(Settings) },
+                        onNavigateToCreateService = { backstack.add(CreateService()) },
+                        onNavigateToMyServices = { backstack.add(MyServices) },
+                        onNavigateToEditService = { serviceId -> backstack.add(CreateService(serviceId = serviceId)) },
+                        onNavigateToChatDetail = { chatId -> backstack.add(ChatDetail(chatId = chatId)) },
+                        onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                        onNavigateToSearch = { backstack.add(must.kdroiders.hustlehub.navigation.SearchScreen) },
+                        onNavigateToAiSearch = { backstack.add(must.kdroiders.hustlehub.navigation.AiSearchScreen) },
+                        onNavigateToEditProfile = { backstack.add(EditProfile) },
+                        onNavigateToNotifications = { backstack.add(Notifications) },
+                    )
+                }
+
+                entry<Settings> {
+                    SettingsScreen(
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onNavigateToChangePassword = { backstack.add(ChangePassword) },
+                        onNavigateToNotificationPreferences = { backstack.add(NotificationPreferences) },
+                    )
+                }
+
+                entry<ChangePassword> {
+                    ChangePasswordScreen(
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    )
+                }
+
+                entry<NotificationPreferences> {
+                    NotificationPreferencesScreen(
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    )
+                }
+
+                // Create / Edit service
+                entry<CreateService> { key ->
+                    CreateServiceScreen(
+                        serviceId = key.serviceId,
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onSuccess = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    )
+                }
+
+                // My services management
+                entry<MyServices> {
+                    MyServicesScreen(
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onCreateService = { backstack.add(CreateService()) },
+                        onEditService = { serviceId -> backstack.add(CreateService(serviceId = serviceId)) },
+                    )
+                }
+
+                entry<ChatDetail> { key ->
+                    ChatDetailScreen(
+                        conversationId = key.chatId,
+                        serviceId = key.serviceId,
+                        serviceTitle = key.serviceTitle,
+                        serviceCategory = key.serviceCategory,
+                        servicePriceRange = key.servicePriceRange,
+                        providerName = key.providerName,
+                        onBackClick = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                        onNavigateToWriteReview = { serviceId, providerId ->
+                            backstack.add(WriteReview(serviceId = serviceId, providerId = providerId))
+                        },
+                    )
+                }
+
+                // Service detail — full provider profile, portfolio and reviews.
+                entry<ServiceDetail> { key ->
+                    ServiceDetailScreen(
+                        serviceId = key.serviceId,
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onNavigateToChat = { providerId, serviceId, title, category, priceRange, providerName ->
+                            backstack.add(
+                                ChatDetail(
+                                    chatId = providerId,
+                                    serviceId = serviceId,
+                                    serviceTitle = title,
+                                    serviceCategory = category,
+                                    servicePriceRange = priceRange,
+                                    providerName = providerName,
+                                ),
+                            )
+                        },
+                        onNavigateToProviderProfile = { providerId -> backstack.add(ProviderProfile(providerId = providerId)) },
+                        onNavigateToWriteReview = { serviceId, providerId ->
+                            backstack.add(WriteReview(serviceId = serviceId, providerId = providerId))
+                        },
+                        onNavigateToAllReviews = { serviceId ->
+                            backstack.add(AllReviews(serviceId = serviceId))
+                        },
+                    )
+                }
+
+                // All reviews
+                entry<AllReviews> { key ->
+                    AllReviewsScreen(
+                        serviceId = key.serviceId,
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    )
+                }
+
+                // Provider public profile
+                entry<ProviderProfile> { key ->
+                    ProviderProfileScreen(
+                        providerId = key.providerId,
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onNavigateToChat = { providerId -> backstack.add(ChatDetail(chatId = providerId)) },
+                        onNavigateToEditProfile = { backstack.add(EditProfile) },
+                        onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                    )
+                }
+
+                // Edit own profile
+                entry<EditProfile> {
+                    EditProfileScreen(
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onSaveSuccess = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    )
+                }
+
+                // Write review
+                entry<WriteReview> { key ->
+                    WriteReviewScreen(
+                        serviceId = key.serviceId,
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onSubmitSuccess = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    )
+                }
+
+                entry<must.kdroiders.hustlehub.navigation.SearchScreen> {
+                    SearchScreen(
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                        onNavigateToChat = { providerId -> backstack.add(ChatDetail(chatId = providerId)) },
+                    )
+                }
+
+                entry<must.kdroiders.hustlehub.navigation.AiSearchScreen> {
+                    AiSearchScreen(
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                        onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
+                    )
+                }
+
+                entry<Notifications> {
+                    NotificationScreen(
+                        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                    )
+                }
+            },
+        )
+
+        InAppNotificationBanner(
+            banner = activeBanner,
+            onTap = { banner ->
+                InAppBannerManager.dismissCurrentBanner()
+                if (!banner.conversationId.isNullOrBlank()) {
+                    mainNavigationViewModel?.triggerDeepLink(DeepLinkAction.OpenChat(banner.conversationId))
+                } else if (!banner.deepLinkUri.isNullOrBlank()) {
+                    val uri = Uri.parse(banner.deepLinkUri)
+                    val intent = Intent(Intent.ACTION_VIEW, uri)
+                    activity?.let {
+                        it.intent = intent
                     }
                 }
-
-                LoginScreen(
-                    prefilledEmail = key.email,
-                    onLoginSuccess = { _ ->
-                        backstack.clear()
-                        backstack.add(MainShell)
-                    },
-                    onNavigateToSignUp = {
-                        backstack.add(SignUp)
-                    },
-                    onNavigateToEmailVerification = { email ->
-                        backstack.add(EmailVerification(email = email))
-                    },
-                    onGoogleSignInClick = onGoogleSignInClick,
-                    loginViewModel = loginViewModel,
-                )
-            }
-
-            entry<EmailVerification> { key ->
-                EmailVerificationScreen(
-                    email = key.email,
-                    onVerified = {
-                        backstack.clear()
-                        backstack.add(Login(email = key.email))
-                    },
-                )
-            }
-
-            entry<SignUp> {
-                SignUpScreen(
-                    onNavigateToLogin = {
-                        if (backstack.isNotEmpty()) backstack.remove(backstack.last())
-                        if (backstack.isEmpty()) backstack.add(Login())
-                    },
-                    onSignUpSuccess = { email ->
-                        backstack.add(EmailVerification(email = email))
-                    },
-                    onGoogleSignInClick = onGoogleSignInClick,
-                )
-            }
-
-            // Onboarding
-            entry<Onboarding> {
-                OnboardingScreen(
-                    onFinished = {
-                        backstack.clear()
-                        backstack.add(Login())
-                    },
-                )
-            }
-
-            // Profile setup
-            entry<ProfileSetup> {
-                ProfileSetupScreen(
-                    onSetupComplete = {
-                        backstack.clear()
-                        backstack.add(MainShell)
-                    },
-                )
-            }
-
-            // Main shell
-            entry<MainShell> {
-                MainShellScreen(
-                    onNavigateToProfileSetup = { backstack.add(ProfileSetup) },
-                    onNavigateToSettings = { backstack.add(Settings) },
-                    onNavigateToCreateService = { backstack.add(CreateService()) },
-                    onNavigateToMyServices = { backstack.add(MyServices) },
-                    onNavigateToEditService = { serviceId -> backstack.add(CreateService(serviceId = serviceId)) },
-                    onNavigateToChatDetail = { chatId -> backstack.add(ChatDetail(chatId = chatId)) },
-                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
-                    onNavigateToSearch = { backstack.add(must.kdroiders.hustlehub.navigation.SearchScreen) },
-                    onNavigateToAiSearch = { backstack.add(must.kdroiders.hustlehub.navigation.AiSearchScreen) },
-                    onNavigateToEditProfile = { backstack.add(EditProfile) },
-                    onNavigateToNotifications = { backstack.add(Notifications) },
-                )
-            }
-
-            entry<Settings> {
-                SettingsScreen(
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onNavigateToChangePassword = { backstack.add(ChangePassword) },
-                    onNavigateToNotificationPreferences = { backstack.add(NotificationPreferences) },
-                )
-            }
-
-            entry<ChangePassword> {
-                ChangePasswordScreen(
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                )
-            }
-
-            entry<NotificationPreferences> {
-                NotificationPreferencesScreen(
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                )
-            }
-
-            // Create / Edit service
-            entry<CreateService> { key ->
-                CreateServiceScreen(
-                    serviceId = key.serviceId,
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onSuccess = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                )
-            }
-
-            // My services management
-            entry<MyServices> {
-                MyServicesScreen(
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onCreateService = { backstack.add(CreateService()) },
-                    onEditService = { serviceId -> backstack.add(CreateService(serviceId = serviceId)) },
-                )
-            }
-
-            entry<ChatDetail> { key ->
-                ChatDetailScreen(
-                    conversationId = key.chatId,
-                    serviceId = key.serviceId,
-                    serviceTitle = key.serviceTitle,
-                    serviceCategory = key.serviceCategory,
-                    servicePriceRange = key.servicePriceRange,
-                    providerName = key.providerName,
-                    onBackClick = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
-                    onNavigateToWriteReview = { serviceId, providerId ->
-                        backstack.add(WriteReview(serviceId = serviceId, providerId = providerId))
-                    },
-                )
-            }
-
-            // Service detail — full provider profile, portfolio and reviews.
-            entry<ServiceDetail> { key ->
-                ServiceDetailScreen(
-                    serviceId = key.serviceId,
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onNavigateToChat = { providerId, serviceId, title, category, priceRange, providerName ->
-                        backstack.add(
-                            ChatDetail(
-                                chatId = providerId,
-                                serviceId = serviceId,
-                                serviceTitle = title,
-                                serviceCategory = category,
-                                servicePriceRange = priceRange,
-                                providerName = providerName,
-                            ),
-                        )
-                    },
-                    onNavigateToProviderProfile = { providerId -> backstack.add(ProviderProfile(providerId = providerId)) },
-                    onNavigateToWriteReview = { serviceId, providerId ->
-                        backstack.add(WriteReview(serviceId = serviceId, providerId = providerId))
-                    },
-                    onNavigateToAllReviews = { serviceId ->
-                        backstack.add(AllReviews(serviceId = serviceId))
-                    },
-                )
-            }
-
-            // All reviews
-            entry<AllReviews> { key ->
-                AllReviewsScreen(
-                    serviceId = key.serviceId,
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                )
-            }
-
-            // Provider public profile
-            entry<ProviderProfile> { key ->
-                ProviderProfileScreen(
-                    providerId = key.providerId,
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onNavigateToChat = { providerId -> backstack.add(ChatDetail(chatId = providerId)) },
-                    onNavigateToEditProfile = { backstack.add(EditProfile) },
-                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
-                )
-            }
-
-            // Edit own profile
-            entry<EditProfile> {
-                EditProfileScreen(
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onSaveSuccess = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                )
-            }
-
-            // Write review
-            entry<WriteReview> { key ->
-                WriteReviewScreen(
-                    serviceId = key.serviceId,
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onSubmitSuccess = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                )
-            }
-
-            entry<must.kdroiders.hustlehub.navigation.SearchScreen> {
-                SearchScreen(
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
-                    onNavigateToChat = { providerId -> backstack.add(ChatDetail(chatId = providerId)) },
-                )
-            }
-
-            entry<must.kdroiders.hustlehub.navigation.AiSearchScreen> {
-                AiSearchScreen(
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                    onNavigateToServiceDetail = { serviceId -> backstack.add(ServiceDetail(serviceId = serviceId)) },
-                )
-            }
-
-            entry<Notifications> {
-                NotificationScreen(
-                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
-                )
-            }
-        },
-    )
-
-    InAppNotificationBanner(
-        banner = activeBanner,
-        onTap = { banner ->
-            InAppBannerManager.dismissCurrentBanner()
-            if (!banner.conversationId.isNullOrBlank()) {
-                mainNavigationViewModel?.triggerDeepLink(DeepLinkAction.OpenChat(banner.conversationId))
-            } else if (!banner.deepLinkUri.isNullOrBlank()) {
-                val uri = Uri.parse(banner.deepLinkUri)
-                val intent = Intent(Intent.ACTION_VIEW, uri)
-                activity?.let {
-                    it.intent = intent
-                }
-            }
-        },
-        onDismiss = {
-            InAppBannerManager.dismissCurrentBanner()
-        },
-        modifier = Modifier.align(Alignment.TopCenter),
-    )
+            },
+            onDismiss = {
+                InAppBannerManager.dismissCurrentBanner()
+            },
+            modifier = Modifier.align(Alignment.TopCenter),
+        )
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -1,17 +1,23 @@
 package must.kdroiders.hustlehub.navigation
 
+import android.content.Intent
+import android.net.Uri
 import androidx.activity.ComponentActivity
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -20,6 +26,8 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import must.kdroiders.hustlehub.core.auth.AuthStateViewModel
+import must.kdroiders.hustlehub.core.notification.InAppBannerManager
+import must.kdroiders.hustlehub.core.notification.InAppNotificationBanner
 import must.kdroiders.hustlehub.navigation.AllReviews
 import must.kdroiders.hustlehub.onboarding.OnboardingScreen
 import must.kdroiders.hustlehub.splash.SplashDestination
@@ -145,9 +153,12 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
         }
     }
 
-    NavDisplay(
-        backStack = backstack,
-        onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+    val activeBanner by InAppBannerManager.activeBanner.collectAsState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        NavDisplay(
+            backStack = backstack,
+            onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
         transitionSpec = {
             (slideInHorizontally(slideSpec) { it } + fadeIn(fadeSpec)) togetherWith
                 (slideOutHorizontally(slideSpec) { -it } + fadeOut(fadeSpec))
@@ -407,4 +418,25 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
             }
         },
     )
+
+    InAppNotificationBanner(
+        banner = activeBanner,
+        onTap = { banner ->
+            InAppBannerManager.dismissCurrentBanner()
+            if (!banner.conversationId.isNullOrBlank()) {
+                mainNavigationViewModel?.triggerDeepLink(DeepLinkAction.OpenChat(banner.conversationId))
+            } else if (!banner.deepLinkUri.isNullOrBlank()) {
+                val uri = Uri.parse(banner.deepLinkUri)
+                val intent = Intent(Intent.ACTION_VIEW, uri)
+                activity?.let {
+                    it.intent = intent
+                }
+            }
+        },
+        onDismiss = {
+            InAppBannerManager.dismissCurrentBanner()
+        },
+        modifier = Modifier.align(Alignment.TopCenter),
+    )
+    }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleHubNavGraph.kt
@@ -33,6 +33,7 @@ import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.LoginVie
 import must.kdroiders.hustlehub.ui.features.chat.presentation.view.ChatDetailScreen
 import must.kdroiders.hustlehub.ui.features.home.presentation.view.AiSearchScreen
 import must.kdroiders.hustlehub.ui.features.home.presentation.view.SearchScreen
+import must.kdroiders.hustlehub.ui.features.notification.presentation.view.NotificationPreferencesScreen
 import must.kdroiders.hustlehub.ui.features.notification.presentation.view.NotificationScreen
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.EditProfileScreen
 import must.kdroiders.hustlehub.ui.features.profile.presentation.view.ProviderProfileScreen
@@ -260,11 +261,18 @@ fun HustleHubNav(onGoogleSignInClick: () -> Unit) {
                 SettingsScreen(
                     onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
                     onNavigateToChangePassword = { backstack.add(ChangePassword) },
+                    onNavigateToNotificationPreferences = { backstack.add(NotificationPreferences) },
                 )
             }
 
             entry<ChangePassword> {
                 ChangePasswordScreen(
+                    onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
+                )
+            }
+
+            entry<NotificationPreferences> {
+                NotificationPreferencesScreen(
                     onBack = { if (backstack.size > 1) backstack.remove(backstack.last()) },
                 )
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
@@ -148,4 +148,3 @@ data class AllReviews(val serviceId: String) : NavKey
 /** Notification preferences screen — pushed from SettingsScreen. */
 @Serializable
 data object NotificationPreferences : NavKey
-

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/HustleNavKeys.kt
@@ -144,3 +144,8 @@ data object Notifications : NavKey
 /** All reviews screen for a specific service. */
 @Serializable
 data class AllReviews(val serviceId: String) : NavKey
+
+/** Notification preferences screen — pushed from SettingsScreen. */
+@Serializable
+data object NotificationPreferences : NavKey
+

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/MainNavigationViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/MainNavigationViewModel.kt
@@ -9,6 +9,10 @@ import javax.inject.Inject
 
 sealed interface DeepLinkAction {
     data class OpenChat(val conversationId: String) : DeepLinkAction
+    data class OpenServiceDetail(val serviceId: String) : DeepLinkAction
+    data class OpenProviderProfile(val providerId: String) : DeepLinkAction
+    data class OpenWriteReview(val serviceId: String, val providerId: String) : DeepLinkAction
+    data object OpenNotifications : DeepLinkAction
     data object OpenProfile : DeepLinkAction
     data object OpenChatList : DeepLinkAction
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
@@ -78,8 +78,9 @@ fun MainShellScreen(
                     innerBackstack.clear()
                     innerBackstack.add(BottomChat)
                 }
-                is DeepLinkAction.OpenChat -> {
-                    // Handled at the root graph level (HustleHubNavGraph)
+                else -> {
+                    // OpenChat, OpenServiceDetail, OpenProviderProfile, OpenWriteReview, OpenNotifications
+                    // are handled at the root graph level (HustleHubNavGraph)
                 }
             }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/navigation/MainScaffold.kt
@@ -89,16 +89,16 @@ fun MainShellScreen(
     // The currently active tab key is always the last element.
     val currentKey = innerBackstack.lastOrNull() ?: BottomHome
 
-    // Observe the total unread count reactively — zero allocation per recomposition.
+    // Observe unread chat message count reactively for bottom bar badge
     val unreadCountViewModel: UnreadCountViewModel = hiltViewModel()
-    val totalUnreadCount by unreadCountViewModel.totalUnreadCount.collectAsState(initial = 0)
+    val unreadMessageCount by unreadCountViewModel.unreadMessageCount.collectAsState(initial = 0)
 
     Scaffold(
         modifier = modifier,
         bottomBar = {
             HustleBottomBar(
                 currentKey = currentKey,
-                totalUnreadCount = totalUnreadCount,
+                unreadMessageCount = unreadMessageCount,
                 onTabSelected = { destination ->
                     // Replace entire stack with the selected tab (no accumulation).
                     innerBackstack.clear()

--- a/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -39,6 +40,9 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -125,13 +129,16 @@ fun OnboardingScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 if (!isFirstPage) {
-                    TextButton(onClick = {
+                    TextButton(
+                        onClick = {
                         scope.launch {
                             pagerState.animateScrollToPage(
                                 pagerState.currentPage - 1,
                             )
                         }
-                    }) {
+                    },
+                        modifier = Modifier.minimumInteractiveComponentSize(),
+                        ) {
                         Text(
                             "Back",
                             color = MaterialTheme.colorScheme
@@ -143,7 +150,10 @@ fun OnboardingScreen(
                 }
 
                 if (!isLastPage) {
-                    TextButton(onClick = onComplete) {
+                    TextButton(
+                        onClick = onComplete,
+                        modifier = Modifier.minimumInteractiveComponentSize(),
+                    ) {
                         Text(
                             "Skip",
                             color = MaterialTheme.colorScheme
@@ -190,6 +200,7 @@ fun OnboardingScreen(
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme
                                 .onSurface,
+                            modifier = Modifier.semantics { heading() },
                         )
                         Text(
                             text = slide.titleHighlight,
@@ -315,7 +326,9 @@ private fun PageIndicator(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier.semantics {
+            contentDescription = "Page ${pagerState.currentPage + 1} of $pageCount"
+        },
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
@@ -131,14 +131,14 @@ fun OnboardingScreen(
                 if (!isFirstPage) {
                     TextButton(
                         onClick = {
-                        scope.launch {
-                            pagerState.animateScrollToPage(
-                                pagerState.currentPage - 1,
-                            )
-                        }
-                    },
+                            scope.launch {
+                                pagerState.animateScrollToPage(
+                                    pagerState.currentPage - 1,
+                                )
+                            }
+                        },
                         modifier = Modifier.minimumInteractiveComponentSize(),
-                        ) {
+                    ) {
                         Text(
                             "Back",
                             color = MaterialTheme.colorScheme

--- a/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/onboarding/OnboardingScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.sharedComposables.HustleButton
 import must.kdroiders.hustlehub.ui.theme.HustleHubTheme

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/EmptyStateView.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/EmptyStateView.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -66,6 +68,7 @@ fun EmptyStateView(
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
 
         Spacer(Modifier.height(10.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/ErrorView.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/ErrorView.kt
@@ -19,6 +19,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -36,7 +40,10 @@ fun ErrorView(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(40.dp),
+            .padding(40.dp)
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+            },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -66,6 +73,7 @@ fun ErrorView(
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
 
         Spacer(Modifier.height(10.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
@@ -84,8 +84,7 @@ fun HustleButton(
                     .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
-                    }
-                    .semantics {
+                    }.semantics {
                         if (loading) {
                             stateDescription = "Loading"
                         }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -82,6 +84,11 @@ fun HustleButton(
                     .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
+                    }
+                    .semantics {
+                        if (loading) {
+                            stateDescription = "Loading"
+                        }
                     },
                 enabled = isActive,
                 shape = ButtonShape,

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -275,7 +276,7 @@ fun HustleButtonLoadingPreview() {
             HustleButton(
                 text = "With Icon",
                 onClick = {},
-                icon = Icons.Default.ArrowForward,
+                icon = Icons.AutoMirrored.Filled.ArrowForward,
                 variant = HustleButtonVariant.Outlined,
             )
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
@@ -23,6 +23,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import must.kdroiders.hustlehub.ui.theme.HustleHubTheme
@@ -73,6 +76,11 @@ fun HustleCard(
         .graphicsLayer {
             scaleX = scale
             scaleY = scale
+        }
+        .semantics(mergeDescendants = true) {
+            if (onClick != null) {
+                role = Role.Button
+            }
         }
 
     val glassBackground = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleCard.kt
@@ -76,8 +76,7 @@ fun HustleCard(
         .graphicsLayer {
             scaleX = scale
             scaleY = scale
-        }
-        .semantics(mergeDescendants = true) {
+        }.semantics(mergeDescendants = true) {
             if (onClick != null) {
                 role = Role.Button
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleTextField.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleTextField.kt
@@ -39,6 +39,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -201,7 +204,11 @@ fun HustleTextField(
             exit = shrinkVertically(motionScheme.fastSpatialSpec()) + fadeOut(motionScheme.fastEffectsSpec()),
         ) {
             Row(
-                modifier = Modifier.padding(start = 12.dp, top = 6.dp),
+                modifier = Modifier.
+                padding(start = 12.dp, top = 6.dp)
+                    .semantics {
+                        liveRegion = LiveRegionMode.Polite
+                    },
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleTextField.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/HustleTextField.kt
@@ -204,8 +204,8 @@ fun HustleTextField(
             exit = shrinkVertically(motionScheme.fastSpatialSpec()) + fadeOut(motionScheme.fastEffectsSpec()),
         ) {
             Row(
-                modifier = Modifier.
-                padding(start = 12.dp, top = 6.dp)
+                modifier = Modifier
+                    .padding(start = 12.dp, top = 6.dp)
                     .semantics {
                         liveRegion = LiveRegionMode.Polite
                     },

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/LoadingIndicator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/LoadingIndicator.kt
@@ -22,6 +22,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -46,7 +50,12 @@ fun LoadingIndicator(
     )
 
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+                contentDescription = message ?: "Loading, please wait"
+            },
         contentAlignment = Alignment.Center,
     ) {
         Column(

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/RatingBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/RatingBar.kt
@@ -12,12 +12,14 @@ import androidx.compose.material.icons.filled.StarOutline
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -89,14 +91,19 @@ fun RatingBar(
 
             Icon(
                 imageVector = icon,
-                contentDescription = if (onRatingChanged == null) null else "Set rating to $i",
+                contentDescription = if (onRatingChanged == null) null else "Rate $i out of $starCount stars",
                 tint = tint,
                 modifier = Modifier
                     .size(starSize)
                     .scale(scale)
                     .then(
                         if (onRatingChanged != null) {
-                            Modifier.clickable { onRatingChanged(i) }
+                            Modifier
+                                .minimumInteractiveComponentSize()
+                                .clickable (
+                                    onClick = { onRatingChanged(i) },
+                                    role = Role.Button,
+                                )
                         } else {
                             Modifier
                         },

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/RatingBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/RatingBar.kt
@@ -100,7 +100,7 @@ fun RatingBar(
                         if (onRatingChanged != null) {
                             Modifier
                                 .minimumInteractiveComponentSize()
-                                .clickable (
+                                .clickable(
                                     onClick = { onRatingChanged(i) },
                                     role = Role.Button,
                                 )

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/SectionHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/SectionHeader.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -39,8 +41,12 @@ fun SectionHeader(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier
+                    .minimumInteractiveComponentSize()
                     .clip(RoundedCornerShape(4.dp))
-                    .clickable(onClick = onAction)
+                    .clickable(
+                        onClick = onAction,
+                        role = Role.Button,
+                    )
                     .padding(horizontal = 4.dp, vertical = 2.dp),
             )
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/SectionHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/sharedComposables/SectionHeader.kt
@@ -46,8 +46,7 @@ fun SectionHeader(
                     .clickable(
                         onClick = onAction,
                         role = Role.Button,
-                    )
-                    .padding(horizontal = 4.dp, vertical = 2.dp),
+                    ).padding(horizontal = 4.dp, vertical = 2.dp),
             )
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/repository/AuthRepositoryImpl.kt
@@ -33,7 +33,6 @@ class AuthRepositoryImpl
         private val firebaseAuth: FirebaseAuth,
         private val userRepositoryProvider: Provider<UserRepository>,
     ) : AuthRepository {
-
         /**
          * Signs in an existing user with email and password.
          *
@@ -235,7 +234,6 @@ class AuthRepositoryImpl
 
             firebaseAuth.signOut()
         }
-
 
         /** Sends a password reset email to the given email address. */
         override suspend fun sendPasswordResetEmail(email: String) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/data/repository/AuthRepositoryImpl.kt
@@ -7,13 +7,16 @@ import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.UserProfileChangeRequest
+import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
 import must.kdroiders.hustlehub.core.api.FirebaseAuthErrorMapper
 import must.kdroiders.hustlehub.ui.features.auth.domain.repository.AuthRepository
 import must.kdroiders.hustlehub.ui.features.auth.domain.repository.LoginResult
+import must.kdroiders.hustlehub.ui.features.profile.domain.repository.UserRepository
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
@@ -28,7 +31,9 @@ class AuthRepositoryImpl
     @Inject
     constructor(
         private val firebaseAuth: FirebaseAuth,
+        private val userRepositoryProvider: Provider<UserRepository>,
     ) : AuthRepository {
+
         /**
          * Signs in an existing user with email and password.
          *
@@ -209,10 +214,28 @@ class AuthRepositoryImpl
         /** Returns the currently signed-in [FirebaseUser], or null if logged out. */
         override fun getCurrentUser(): FirebaseUser? = firebaseAuth.currentUser
 
-        /** Signs the current user out of Firebase Auth. */
-        override fun logout() {
+        /** Signs the current user out of Firebase Auth and removes FCM token from backend. */
+        override suspend fun logout() {
+            runCatching {
+                val token = FirebaseMessaging.getInstance().token.await()
+                if (!token.isNullOrBlank()) {
+                    userRepositoryProvider.get().removeFcmToken(token)
+                }
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+                Timber.e(e, "Failed to remove FCM token from backend during logout")
+            }
+
+            runCatching {
+                FirebaseMessaging.getInstance().deleteToken().await()
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+                Timber.e(e, "Failed to delete FCM instance token during logout")
+            }
+
             firebaseAuth.signOut()
         }
+
 
         /** Sends a password reset email to the given email address. */
         override suspend fun sendPasswordResetEmail(email: String) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/domain/repository/AuthRepository.kt
@@ -32,4 +32,3 @@ interface AuthRepository {
     fun getCurrentUser(): FirebaseUser?
     suspend fun logout()
 }
-

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/domain/repository/AuthRepository.kt
@@ -30,5 +30,6 @@ interface AuthRepository {
         newPassword: String,
     ): Result<Unit>
     fun getCurrentUser(): FirebaseUser?
-    fun logout()
+    suspend fun logout()
 }
+

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/domain/usecase/SignOutUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/domain/usecase/SignOutUseCase.kt
@@ -20,4 +20,3 @@ class SignOutUseCase
             authRepository.logout()
         }
     }
-

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/domain/usecase/SignOutUseCase.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/domain/usecase/SignOutUseCase.kt
@@ -16,7 +16,8 @@ class SignOutUseCase
         private val authRepository: AuthRepository,
     ) {
         /** Calls [AuthRepository.logout] to sign the user out immediately. */
-        operator fun invoke() {
+        suspend operator fun invoke() {
             authRepository.logout()
         }
     }
+

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/ChangePasswordScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -51,10 +53,15 @@ fun ChangePasswordScreen(
     HustleScaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Change Password") },
+                title = {
+                    Text(
+                        "Change Password",
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Navigate back")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -77,6 +84,7 @@ fun ChangePasswordScreen(
                 text = "Secure your account",
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
+                modifier = Modifier.semantics { heading() },
             )
 
             Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/EmailVerificationScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/EmailVerificationScreen.kt
@@ -15,6 +15,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -48,7 +51,9 @@ fun EmailVerificationScreen(
             text = "Verify your email",
             style = MaterialTheme.typography.headlineLarge,
             fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 8.dp),
+            modifier = Modifier
+                .padding(bottom = 8.dp)
+                .semantics { heading() },
         )
 
         Text(
@@ -68,13 +73,16 @@ fun EmailVerificationScreen(
             ) {
                 Spacer(modifier = Modifier.height(8.dp))
 
-                // Error message
+                // Error message with liveRegion
                 uiState.errorMessage?.let { error ->
                     Text(
                         text = error,
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodySmall,
                         textAlign = TextAlign.Center,
+                        modifier = Modifier.semantics {
+                            liveRegion = androidx.compose.ui.semantics.LiveRegionMode.Polite
+                        },
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -49,6 +50,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.R
@@ -128,6 +131,7 @@ fun LoginScreen(
                 text = "Login to your account",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.semantics { heading() },
             )
 
             Spacer(Modifier.height(36.dp))
@@ -323,7 +327,7 @@ private fun LoginBackground() {
     val bgColor = MaterialTheme.colorScheme.background
     val density = LocalDensity.current
 
-    Canvas(modifier = Modifier.fillMaxSize()) {
+    Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics{}) {
         val w = size.width
         val h = size.height
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/LoginScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -50,8 +52,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.semantics
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import must.kdroiders.hustlehub.R
@@ -327,7 +327,7 @@ private fun LoginBackground() {
     val bgColor = MaterialTheme.colorScheme.background
     val density = LocalDensity.current
 
-    Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics{}) {
+    Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics {}) {
         val w = size.width
         val h = size.height
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/OtpInputField.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/OtpInputField.kt
@@ -14,6 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
@@ -27,7 +31,11 @@ fun OtpInputField(
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                isTraversalGroup = true
+            },
     ) {
         otpValues.forEachIndexed { index, value ->
             OutlinedTextField(
@@ -43,7 +51,11 @@ fun OtpInputField(
                 modifier = Modifier
                     .weight(1f)
                     .aspectRatio(1f)
-                    .focusRequester(focusRequesters[index]),
+                    .focusRequester(focusRequesters[index])
+                    .semantics {
+                        traversalIndex = index.toFloat()
+                        contentDescription = "OTP digit ${index + 1} of ${otpValues.size}, ${if (value.isEmpty()) "empty" else "digit $value"}"
+                    },
                 textStyle = LocalTextStyle.current.copy(
                     textAlign = TextAlign.Center,
                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/OtpInputField.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/OtpInputField.kt
@@ -54,7 +54,8 @@ fun OtpInputField(
                     .focusRequester(focusRequesters[index])
                     .semantics {
                         traversalIndex = index.toFloat()
-                        contentDescription = "OTP digit ${index + 1} of ${otpValues.size}, ${if (value.isEmpty()) "empty" else "digit $value"}"
+                        contentDescription =
+                            "OTP digit ${index + 1} of ${otpValues.size}, ${if (value.isEmpty()) "empty" else "digit $value"}"
                     },
                 textStyle = LocalTextStyle.current.copy(
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/SignUpScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/SignUpScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -63,7 +65,12 @@ fun SignUpScreen(
                 style = MaterialTheme.typography.headlineLarge,
                 color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(bottom = 8.dp),
+                modifier = Modifier
+                    .padding(bottom = 8.dp)
+                    .semantics {
+                        heading()
+                    },
+
             )
             Text(
                 text = "Join HustleHub with your student email",

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/components/PasswordStrengthIndicator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/components/PasswordStrengthIndicator.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import must.kdroiders.hustlehub.ui.features.auth.presentation.viewmodel.PasswordStrength
 
@@ -65,7 +67,10 @@ fun PasswordStrengthIndicator(strength: PasswordStrength) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 4.dp, bottom = 8.dp),
+            .padding(top = 4.dp, bottom = 8.dp)
+            .semantics(mergeDescendants = true) {
+               contentDescription = "Password strength level: $strengthText"
+            },
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/components/PasswordStrengthIndicator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/auth/presentation/view/components/PasswordStrengthIndicator.kt
@@ -69,7 +69,7 @@ fun PasswordStrengthIndicator(strength: PasswordStrength) {
             .fillMaxWidth()
             .padding(top = 4.dp, bottom = 8.dp)
             .semantics(mergeDescendants = true) {
-               contentDescription = "Password strength level: $strengthText"
+                contentDescription = "Password strength level: $strengthText"
             },
     ) {
         Row(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ChatLocationPickerSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/ChatLocationPickerSheet.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -181,7 +183,9 @@ fun ChatLocationPickerSheet(
                 text = "Share Location",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                modifier = Modifier
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+                    .semantics { heading() },
             )
 
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/DateSeparator.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/DateSeparator.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -56,6 +58,7 @@ fun DateSeparator(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.SemiBold,
                 fontSize = 11.sp,
+                modifier = Modifier.semantics { heading() },
             )
         }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/components/MessageBubble.kt
@@ -60,6 +60,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -183,6 +186,7 @@ fun MessageBubble(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .semantics(mergeDescendants = true) {}
                 .then(
                     if (message.isDeleted) {
                         Modifier
@@ -364,7 +368,7 @@ fun MessageBubble(
                                             if (isUploading) {
                                                 this
                                             } else {
-                                                clickable { onImageClick(imageUrl) }
+                                                clickable(role = Role.Button) { onImageClick(imageUrl) }
                                             }
                                         },
                                     contentAlignment = Alignment.Center,
@@ -523,7 +527,7 @@ private fun VoiceMessageContent(
         // Play/Pause or Buffering spinner
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.size(38.dp),
+            modifier = Modifier.size(48.dp),
         ) {
             if (isBufferingThis) {
                 CircularWavyProgressIndicator(
@@ -538,7 +542,7 @@ private fun VoiceMessageContent(
                         containerColor = textColor.copy(alpha = 0.15f),
                         contentColor = textColor,
                     ),
-                    modifier = Modifier.size(38.dp),
+                    modifier = Modifier.size(48.dp),
                 ) {
                     Icon(
                         imageVector = if (isPlayingThis) Icons.Default.Pause else Icons.Default.PlayArrow,
@@ -597,7 +601,7 @@ private fun VoiceMessageContent(
                         color = textColor.copy(alpha = 0.85f),
                         modifier = Modifier
                             .clip(RoundedCornerShape(4.dp))
-                            .clickable { onSpeedToggle() }
+                            .clickable(role = Role.Button) { onSpeedToggle() }
                             .padding(horizontal = 4.dp, vertical = 2.dp),
                     )
                 }
@@ -700,7 +704,7 @@ private fun LocationMessageContent(
     Column(
         modifier = Modifier
             .width(250.dp)
-            .clickable {
+            .clickable(role = Role.Button) {
                 if (locationData != null) {
                     onClick(
                         locationData.lat,
@@ -717,7 +721,7 @@ private fun LocationMessageContent(
         ) {
             Icon(
                 imageVector = Icons.Default.LocationOn,
-                contentDescription = "Location",
+                contentDescription = null, // decorative
                 tint = textColor,
                 modifier = Modifier.size(20.dp),
             )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatDetailScreen.kt
@@ -77,6 +77,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -398,13 +403,15 @@ fun ChatDetailScreen(
                 title = {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { heading() },
                     ) {
                         // User Avatar
                         if (!state.otherUserAvatar.isNullOrBlank()) {
                             AsyncImage(
                                 model = state.otherUserAvatar,
-                                contentDescription = "Avatar",
+                                contentDescription = "Avatar of ${state.otherUserName}",
                                 modifier = Modifier
                                     .size(40.dp)
                                     .clip(CircleShape),
@@ -415,7 +422,8 @@ fun ChatDetailScreen(
                                 modifier = Modifier
                                     .size(40.dp)
                                     .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.primaryContainer),
+                                    .background(MaterialTheme.colorScheme.primaryContainer)
+                                    .clearAndSetSemantics { },
                                 contentAlignment = Alignment.Center,
                             ) {
                                 val firstLetter = state.otherUserName.firstOrNull()?.uppercase() ?: "?"
@@ -501,7 +509,7 @@ fun ChatDetailScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f))
-                        .clickable { viewModel.markServiceCompleted() }
+                        .clickable(role = Role.Button) { viewModel.markServiceCompleted() }
                         .padding(horizontal = 16.dp, vertical = 10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -509,7 +517,7 @@ fun ChatDetailScreen(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             imageVector = Icons.Default.CheckCircle,
-                            contentDescription = null,
+                            contentDescription = null, // decorative
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(20.dp),
                         )
@@ -983,7 +991,7 @@ private fun AttachmentOption(
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.clickable(onClick = onClick),
+        modifier = Modifier.clickable(role = Role.Button, onClick = onClick),
     ) {
         Box(
             modifier = Modifier
@@ -994,7 +1002,7 @@ private fun AttachmentOption(
         ) {
             Icon(
                 imageVector = icon,
-                contentDescription = label,
+                contentDescription = null, // decorative since label announces it
                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
             )
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -47,7 +47,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -205,6 +208,9 @@ private fun ConversationItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+            }
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -214,7 +220,7 @@ private fun ConversationItem(
         if (!avatarUrl.isNullOrBlank()) {
             AsyncImage(
                 model = avatarUrl,
-                contentDescription = "User Avatar",
+                contentDescription = null,
                 modifier = Modifier
                     .size(52.dp)
                     .clip(CircleShape),
@@ -226,7 +232,8 @@ private fun ConversationItem(
                 modifier = Modifier
                     .size(52.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .clearAndSetSemantics { },
                 contentAlignment = Alignment.Center,
             ) {
                 val firstLetter = conversation.otherUserName.firstOrNull()?.uppercase() ?: "?"

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -79,6 +81,8 @@ fun ChatScreen(
                         text = "Messages",
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.semantics { heading() },
                     )
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/view/ChatScreen.kt
@@ -210,8 +210,7 @@ private fun ConversationItem(
             .fillMaxWidth()
             .semantics(mergeDescendants = true) {
                 role = Role.Button
-            }
-            .clickable(onClick = onClick)
+            }.clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModel.kt
@@ -1,29 +1,36 @@
 package must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.core.notification.AppBadgeHelper
 import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.ConversationDao
+import must.kdroiders.hustlehub.ui.features.notification.domain.repository.NotificationRepository
 import javax.inject.Inject
 
 /**
- * Lightweight ViewModel scoped to the main shell that exposes the total
- * unread message count across all conversations.
- *
- * Consumed by [MainShellScreen] to drive the bottom navigation badge.
- * Using a dedicated ViewModel (rather than collecting directly in the
- * composable) ensures the Flow survives recomposition and tab switches.
+ * Lightweight ViewModel scoped to the main shell that exposes unread counts
+ * for Chat messages, Notifications, and total unread launcher icon badge.
  */
 @HiltViewModel
 class UnreadCountViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         conversationDao: ConversationDao,
+        private val notificationRepository: NotificationRepository,
     ) : ViewModel() {
-        val totalUnreadCount: StateFlow<Int> =
+
+        val unreadMessageCount: StateFlow<Int> =
             conversationDao
                 .getTotalUnreadCount()
                 .stateIn(
@@ -31,4 +38,41 @@ class UnreadCountViewModel
                     started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
                     initialValue = 0,
                 )
+
+        private val _unreadNotificationCount = MutableStateFlow(0)
+        val unreadNotificationCount: StateFlow<Int> = _unreadNotificationCount.asStateFlow()
+
+        val totalUnreadCount: StateFlow<Int> =
+            combine(unreadMessageCount, _unreadNotificationCount) { messages, notifications ->
+                messages + notifications
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                initialValue = 0,
+            )
+
+        init {
+            refreshUnreadNotifications()
+            viewModelScope.launch {
+                totalUnreadCount.collect { count ->
+                    AppBadgeHelper.applyBadgeCount(context, count)
+                }
+            }
+        }
+
+        fun refreshUnreadNotifications() {
+            viewModelScope.launch {
+                notificationRepository.getUnreadCount()
+                    .onSuccess { count ->
+                        _unreadNotificationCount.value = count
+                    }
+            }
+        }
+
+        fun clearNotificationsBadge() {
+            viewModelScope.launch {
+                notificationRepository.markAllRead()
+                _unreadNotificationCount.value = 0
+            }
+        }
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModel.kt
@@ -29,7 +29,6 @@ class UnreadCountViewModel
         conversationDao: ConversationDao,
         private val notificationRepository: NotificationRepository,
     ) : ViewModel() {
-
         val unreadMessageCount: StateFlow<Int> =
             conversationDao
                 .getTotalUnreadCount()
@@ -62,7 +61,8 @@ class UnreadCountViewModel
 
         fun refreshUnreadNotifications() {
             viewModelScope.launch {
-                notificationRepository.getUnreadCount()
+                notificationRepository
+                    .getUnreadCount()
                     .onSuccess { count ->
                         _unreadNotificationCount.value = count
                     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
@@ -79,7 +79,7 @@ fun FilterBottomSheet(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.semantics {heading()}
+                    modifier = Modifier.semantics { heading() },
                 )
                 TextButton(
                     onClick = onReset,
@@ -225,6 +225,6 @@ private fun FilterSectionLabel(text: String) {
         style = MaterialTheme.typography.labelLarge,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 8.dp) .semantics{heading()},
+        modifier = Modifier.padding(bottom = 8.dp).semantics { heading() },
     )
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/FilterBottomSheet.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -77,6 +79,7 @@ fun FilterBottomSheet(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.semantics {heading()}
                 )
                 TextButton(
                     onClick = onReset,
@@ -222,6 +225,6 @@ private fun FilterSectionLabel(text: String) {
         style = MaterialTheme.typography.labelLarge,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 8.dp),
+        modifier = Modifier.padding(bottom = 8.dp) .semantics{heading()},
     )
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
@@ -76,8 +76,7 @@ fun HomeSearchBar(
                 .semantics {
                     role = Role.Button
                     contentDescription = "Search services"
-                }
-                .clickable(
+                }.clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = onSearchClick,
@@ -98,9 +97,8 @@ fun HomeSearchBar(
                     ),
                 ).clickable(
                     onClick = onAiSearchClick,
-                    role = Role.Button
-                )
-                .padding(horizontal = 10.dp, vertical = 5.dp)
+                    role = Role.Button,
+                ).padding(horizontal = 10.dp, vertical = 5.dp)
                 .testTag("home_ai_search_button"),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeSearchBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -23,6 +24,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -68,6 +73,10 @@ fun HomeSearchBar(
             },
             modifier = Modifier
                 .weight(1f)
+                .semantics {
+                    role = Role.Button
+                    contentDescription = "Search services"
+                }
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -75,9 +84,10 @@ fun HomeSearchBar(
                 ).testTag("home_search_field"),
         )
         Spacer(Modifier.width(8.dp))
-        // ✨ AI chip — placeholder; routes to AI Search screen (upcoming issue).
+        // AI chip — placeholder; routes to AI Search screen .
         Row(
             modifier = Modifier
+                .minimumInteractiveComponentSize()
                 .clip(RoundedCornerShape(20.dp))
                 .background(
                     Brush.linearGradient(
@@ -86,7 +96,10 @@ fun HomeSearchBar(
                             MaterialTheme.colorScheme.tertiary.copy(alpha = 0.9f),
                         ),
                     ),
-                ).clickable(onClick = onAiSearchClick)
+                ).clickable(
+                    onClick = onAiSearchClick,
+                    role = Role.Button
+                )
                 .padding(horizontal = 10.dp, vertical = 5.dp)
                 .testTag("home_ai_search_button"),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
@@ -61,7 +61,7 @@ fun HomeTopBar(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.semantics(mergeDescendants = true) {
                 heading()
-            }
+            },
         ) {
             Box(
                 modifier = Modifier
@@ -71,8 +71,7 @@ fun HomeTopBar(
                         Brush.linearGradient(
                             colors = listOf(MaterialTheme.colorScheme.primary, Color(0xFF7C4DFF)),
                         ),
-                    )
-                    .clearAndSetSemantics { }, // Hides "Capital H" from TalkBack,
+                    ).clearAndSetSemantics { }, // Hides "Capital H" from TalkBack,
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -138,13 +137,11 @@ fun HomeTopBar(
                             colors = listOf(MaterialTheme.colorScheme.primary, Color(0xFF7C4DFF)),
                         ),
                         shape = CircleShape,
-                    )
-                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    ).background(MaterialTheme.colorScheme.surfaceVariant)
                     .semantics {
                         role = Role.Button
                         contentDescription = "User profile, initials $initials"
-                    }
-                    .clickable {
+                    }.clickable {
                         if (onProfileClick != null) {
                             onProfileClick()
                         } else {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/home/presentation/components/HomeTopBar.kt
@@ -29,6 +29,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -51,7 +57,12 @@ fun HomeTopBar(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         // Logo + wordmark
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.semantics(mergeDescendants = true) {
+                heading()
+            }
+        ) {
             Box(
                 modifier = Modifier
                     .size(36.dp)
@@ -60,7 +71,8 @@ fun HomeTopBar(
                         Brush.linearGradient(
                             colors = listOf(MaterialTheme.colorScheme.primary, Color(0xFF7C4DFF)),
                         ),
-                    ),
+                    )
+                    .clearAndSetSemantics { }, // Hides "Capital H" from TalkBack,
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -74,6 +86,7 @@ fun HomeTopBar(
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.semantics { heading() },
             )
         }
 
@@ -107,7 +120,7 @@ fun HomeTopBar(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Notifications,
-                        contentDescription = "Notifications",
+                        contentDescription = "Notifications${if (notificationCount > 0) ", $notificationCount unread" else ""}",
                         tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.size(20.dp),
                     )
@@ -125,7 +138,12 @@ fun HomeTopBar(
                             colors = listOf(MaterialTheme.colorScheme.primary, Color(0xFF7C4DFF)),
                         ),
                         shape = CircleShape,
-                    ).background(MaterialTheme.colorScheme.surfaceVariant)
+                    )
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = "User profile, initials $initials"
+                    }
                     .clickable {
                         if (onProfileClick != null) {
                             onProfileClick()
@@ -140,6 +158,7 @@ fun HomeTopBar(
                     style = MaterialTheme.typography.labelMedium,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.clearAndSetSemantics { }, // Suppresses raw text reading
                 )
             }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/NotificationApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/NotificationApiService.kt
@@ -6,12 +6,11 @@ import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.Notific
 import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.NotificationResponse
 import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.UpdateNotificationPreferencesRequest
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
-
-import retrofit2.http.DELETE
 
 interface NotificationApiService {
     @GET("notifications")
@@ -44,4 +43,3 @@ interface NotificationApiService {
         @Body request: UpdateNotificationPreferencesRequest,
     ): ApiResponse<NotificationPreferencesDto>
 }
-

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/NotificationApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/NotificationApiService.kt
@@ -26,6 +26,9 @@ interface NotificationApiService {
     @PUT("notifications/read-all")
     suspend fun markAllRead(): ApiResponse<Unit>
 
+    @GET("notifications/unread-count")
+    suspend fun getUnreadCount(): ApiResponse<must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.UnreadCountDto>
+
     @GET("notifications/preferences")
     suspend fun getPreferences(): ApiResponse<NotificationPreferencesDto>
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/NotificationApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/NotificationApiService.kt
@@ -11,6 +11,8 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
+import retrofit2.http.DELETE
+
 interface NotificationApiService {
     @GET("notifications")
     suspend fun getNotifications(
@@ -20,6 +22,11 @@ interface NotificationApiService {
 
     @PUT("notifications/{notificationId}/read")
     suspend fun markRead(
+        @Path("notificationId") notificationId: String,
+    ): ApiResponse<Unit>
+
+    @DELETE("notifications/{notificationId}")
+    suspend fun deleteNotification(
         @Path("notificationId") notificationId: String,
     ): ApiResponse<Unit>
 

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/NotificationApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/NotificationApiService.kt
@@ -2,7 +2,10 @@ package must.kdroiders.hustlehub.ui.features.notification.data.remote
 
 import must.kdroiders.hustlehub.core.api.ApiResponse
 import must.kdroiders.hustlehub.core.api.PageResponse
+import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.NotificationPreferencesDto
 import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.NotificationResponse
+import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.UpdateNotificationPreferencesRequest
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -22,4 +25,13 @@ interface NotificationApiService {
 
     @PUT("notifications/read-all")
     suspend fun markAllRead(): ApiResponse<Unit>
+
+    @GET("notifications/preferences")
+    suspend fun getPreferences(): ApiResponse<NotificationPreferencesDto>
+
+    @PUT("notifications/preferences")
+    suspend fun updatePreferences(
+        @Body request: UpdateNotificationPreferencesRequest,
+    ): ApiResponse<NotificationPreferencesDto>
 }
+

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/dto/NotificationPreferencesDto.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/dto/NotificationPreferencesDto.kt
@@ -1,0 +1,27 @@
+package must.kdroiders.hustlehub.ui.features.notification.data.remote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationPreferencesDto(
+    val newMessages: Boolean,
+    val newReviews: Boolean,
+    val serviceInquiries: Boolean,
+    val marketing: Boolean,
+    val soundEnabled: Boolean,
+    val vibrationEnabled: Boolean,
+    val quietHoursStart: Int,
+    val quietHoursEnd: Int,
+)
+
+@Serializable
+data class UpdateNotificationPreferencesRequest(
+    val newMessages: Boolean? = null,
+    val newReviews: Boolean? = null,
+    val serviceInquiries: Boolean? = null,
+    val marketing: Boolean? = null,
+    val soundEnabled: Boolean? = null,
+    val vibrationEnabled: Boolean? = null,
+    val quietHoursStart: Int? = null,
+    val quietHoursEnd: Int? = null,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/dto/UnreadCountDto.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/remote/dto/UnreadCountDto.kt
@@ -1,0 +1,8 @@
+package must.kdroiders.hustlehub.ui.features.notification.data.remote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UnreadCountDto(
+    val unreadCount: Long,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/repository/NotificationRepositoryImpl.kt
@@ -30,6 +30,11 @@ class NotificationRepositoryImpl
                 apiService.markRead(id)
             }.map { }
 
+        override suspend fun deleteNotification(id: String): Result<Unit> =
+            runCatching {
+                apiService.deleteNotification(id)
+            }.map { }
+
         override suspend fun markAllRead(): Result<Unit> =
             runCatching {
                 apiService.markAllRead()

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/repository/NotificationRepositoryImpl.kt
@@ -87,14 +87,15 @@ class NotificationRepositoryImpl
             )
         }
 
-        private fun NotificationPreferencesDto.toDomain() = NotificationPreferences(
-            newMessages = newMessages,
-            newReviews = newReviews,
-            serviceInquiries = serviceInquiries,
-            marketing = marketing,
-            soundEnabled = soundEnabled,
-            vibrationEnabled = vibrationEnabled,
-            quietHoursStart = quietHoursStart,
-            quietHoursEnd = quietHoursEnd,
-        )
+        private fun NotificationPreferencesDto.toDomain() =
+            NotificationPreferences(
+                newMessages = newMessages,
+                newReviews = newReviews,
+                serviceInquiries = serviceInquiries,
+                marketing = marketing,
+                soundEnabled = soundEnabled,
+                vibrationEnabled = vibrationEnabled,
+                quietHoursStart = quietHoursStart,
+                quietHoursEnd = quietHoursEnd,
+            )
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/repository/NotificationRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package must.kdroiders.hustlehub.ui.features.notification.data.repository
 
 import must.kdroiders.hustlehub.ui.features.notification.data.remote.NotificationApiService
+import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.NotificationPreferencesDto
 import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.NotificationResponse
+import must.kdroiders.hustlehub.ui.features.notification.data.remote.dto.UpdateNotificationPreferencesRequest
 import must.kdroiders.hustlehub.ui.features.notification.domain.model.Notification
+import must.kdroiders.hustlehub.ui.features.notification.domain.model.NotificationPreferences
 import must.kdroiders.hustlehub.ui.features.notification.domain.model.NotificationType
 import must.kdroiders.hustlehub.ui.features.notification.domain.repository.NotificationRepository
 import javax.inject.Inject
@@ -32,6 +35,28 @@ class NotificationRepositoryImpl
                 apiService.markAllRead()
             }.map { }
 
+        override suspend fun getPreferences(): Result<NotificationPreferences> =
+            runCatching {
+                val response = apiService.getPreferences()
+                response.data?.toDomain() ?: NotificationPreferences()
+            }
+
+        override suspend fun updatePreferences(preferences: NotificationPreferences): Result<NotificationPreferences> =
+            runCatching {
+                val request = UpdateNotificationPreferencesRequest(
+                    newMessages = preferences.newMessages,
+                    newReviews = preferences.newReviews,
+                    serviceInquiries = preferences.serviceInquiries,
+                    marketing = preferences.marketing,
+                    soundEnabled = preferences.soundEnabled,
+                    vibrationEnabled = preferences.vibrationEnabled,
+                    quietHoursStart = preferences.quietHoursStart,
+                    quietHoursEnd = preferences.quietHoursEnd,
+                )
+                val response = apiService.updatePreferences(request)
+                response.data?.toDomain() ?: preferences
+            }
+
         private fun NotificationResponse.toDomain(): Notification {
             val typeEnum = when (type.uppercase()) {
                 "NEW_MESSAGE" -> NotificationType.NEW_MESSAGE
@@ -50,4 +75,15 @@ class NotificationRepositoryImpl
                 sentAt = sentAt,
             )
         }
+
+        private fun NotificationPreferencesDto.toDomain() = NotificationPreferences(
+            newMessages = newMessages,
+            newReviews = newReviews,
+            serviceInquiries = serviceInquiries,
+            marketing = marketing,
+            soundEnabled = soundEnabled,
+            vibrationEnabled = vibrationEnabled,
+            quietHoursStart = quietHoursStart,
+            quietHoursEnd = quietHoursEnd,
+        )
     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/data/repository/NotificationRepositoryImpl.kt
@@ -35,6 +35,12 @@ class NotificationRepositoryImpl
                 apiService.markAllRead()
             }.map { }
 
+        override suspend fun getUnreadCount(): Result<Int> =
+            runCatching {
+                val response = apiService.getUnreadCount()
+                (response.data?.unreadCount ?: 0L).toInt()
+            }
+
         override suspend fun getPreferences(): Result<NotificationPreferences> =
             runCatching {
                 val response = apiService.getPreferences()

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/domain/model/NotificationPreferences.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/domain/model/NotificationPreferences.kt
@@ -1,0 +1,12 @@
+package must.kdroiders.hustlehub.ui.features.notification.domain.model
+
+data class NotificationPreferences(
+    val newMessages: Boolean = true,
+    val newReviews: Boolean = true,
+    val serviceInquiries: Boolean = true,
+    val marketing: Boolean = false,
+    val soundEnabled: Boolean = true,
+    val vibrationEnabled: Boolean = true,
+    val quietHoursStart: Int = 22,
+    val quietHoursEnd: Int = 7,
+)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/domain/repository/NotificationRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/domain/repository/NotificationRepository.kt
@@ -9,6 +9,7 @@ interface NotificationRepository {
         size: Int,
     ): Result<List<Notification>>
     suspend fun markRead(id: String): Result<Unit>
+    suspend fun deleteNotification(id: String): Result<Unit>
     suspend fun markAllRead(): Result<Unit>
     suspend fun getUnreadCount(): Result<Int>
     suspend fun getPreferences(): Result<NotificationPreferences>

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/domain/repository/NotificationRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/domain/repository/NotificationRepository.kt
@@ -1,6 +1,7 @@
 package must.kdroiders.hustlehub.ui.features.notification.domain.repository
 
 import must.kdroiders.hustlehub.ui.features.notification.domain.model.Notification
+import must.kdroiders.hustlehub.ui.features.notification.domain.model.NotificationPreferences
 
 interface NotificationRepository {
     suspend fun getNotifications(
@@ -9,4 +10,6 @@ interface NotificationRepository {
     ): Result<List<Notification>>
     suspend fun markRead(id: String): Result<Unit>
     suspend fun markAllRead(): Result<Unit>
+    suspend fun getPreferences(): Result<NotificationPreferences>
+    suspend fun updatePreferences(preferences: NotificationPreferences): Result<NotificationPreferences>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/domain/repository/NotificationRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/domain/repository/NotificationRepository.kt
@@ -10,6 +10,7 @@ interface NotificationRepository {
     ): Result<List<Notification>>
     suspend fun markRead(id: String): Result<Unit>
     suspend fun markAllRead(): Result<Unit>
+    suspend fun getUnreadCount(): Result<Int>
     suspend fun getPreferences(): Result<NotificationPreferences>
     suspend fun updatePreferences(preferences: NotificationPreferences): Result<NotificationPreferences>
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationPreferencesScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationPreferencesScreen.kt
@@ -9,29 +9,29 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Campaign
-import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.HourglassFull
 import androidx.compose.material.icons.filled.MusicNote
-import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.RateReview
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.Work
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -41,11 +41,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import must.kdroiders.hustlehub.sharedComposables.HustleScaffold
 import must.kdroiders.hustlehub.ui.features.notification.presentation.viewmodel.NotificationPreferencesViewModel
 import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsDivider
 import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsGroup
@@ -61,40 +59,29 @@ fun NotificationPreferencesScreen(
     val state by notificationPreferencesViewModel.uiState.collectAsState()
     val prefs = state.preferences
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .statusBarsPadding(),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            IconButton(onClick = onBack) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Navigate back",
-                    tint = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-            Spacer(Modifier.weight(1f))
-            Text(
-                text = "Notification Preferences",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.semantics { heading() },
+    HustleScaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Notification Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Navigate back",
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
             )
-            Spacer(Modifier.weight(1f))
-            Spacer(Modifier.size(48.dp))
-        }
-
+        },
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .padding(innerPadding)
+                .background(MaterialTheme.colorScheme.background)
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
         ) {
@@ -105,7 +92,7 @@ fun NotificationPreferencesScreen(
             Spacer(Modifier.height(8.dp))
             SettingsGroup {
                 SettingsRowToggle(
-                    icon = Icons.Default.Chat,
+                    icon = Icons.AutoMirrored.Filled.Chat,
                     label = "New Messages",
                     checked = prefs.newMessages,
                     onCheckedChange = notificationPreferencesViewModel::onNewMessagesToggled,
@@ -127,7 +114,7 @@ fun NotificationPreferencesScreen(
                 SettingsDivider()
                 SettingsRowToggle(
                     icon = Icons.Default.Campaign,
-                    label = "Marketing & Announcements",
+                    label = "Marketing & Promotions",
                     checked = prefs.marketing,
                     onCheckedChange = notificationPreferencesViewModel::onMarketingToggled,
                 )
@@ -135,49 +122,43 @@ fun NotificationPreferencesScreen(
 
             Spacer(Modifier.height(24.dp))
 
-            // Alert style
-            SettingsSectionLabel("ALERT STYLE")
+            // Quiet hours
+            SettingsSectionLabel("QUIET HOURS")
             Spacer(Modifier.height(8.dp))
             SettingsGroup {
-                SettingsRowToggle(
-                    icon = Icons.Default.MusicNote,
-                    label = "Sound",
-                    checked = prefs.soundEnabled,
-                    onCheckedChange = notificationPreferencesViewModel::onSoundToggled,
+                HourPickerDropdownRow(
+                    label = "Quiet Hours Start",
+                    icon = Icons.Default.HourglassFull,
+                    selectedHour = prefs.quietHoursStart,
+                    onHourSelected = notificationPreferencesViewModel::onQuietHoursStartChanged,
                 )
                 SettingsDivider()
+                HourPickerDropdownRow(
+                    label = "Quiet Hours End",
+                    icon = Icons.Default.HourglassFull,
+                    selectedHour = prefs.quietHoursEnd,
+                    onHourSelected = notificationPreferencesViewModel::onQuietHoursEndChanged,
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Preferences
+            SettingsSectionLabel("PREFERENCES")
+            Spacer(Modifier.height(8.dp))
+            SettingsGroup {
                 SettingsRowToggle(
                     icon = Icons.Default.Vibration,
                     label = "Vibration",
                     checked = prefs.vibrationEnabled,
                     onCheckedChange = notificationPreferencesViewModel::onVibrationToggled,
                 )
-            }
-
-            Spacer(Modifier.height(24.dp))
-
-            // Quiet hours
-            SettingsSectionLabel("QUIET HOURS")
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = "No push notifications will be delivered during this window.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
-            )
-            SettingsGroup {
-                HourPickerRow(
-                    icon = Icons.Default.HourglassFull,
-                    label = "Start time",
-                    selectedHour = prefs.quietHoursStart,
-                    onHourSelected = notificationPreferencesViewModel::onQuietHoursStartChanged,
-                )
                 SettingsDivider()
-                HourPickerRow(
-                    icon = Icons.Default.Notifications,
-                    label = "End time",
-                    selectedHour = prefs.quietHoursEnd,
-                    onHourSelected = notificationPreferencesViewModel::onQuietHoursEndChanged,
+                SettingsRowToggle(
+                    icon = Icons.Default.MusicNote,
+                    label = "Notification Sound",
+                    checked = prefs.soundEnabled,
+                    onCheckedChange = notificationPreferencesViewModel::onSoundToggled,
                 )
             }
 
@@ -188,9 +169,9 @@ fun NotificationPreferencesScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun HourPickerRow(
-    icon: ImageVector,
+private fun HourPickerDropdownRow(
     label: String,
+    icon: ImageVector,
     selectedHour: Int,
     onHourSelected: (Int) -> Unit,
 ) {
@@ -198,24 +179,27 @@ private fun HourPickerRow(
 
     Row(
         modifier = Modifier
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .fillMaxWidth()
+            .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
             imageVector = icon,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(end = 16.dp),
+            modifier = Modifier.size(24.dp),
         )
+        Spacer(Modifier.size(16.dp))
         Text(
             text = label,
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f),
         )
+
         ExposedDropdownMenuBox(
             expanded = expanded,
-            onExpandedChange = { expanded = it },
+            onExpandedChange = { expanded = !expanded },
         ) {
             OutlinedTextField(
                 value = formatHour(selectedHour),
@@ -223,7 +207,7 @@ private fun HourPickerRow(
                 readOnly = true,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                 modifier = Modifier
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                     .padding(0.dp),
                 textStyle = MaterialTheme.typography.bodyMedium,
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationPreferencesScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationPreferencesScreen.kt
@@ -1,0 +1,257 @@
+package must.kdroiders.hustlehub.ui.features.notification.presentation.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Campaign
+import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.HourglassFull
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.RateReview
+import androidx.compose.material.icons.filled.Vibration
+import androidx.compose.material.icons.filled.Work
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import must.kdroiders.hustlehub.ui.features.notification.presentation.viewmodel.NotificationPreferencesViewModel
+import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsDivider
+import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsGroup
+import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsRowToggle
+import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsSectionLabel
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationPreferencesScreen(
+    onBack: () -> Unit = {},
+    notificationPreferencesViewModel: NotificationPreferencesViewModel = hiltViewModel(),
+) {
+    val state by notificationPreferencesViewModel.uiState.collectAsState()
+    val prefs = state.preferences
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Navigate back",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            Spacer(Modifier.weight(1f))
+            Text(
+                text = "Notification Preferences",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.semantics { heading() },
+            )
+            Spacer(Modifier.weight(1f))
+            Spacer(Modifier.size(48.dp))
+        }
+
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+        ) {
+            Spacer(Modifier.height(16.dp))
+
+            // Notification types
+            SettingsSectionLabel("NOTIFICATION TYPES")
+            Spacer(Modifier.height(8.dp))
+            SettingsGroup {
+                SettingsRowToggle(
+                    icon = Icons.Default.Chat,
+                    label = "New Messages",
+                    checked = prefs.newMessages,
+                    onCheckedChange = notificationPreferencesViewModel::onNewMessagesToggled,
+                )
+                SettingsDivider()
+                SettingsRowToggle(
+                    icon = Icons.Default.RateReview,
+                    label = "New Reviews",
+                    checked = prefs.newReviews,
+                    onCheckedChange = notificationPreferencesViewModel::onNewReviewsToggled,
+                )
+                SettingsDivider()
+                SettingsRowToggle(
+                    icon = Icons.Default.Work,
+                    label = "Service Inquiries",
+                    checked = prefs.serviceInquiries,
+                    onCheckedChange = notificationPreferencesViewModel::onServiceInquiriesToggled,
+                )
+                SettingsDivider()
+                SettingsRowToggle(
+                    icon = Icons.Default.Campaign,
+                    label = "Marketing & Announcements",
+                    checked = prefs.marketing,
+                    onCheckedChange = notificationPreferencesViewModel::onMarketingToggled,
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Alert style
+            SettingsSectionLabel("ALERT STYLE")
+            Spacer(Modifier.height(8.dp))
+            SettingsGroup {
+                SettingsRowToggle(
+                    icon = Icons.Default.MusicNote,
+                    label = "Sound",
+                    checked = prefs.soundEnabled,
+                    onCheckedChange = notificationPreferencesViewModel::onSoundToggled,
+                )
+                SettingsDivider()
+                SettingsRowToggle(
+                    icon = Icons.Default.Vibration,
+                    label = "Vibration",
+                    checked = prefs.vibrationEnabled,
+                    onCheckedChange = notificationPreferencesViewModel::onVibrationToggled,
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Quiet hours
+            SettingsSectionLabel("QUIET HOURS")
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "No push notifications will be delivered during this window.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
+            )
+            SettingsGroup {
+                HourPickerRow(
+                    icon = Icons.Default.HourglassFull,
+                    label = "Start time",
+                    selectedHour = prefs.quietHoursStart,
+                    onHourSelected = notificationPreferencesViewModel::onQuietHoursStartChanged,
+                )
+                SettingsDivider()
+                HourPickerRow(
+                    icon = Icons.Default.Notifications,
+                    label = "End time",
+                    selectedHour = prefs.quietHoursEnd,
+                    onHourSelected = notificationPreferencesViewModel::onQuietHoursEndChanged,
+                )
+            }
+
+            Spacer(Modifier.height(32.dp))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HourPickerRow(
+    icon: ImageVector,
+    label: String,
+    selectedHour: Int,
+    onHourSelected: (Int) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(end = 16.dp),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = it },
+        ) {
+            OutlinedTextField(
+                value = formatHour(selectedHour),
+                onValueChange = {},
+                readOnly = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                    .padding(0.dp),
+                textStyle = MaterialTheme.typography.bodyMedium,
+                colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                (0..23).forEach { hour ->
+                    DropdownMenuItem(
+                        text = { Text(formatHour(hour)) },
+                        onClick = {
+                            onHourSelected(hour)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatHour(hour: Int): String {
+    val period = if (hour < 12) "AM" else "PM"
+    val displayHour = when {
+        hour == 0 -> 12
+        hour > 12 -> hour - 12
+        else -> hour
+    }
+    return "%d:00 %s".format(displayHour, period)
+}

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationPreferencesScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationPreferencesScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -51,7 +52,6 @@ import must.kdroiders.hustlehub.ui.features.settings.presentation.components.Set
 import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsRowToggle
 import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsSectionLabel
 
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationPreferencesScreen(
@@ -64,7 +64,8 @@ fun NotificationPreferencesScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding(),
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationPreferencesScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationPreferencesScreen.kt
@@ -92,7 +92,6 @@ fun NotificationPreferencesScreen(
             Spacer(Modifier.size(48.dp))
         }
 
-
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -143,7 +145,9 @@ fun NotificationHeader(
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(start = 8.dp),
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .semantics { heading() },
         )
         if (unreadCount > 0) {
             Box(
@@ -222,6 +226,7 @@ fun NotificationItem(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))
+            .semantics(mergeDescendants = true) {}
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = containerColor),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -307,6 +312,7 @@ fun NotificationEmptyState() {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
@@ -416,7 +416,8 @@ fun groupNotificationsByDate(notifications: List<Notification>): Map<String, Lis
 
     return notifications.groupBy { notification ->
         val date = try {
-            Instant.parse(notification.sentAt)
+            Instant
+                .parse(notification.sentAt)
                 .atZone(ZoneId.systemDefault())
                 .toLocalDate()
         } catch (e: Exception) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.NotificationsNone
@@ -34,29 +35,38 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import must.kdroiders.hustlehub.navigation.DeepLinkAction
 import must.kdroiders.hustlehub.navigation.MainNavigationViewModel
+import must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.UnreadCountViewModel
 import must.kdroiders.hustlehub.ui.features.notification.domain.model.Notification
 import must.kdroiders.hustlehub.ui.features.notification.domain.model.NotificationType
 import must.kdroiders.hustlehub.ui.features.notification.presentation.viewmodel.NotificationViewModel
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -73,8 +83,8 @@ fun NotificationScreen(
     } else {
         null
     }
-    val unreadCountViewModel: must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.UnreadCountViewModel? = if (activity != null) {
-        hiltViewModel<must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.UnreadCountViewModel>(viewModelStoreOwner = activity)
+    val unreadCountViewModel: UnreadCountViewModel? = if (activity != null) {
+        hiltViewModel<UnreadCountViewModel>(viewModelStoreOwner = activity)
     } else {
         null
     }
@@ -90,14 +100,14 @@ fun NotificationScreen(
             .background(MaterialTheme.colorScheme.background),
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
-            // Header Top Bar
+            // Top Bar
             NotificationHeader(
                 unreadCount = state.unreadCount,
                 onBack = onBack,
                 onMarkAllRead = { viewModel.markAllAsRead() },
             )
 
-            // Notifications List / Empty State / PullToRefresh
+            // Notifications Content with Date Grouping & Pull-to-refresh
             PullToRefreshBox(
                 isRefreshing = state.isRefreshing,
                 onRefresh = { viewModel.loadNotifications(isRefresh = true) },
@@ -106,22 +116,31 @@ fun NotificationScreen(
                 if (state.notifications.isEmpty() && !state.isLoading) {
                     NotificationEmptyState()
                 } else {
+                    val grouped = groupNotificationsByDate(state.notifications)
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(bottom = 24.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        items(
-                            items = state.notifications,
-                            key = { it.id },
-                        ) { notification ->
-                            NotificationItem(
-                                notification = notification,
-                                onClick = {
-                                    viewModel.markAsRead(notification.id)
-                                    handleNotificationTap(notification, onBack, mainNavigationViewModel)
-                                },
-                            )
+                        grouped.forEach { (dateGroup, notificationsInGroup) ->
+                            item(key = "header_$dateGroup") {
+                                DateHeaderGroup(text = dateGroup)
+                            }
+                            items(
+                                items = notificationsInGroup,
+                                key = { it.id },
+                            ) { notification ->
+                                SwipeableNotificationItem(
+                                    notification = notification,
+                                    onClick = {
+                                        viewModel.markAsRead(notification.id)
+                                        handleNotificationTap(notification, onBack, mainNavigationViewModel)
+                                    },
+                                    onDelete = {
+                                        viewModel.deleteNotification(notification.id)
+                                    },
+                                )
+                            }
                         }
                     }
                 }
@@ -146,7 +165,7 @@ fun NotificationHeader(
         IconButton(onClick = onBack) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                contentDescription = "Navigate back",
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
@@ -183,7 +202,7 @@ fun NotificationHeader(
             ) {
                 Icon(
                     imageVector = Icons.Default.DoneAll,
-                    contentDescription = "Mark all read",
+                    contentDescription = "Mark all as read",
                     modifier = Modifier.size(16.dp),
                     tint = MaterialTheme.colorScheme.primary,
                 )
@@ -195,6 +214,65 @@ fun NotificationHeader(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun DateHeaderGroup(text: String) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .padding(start = 16.dp, top = 16.dp, bottom = 4.dp)
+            .semantics { heading() },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SwipeableNotificationItem(
+    notification: Notification,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { dismissValue ->
+            if (dismissValue == SwipeToDismissBoxValue.EndToStart || dismissValue == SwipeToDismissBoxValue.StartToEnd) {
+                onDelete()
+                true
+            } else {
+                false
+            }
+        },
+    )
+
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = Modifier.padding(horizontal = 16.dp),
+        backgroundContent = {
+            val color = when (dismissState.targetValue) {
+                SwipeToDismissBoxValue.EndToStart, SwipeToDismissBoxValue.StartToEnd -> MaterialTheme.colorScheme.errorContainer
+                else -> Color.Transparent
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(color)
+                    .padding(horizontal = 20.dp),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete notification",
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        },
+    ) {
+        NotificationItem(notification = notification, onClick = onClick)
     }
 }
 
@@ -245,7 +323,6 @@ fun NotificationItem(
             modifier = Modifier.padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Left circular icon
             Box(
                 modifier = Modifier
                     .size(44.dp)
@@ -263,7 +340,6 @@ fun NotificationItem(
 
             Spacer(modifier = Modifier.width(16.dp))
 
-            // Body text
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = notification.title,
@@ -287,7 +363,6 @@ fun NotificationItem(
                 )
             }
 
-            // Blue unread indicator dot
             if (!notification.isRead) {
                 Spacer(modifier = Modifier.width(12.dp))
                 Box(
@@ -318,7 +393,7 @@ fun NotificationEmptyState() {
         )
         Spacer(modifier = Modifier.height(24.dp))
         Text(
-            text = "Your inbox is empty",
+            text = "No notifications yet",
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
@@ -329,15 +404,37 @@ fun NotificationEmptyState() {
             text = "We will notify you here when you receive new messages, reviews, or inquiries.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            textAlign = TextAlign.Center,
         )
+    }
+}
+
+fun groupNotificationsByDate(notifications: List<Notification>): Map<String, List<Notification>> {
+    val today = LocalDate.now(ZoneId.systemDefault())
+    val yesterday = today.minusDays(1)
+    val weekAgo = today.minusDays(7)
+
+    return notifications.groupBy { notification ->
+        val date = try {
+            Instant.parse(notification.sentAt)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+        } catch (e: Exception) {
+            today
+        }
+        when {
+            date.isEqual(today) -> "Today"
+            date.isEqual(yesterday) -> "Yesterday"
+            date.isAfter(weekAgo) -> "This Week"
+            else -> "Older"
+        }
     }
 }
 
 fun formatRelativeTime(dateString: String): String {
     return try {
-        val instant = java.time.Instant.parse(dateString)
-        val now = java.time.Instant.now()
+        val instant = Instant.parse(dateString)
+        val now = Instant.now()
         val duration = Duration.between(instant, now)
         val diffSeconds = duration.seconds
         when {
@@ -362,7 +459,7 @@ private fun handleNotificationTap(
         NotificationType.NEW_MESSAGE -> {
             val conversationId = notification.data?.get("conversationId")
             if (!conversationId.isNullOrBlank()) {
-                onBack() // Close notifications overlay
+                onBack()
                 mainNavigationViewModel.triggerDeepLink(DeepLinkAction.OpenChat(conversationId))
             }
         }
@@ -375,7 +472,7 @@ private fun handleNotificationTap(
             mainNavigationViewModel.triggerDeepLink(DeepLinkAction.OpenChatList)
         }
         NotificationType.SYSTEM -> {
-            // No action needed for system notifications
+            // No navigation needed for system notifications
         }
     }
 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/view/NotificationScreen.kt
@@ -73,6 +73,16 @@ fun NotificationScreen(
     } else {
         null
     }
+    val unreadCountViewModel: must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.UnreadCountViewModel? = if (activity != null) {
+        hiltViewModel<must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel.UnreadCountViewModel>(viewModelStoreOwner = activity)
+    } else {
+        null
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.markAllAsRead()
+        unreadCountViewModel?.clearNotificationsBadge()
+    }
 
     Box(
         modifier = modifier

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationPreferencesViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationPreferencesViewModel.kt
@@ -36,11 +36,11 @@ class NotificationPreferencesViewModel
         private fun loadPreferences() {
             viewModelScope.launch {
                 _uiState.update { it.copy(isLoading = true, error = null) }
-                notificationRepository.getPreferences()
+                notificationRepository
+                    .getPreferences()
                     .onSuccess { prefs ->
                         _uiState.update { it.copy(preferences = prefs, isLoading = false) }
-                    }
-                    .onFailure { e ->
+                    }.onFailure { e ->
                         Timber.e(e, "Failed to load notification preferences")
                         _uiState.update { it.copy(isLoading = false, error = "Failed to load preferences") }
                     }
@@ -65,11 +65,11 @@ class NotificationPreferencesViewModel
         private fun savePreferences(preferences: NotificationPreferences) {
             viewModelScope.launch {
                 _uiState.update { it.copy(isSaving = true, error = null) }
-                notificationRepository.updatePreferences(preferences)
+                notificationRepository
+                    .updatePreferences(preferences)
                     .onSuccess {
                         _uiState.update { it.copy(isSaving = false) }
-                    }
-                    .onFailure { e ->
+                    }.onFailure { e ->
                         Timber.e(e, "Failed to save notification preferences")
                         _uiState.update { it.copy(isSaving = false, error = "Failed to save preferences") }
                     }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationPreferencesViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationPreferencesViewModel.kt
@@ -1,0 +1,78 @@
+package must.kdroiders.hustlehub.ui.features.notification.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import must.kdroiders.hustlehub.ui.features.notification.domain.model.NotificationPreferences
+import must.kdroiders.hustlehub.ui.features.notification.domain.repository.NotificationRepository
+import timber.log.Timber
+import javax.inject.Inject
+
+data class NotificationPreferencesUiState(
+    val preferences: NotificationPreferences = NotificationPreferences(),
+    val isLoading: Boolean = false,
+    val isSaving: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class NotificationPreferencesViewModel
+    @Inject
+    constructor(
+        private val notificationRepository: NotificationRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(NotificationPreferencesUiState())
+        val uiState: StateFlow<NotificationPreferencesUiState> = _uiState.asStateFlow()
+
+        init {
+            loadPreferences()
+        }
+
+        private fun loadPreferences() {
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+                notificationRepository.getPreferences()
+                    .onSuccess { prefs ->
+                        _uiState.update { it.copy(preferences = prefs, isLoading = false) }
+                    }
+                    .onFailure { e ->
+                        Timber.e(e, "Failed to load notification preferences")
+                        _uiState.update { it.copy(isLoading = false, error = "Failed to load preferences") }
+                    }
+            }
+        }
+
+        fun onNewMessagesToggled(enabled: Boolean) = updatePrefs { it.copy(newMessages = enabled) }
+        fun onNewReviewsToggled(enabled: Boolean) = updatePrefs { it.copy(newReviews = enabled) }
+        fun onServiceInquiriesToggled(enabled: Boolean) = updatePrefs { it.copy(serviceInquiries = enabled) }
+        fun onMarketingToggled(enabled: Boolean) = updatePrefs { it.copy(marketing = enabled) }
+        fun onSoundToggled(enabled: Boolean) = updatePrefs { it.copy(soundEnabled = enabled) }
+        fun onVibrationToggled(enabled: Boolean) = updatePrefs { it.copy(vibrationEnabled = enabled) }
+        fun onQuietHoursStartChanged(hour: Int) = updatePrefs { it.copy(quietHoursStart = hour) }
+        fun onQuietHoursEndChanged(hour: Int) = updatePrefs { it.copy(quietHoursEnd = hour) }
+
+        private fun updatePrefs(transform: (NotificationPreferences) -> NotificationPreferences) {
+            val updated = transform(_uiState.value.preferences)
+            _uiState.update { it.copy(preferences = updated) }
+            savePreferences(updated)
+        }
+
+        private fun savePreferences(preferences: NotificationPreferences) {
+            viewModelScope.launch {
+                _uiState.update { it.copy(isSaving = true, error = null) }
+                notificationRepository.updatePreferences(preferences)
+                    .onSuccess {
+                        _uiState.update { it.copy(isSaving = false) }
+                    }
+                    .onFailure { e ->
+                        Timber.e(e, "Failed to save notification preferences")
+                        _uiState.update { it.copy(isSaving = false, error = "Failed to save preferences") }
+                    }
+            }
+        }
+    }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationViewModel.kt
@@ -125,6 +125,31 @@ class NotificationViewModel
             }
         }
 
+        fun deleteNotification(notificationId: String) {
+            val currentList = _uiState.value.notifications
+            val target = currentList.find { it.id == notificationId } ?: return
+
+            val updatedList = currentList.filterNot { it.id == notificationId }
+            _uiState.update { current ->
+                current.copy(
+                    notifications = updatedList,
+                    unreadCount = updatedList.count { !it.isRead },
+                )
+            }
+
+            viewModelScope.launch {
+                repository.deleteNotification(notificationId)
+                    .onFailure {
+                        _uiState.update { current ->
+                            current.copy(
+                                notifications = currentList,
+                                unreadCount = currentList.count { !it.isRead },
+                            )
+                        }
+                    }
+            }
+        }
+
         fun clearError() {
             _uiState.update { it.copy(error = null) }
         }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationViewModel.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationViewModel.kt
@@ -138,7 +138,8 @@ class NotificationViewModel
             }
 
             viewModelScope.launch {
-                repository.deleteNotification(notificationId)
+                repository
+                    .deleteNotification(notificationId)
                     .onFailure {
                         _uiState.update { current ->
                             current.copy(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/remote/UserApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/remote/UserApiService.kt
@@ -4,10 +4,12 @@ import must.kdroiders.hustlehub.core.api.ApiResponse
 import must.kdroiders.hustlehub.ui.features.auth.data.remote.UserResponseDto
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
+
 
 data class UpdateProfileRequest(
     val name: String? = null,
@@ -55,6 +57,12 @@ interface UserApiService {
     suspend fun updateFcmToken(
         @Body request: FcmTokenRequest,
     ): Response<Unit>
+
+    @DELETE("users/fcm-token")
+    suspend fun removeFcmToken(
+        @Query("token") token: String,
+    ): Response<Unit>
+
 
     @PUT("users/me/location")
     suspend fun updateLocation(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/remote/UserApiService.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/remote/UserApiService.kt
@@ -10,7 +10,6 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
-
 data class UpdateProfileRequest(
     val name: String? = null,
     val bio: String? = null,
@@ -62,7 +61,6 @@ interface UserApiService {
     suspend fun removeFcmToken(
         @Query("token") token: String,
     ): Response<Unit>
-
 
     @PUT("users/me/location")
     suspend fun updateLocation(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImpl.kt
@@ -198,7 +198,6 @@ class UserRepositoryImpl
                 Timber.e(e, "UserRepositoryImpl: failed to remove FCM token")
             }
 
-
         override suspend fun updateUserLocation(
             lat: Double,
             lng: Double,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImpl.kt
@@ -188,6 +188,17 @@ class UserRepositoryImpl
                 Timber.e(e, "UserRepositoryImpl: failed to update FCM token")
             }
 
+        override suspend fun removeFcmToken(token: String): Result<Unit> =
+            runCatching {
+                val response = userApiService.removeFcmToken(token)
+                if (!response.isSuccessful) {
+                    throw Exception("FCM token removal failed: code ${response.code()}")
+                }
+            }.onFailure { e ->
+                Timber.e(e, "UserRepositoryImpl: failed to remove FCM token")
+            }
+
+
         override suspend fun updateUserLocation(
             lat: Double,
             lng: Double,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/repository/UserRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/repository/UserRepository.kt
@@ -79,6 +79,13 @@ interface UserRepository {
     suspend fun updateFcmToken(token: String): Result<Unit>
 
     /**
+     * Removes an FCM token for the currently authenticated user.
+     * Wraps DELETE /api/v1/users/fcm-token.
+     */
+    suspend fun removeFcmToken(token: String): Result<Unit>
+
+
+    /**
      * Updates the user's location coordinates.
      * Wraps PUT /api/v1/users/me/location.
      */

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/repository/UserRepository.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/domain/repository/UserRepository.kt
@@ -84,7 +84,6 @@ interface UserRepository {
      */
     suspend fun removeFcmToken(token: String): Result<Unit>
 
-
     /**
      * Updates the user's location coordinates.
      * Wraps PUT /api/v1/users/me/location.

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -108,14 +108,15 @@ fun EditProfileScreen(
                         text = "Edit Profile",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.semantics { heading() }
+                        modifier = Modifier.semantics { heading() },
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Navigate Back")
+                            contentDescription = "Navigate Back",
+                        )
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -156,8 +157,7 @@ fun EditProfileScreen(
                         .semantics {
                             role = Role.Button
                             contentDescription = "Change Profile Photo"
-                        }
-                        .clickable {
+                        }.clickable {
                             photoPicker.launch(
                                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
                             )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/EditProfileScreen.kt
@@ -50,6 +50,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -102,11 +108,14 @@ fun EditProfileScreen(
                         text = "Edit Profile",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() }
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Navigate Back")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -144,6 +153,10 @@ fun EditProfileScreen(
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.surfaceVariant)
                         .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                        .semantics {
+                            role = Role.Button
+                            contentDescription = "Change Profile Photo"
+                        }
                         .clickable {
                             photoPicker.launch(
                                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
@@ -223,7 +236,12 @@ fun EditProfileScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(16.dp)
+                        .semantics {
+                            role = Role.Switch
+                            stateDescription = if (state.allowCalls) "On" else "Off"
+                            contentDescription = "Allow Direct Calls"
+                        },
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileAvatar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileAvatar.kt
@@ -27,6 +27,7 @@ fun ProfileAvatar(
     photoUrl: String?,
     modifier: Modifier = Modifier,
     isVerified: Boolean = false,
+    contentDescription: String? = "Profile photo",
 ) {
     Box(contentAlignment = Alignment.BottomEnd, modifier = modifier) {
         Box(
@@ -44,14 +45,14 @@ fun ProfileAvatar(
             if (photoUrl.isNullOrEmpty()) {
                 Icon(
                     imageVector = Icons.Default.Person,
-                    contentDescription = "Default Avatar",
+                    contentDescription = contentDescription,
                     modifier = Modifier.size(64.dp),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             } else {
                 AsyncImage(
                     model = photoUrl,
-                    contentDescription = "Profile Photo",
+                    contentDescription = contentDescription,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop,
                 )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileBottomTabs.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileBottomTabs.kt
@@ -70,8 +70,7 @@ fun TabButton(
                 width = 1.dp,
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f),
                 shape = RoundedCornerShape(24.dp),
-            )
-            .clickable(onClick = onClick)
+            ).clickable(onClick = onClick)
             .padding(vertical = 18.dp, horizontal = 20.dp)
             .semantics {
                 role = androidx.compose.ui.semantics.Role.Tab

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileBottomTabs.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileBottomTabs.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
@@ -22,6 +21,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -68,8 +70,13 @@ fun TabButton(
                 width = 1.dp,
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f),
                 shape = RoundedCornerShape(24.dp),
-            ).clickable(onClick = onClick)
-            .padding(vertical = 18.dp, horizontal = 20.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = 18.dp, horizontal = 20.dp)
+            .semantics {
+                role = androidx.compose.ui.semantics.Role.Tab
+                contentDescription = "$label tab"
+            },
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
@@ -19,6 +19,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,6 +53,7 @@ fun ProfileHeader(
             fontSize = 24.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.semantics { heading() },
         )
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -56,11 +62,15 @@ fun ProfileHeader(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = "Share profile"
+                    },
             ) {
                 Icon(
                     imageVector = Icons.Default.Share,
-                    contentDescription = "Share profile",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(20.dp),
                 )
@@ -70,11 +80,15 @@ fun ProfileHeader(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = "Edit profile"
+                    },
             ) {
                 Icon(
                     imageVector = Icons.Default.Edit,
-                    contentDescription = "Edit profile",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(20.dp),
                 )
@@ -84,11 +98,16 @@ fun ProfileHeader(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .semantics {
+                      role =
+                            Role.Button
+                        contentDescription = "Settings"
+                    },
             ) {
                 Icon(
                     imageVector = Icons.Default.Settings,
-                    contentDescription = "Settings",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(20.dp),
                 )

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileHeader.kt
@@ -100,7 +100,7 @@ fun ProfileHeader(
                     .clip(CircleShape)
                     .background(MaterialTheme.colorScheme.surfaceVariant)
                     .semantics {
-                      role =
+                        role =
                             Role.Button
                         contentDescription = "Settings"
                     },

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -75,13 +78,20 @@ fun StatCard(
     iconTint: Color = HustleWarningAmber,
     onClick: (() -> Unit)? = null,
 ) {
+    val cleanLabel = label.replace("\n", " ")
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(24.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f), RoundedCornerShape(24.dp))
             .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
-            .padding(vertical = 24.dp, horizontal = 8.dp),
+            .padding(vertical = 24.dp, horizontal = 8.dp)
+            .semantics(mergeDescendants = true) {
+               contentDescription = "$value $cleanLabel"
+                if (onClick != null) {
+                    role = androidx.compose.ui.semantics.Role.Button
+                }
+            },
         contentAlignment = Alignment.Center,
     ) {
         Column(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProfileStatsRow.kt
@@ -87,7 +87,7 @@ fun StatCard(
             .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
             .padding(vertical = 24.dp, horizontal = 8.dp)
             .semantics(mergeDescendants = true) {
-               contentDescription = "$value $cleanLabel"
+                contentDescription = "$value $cleanLabel"
                 if (onClick != null) {
                     role = androidx.compose.ui.semantics.Role.Button
                 }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import must.kdroiders.hustlehub.R
@@ -62,6 +64,7 @@ fun ProviderOnboardingCard(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.semantics { heading () }
             )
 
             Spacer(Modifier.height(6.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ProviderOnboardingCard.kt
@@ -64,7 +64,7 @@ fun ProviderOnboardingCard(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.semantics { heading () }
+                modifier = Modifier.semantics { heading() },
             )
 
             Spacer(Modifier.height(6.dp))

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ServicesSection.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/profile/presentation/view/components/ServicesSection.kt
@@ -29,6 +29,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,6 +59,7 @@ fun ServicesHeader(
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.semantics { heading() },
         )
         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
             TextButton(onClick = onManageServicesClick) {
@@ -68,7 +74,7 @@ fun ServicesHeader(
                 Text(
                     text = "Add New +",
                     fontSize = 14.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.primary,
                 )
             }
@@ -90,7 +96,11 @@ fun ServiceCard(
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f), RoundedCornerShape(24.dp))
             .clickable { onClick() }
-            .padding(16.dp),
+            .padding(16.dp)
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                contentDescription = "Service: ${service.title}, Price: KES ${service.priceRange}"
+            },
     ) {
         Column {
             Row(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -137,7 +137,7 @@ fun CreateServiceScreen(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.semantics { heading()}
+                    modifier = Modifier.semantics { heading() },
                 )
             }
 
@@ -319,8 +319,7 @@ fun CreateServiceScreen(
                             .semantics {
                                 role = Role.Button
                                 contentDescription = "Add tag"
-                            }
-                            .clickable { createServiceViewModel.addTag() },
+                            }.clickable { createServiceViewModel.addTag() },
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/CreateServiceScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -49,6 +50,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -121,7 +128,7 @@ fun CreateServiceScreen(
                 IconButton(onClick = onBack) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
+                        contentDescription = "Navigate back",
                         tint = MaterialTheme.colorScheme.onBackground,
                     )
                 }
@@ -130,6 +137,7 @@ fun CreateServiceScreen(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.semantics { heading()}
                 )
             }
 
@@ -304,15 +312,20 @@ fun CreateServiceScreen(
                     )
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .size(48.dp)
                             .clip(RoundedCornerShape(12.dp))
                             .background(MaterialTheme.colorScheme.primary)
+                            .semantics {
+                                role = Role.Button
+                                contentDescription = "Add tag"
+                            }
                             .clickable { createServiceViewModel.addTag() },
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             imageVector = Icons.Default.Add,
-                            contentDescription = "Add tag",
+                            contentDescription = null,
                             tint = MaterialTheme.colorScheme.onPrimary,
                             modifier = Modifier.size(20.dp),
                         )
@@ -326,7 +339,12 @@ fun CreateServiceScreen(
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(12.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant)
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                        .semantics {
+                            role = Role.Switch
+                            stateDescription = if (state.openToBarter) "On" else "Off"
+                            contentDescription = "Open to Barter Service"
+                        },
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
@@ -92,12 +92,11 @@ private fun AvailabilityChip(
             .background(bgColor)
             .border(1.dp, borderColor, RoundedCornerShape(20.dp))
             .clickable(enabled = enabled) { onClick() }
-            .semantics{
+            .semantics {
                 role = Role.RadioButton
                 this.selected = selected
                 stateDescription = if (selected) "Selected" else "Not selected"
-            }
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            }.padding(horizontal = 12.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/AvailabilityChipSelector.kt
@@ -1,5 +1,6 @@
 package must.kdroiders.hustlehub.ui.features.service.presentation.view.components
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -10,11 +11,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -80,16 +87,22 @@ private fun AvailabilityChip(
 
     Row(
         modifier = Modifier
+            .minimumInteractiveComponentSize()
             .clip(RoundedCornerShape(20.dp))
             .background(bgColor)
             .border(1.dp, borderColor, RoundedCornerShape(20.dp))
             .clickable(enabled = enabled) { onClick() }
+            .semantics{
+                role = Role.RadioButton
+                this.selected = selected
+                stateDescription = if (selected) "Selected" else "Not selected"
+            }
             .padding(horizontal = 12.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         // Dot indicator
-        androidx.compose.foundation.Canvas(modifier = Modifier.size(8.dp)) {
+        Canvas(modifier = Modifier.size(8.dp)) {
             drawCircle(color = dotColor)
         }
         Text(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/DeleteConfirmDialog.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/DeleteConfirmDialog.kt
@@ -4,7 +4,11 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 
 @Composable
@@ -20,6 +24,7 @@ fun DeleteConfirmDialog(
                 text = "Delete Service",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
+                modifier = Modifier.semantics { heading() },
             )
         },
         text = {
@@ -30,7 +35,10 @@ fun DeleteConfirmDialog(
             )
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(
+                onClick = onConfirm,
+                modifier = Modifier.minimumInteractiveComponentSize(),
+            ) {
                 Text(
                     text = "Delete",
                     color = MaterialTheme.colorScheme.error,
@@ -39,7 +47,10 @@ fun DeleteConfirmDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.minimumInteractiveComponentSize(),
+            ) {
                 Text("Cancel")
             }
         },

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/MapLocationPickerModal.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -49,6 +50,11 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -231,6 +237,7 @@ fun MapLocationPickerModal(
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.semantics { heading() },
                     )
                     Text(
                         text = "Tap the map to drop a pin, or drag to center",
@@ -344,7 +351,12 @@ fun MapLocationPickerModal(
                         .padding(16.dp)
                         .shadow(4.dp, CircleShape)
                         .background(MaterialTheme.colorScheme.surface, CircleShape)
-                        .size(44.dp),
+                        .minimumInteractiveComponentSize()
+                        .size(44.dp)
+                        .semantics {
+                            role = Role.Button
+                            contentDescription = "Find my current location"
+                        },
                 ) {
                     Icon(
                         imageVector = Icons.Default.MyLocation,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -34,7 +35,11 @@ fun ReviewCard(
     review: Review,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) { }
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ReviewCard.kt
@@ -38,7 +38,7 @@ fun ReviewCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .semantics(mergeDescendants = true) { }
+            .semantics(mergeDescendants = true) { },
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
@@ -25,11 +25,16 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -112,9 +117,14 @@ fun ServiceManagementCard(
                 ) {
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(MaterialTheme.colorScheme.primaryContainer)
+                            .semantics{
+                                role = Role.Button
+                                contentDescription = "Edit service"
+                            }
                             .clickable(enabled = !isUpdating, onClick = onEditClick),
                         contentAlignment = Alignment.Center,
                     ) {
@@ -128,15 +138,20 @@ fun ServiceManagementCard(
 
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(MaterialTheme.colorScheme.secondaryContainer)
+                            .semantics {
+                                role = Role.Button
+                                contentDescription = "Manage service photo gallery"
+                            }
                             .clickable(enabled = !isUpdating, onClick = onGalleryClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             imageVector = Icons.Default.PhotoLibrary,
-                            contentDescription = "Manage gallery",
+                            contentDescription = null,
                             tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier = Modifier.size(18.dp),
                         )
@@ -144,15 +159,20 @@ fun ServiceManagementCard(
 
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(MaterialTheme.colorScheme.errorContainer)
+                            .semantics {
+                                role = Role.Button
+                                contentDescription = "Delete service"
+                            }
                             .clickable(enabled = !isUpdating, onClick = onDeleteClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete service",
+                            contentDescription = null,
                             tint = MaterialTheme.colorScheme.onErrorContainer,
                             modifier = Modifier.size(18.dp),
                         )
@@ -225,7 +245,10 @@ private fun StatItem(
     label: String,
     value: String,
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.semantics(mergeDescendants = true) { },
+    ) {
         Text(
             text = value,
             style = MaterialTheme.typography.titleSmall,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/service/presentation/view/components/ServiceManagementCard.kt
@@ -121,11 +121,10 @@ fun ServiceManagementCard(
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))
                             .background(MaterialTheme.colorScheme.primaryContainer)
-                            .semantics{
+                            .semantics {
                                 role = Role.Button
                                 contentDescription = "Edit service"
-                            }
-                            .clickable(enabled = !isUpdating, onClick = onEditClick),
+                            }.clickable(enabled = !isUpdating, onClick = onEditClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
@@ -145,8 +144,7 @@ fun ServiceManagementCard(
                             .semantics {
                                 role = Role.Button
                                 contentDescription = "Manage service photo gallery"
-                            }
-                            .clickable(enabled = !isUpdating, onClick = onGalleryClick),
+                            }.clickable(enabled = !isUpdating, onClick = onGalleryClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
@@ -166,8 +164,7 @@ fun ServiceManagementCard(
                             .semantics {
                                 role = Role.Button
                                 contentDescription = "Delete service"
-                            }
-                            .clickable(enabled = !isUpdating, onClick = onDeleteClick),
+                            }.clickable(enabled = !isUpdating, onClick = onDeleteClick),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsComponents.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsComponents.kt
@@ -2,6 +2,7 @@ package must.kdroiders.hustlehub.ui.features.settings.presentation.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -165,12 +166,12 @@ fun SettingsRowToggle(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 10.dp)
-            .semantics {
-                role = Role.Switch
-                stateDescription = if (checked) "On" else "Off"
-                contentDescription = label
-            },
+            .toggleable(
+                value = checked,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+            )
+            .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SettingsIconBox(icon = icon)
@@ -184,7 +185,7 @@ fun SettingsRowToggle(
         )
         Switch(
             checked = checked,
-            onCheckedChange = onCheckedChange,
+            onCheckedChange = null, // Handled by row toggleable modifier
             colors = SwitchDefaults.colors(
                 checkedTrackColor = MaterialTheme.colorScheme.primary,
                 checkedThumbColor = MaterialTheme.colorScheme.onPrimary,

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsComponents.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsComponents.kt
@@ -2,7 +2,6 @@ package must.kdroiders.hustlehub.ui.features.settings.presentation.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
@@ -33,7 +33,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -170,8 +169,7 @@ fun SettingsRowToggle(
                 value = checked,
                 role = Role.Switch,
                 onValueChange = onCheckedChange,
-            )
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            ).padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SettingsIconBox(icon = icon)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsComponents.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsComponents.kt
@@ -27,6 +27,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,7 +45,9 @@ fun SettingsSectionLabel(text: String) {
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         letterSpacing = 1.2.sp,
-        modifier = Modifier.padding(start = 4.dp),
+        modifier = Modifier
+            .padding(start = 4.dp)
+            .semantics { heading() },
     )
 }
 
@@ -68,7 +76,11 @@ fun SettingsRowNavigate(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .semantics {
+                role = Role.Button
+                contentDescription = "$label${if (subtitle != null) ", $subtitle" else ""}"
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SettingsIconBox(icon = icon)
@@ -117,7 +129,11 @@ fun SettingsRowExternalLink(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .semantics {
+                role = Role.Button
+                contentDescription = "$label, opens external link"
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SettingsIconBox(icon = icon)
@@ -131,7 +147,7 @@ fun SettingsRowExternalLink(
         )
         Icon(
             imageVector = Icons.AutoMirrored.Filled.OpenInNew,
-            contentDescription = "Opens externally",
+            contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(16.dp),
         )
@@ -149,7 +165,12 @@ fun SettingsRowToggle(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .semantics {
+                role = Role.Switch
+                stateDescription = if (checked) "On" else "Off"
+                contentDescription = label
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SettingsIconBox(icon = icon)

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsTopBar.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/components/SettingsTopBar.kt
@@ -14,6 +14,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -28,7 +30,7 @@ fun SettingsTopBar(onBack: () -> Unit) {
         IconButton(onClick = onBack) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                contentDescription = "Navigate back",
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
@@ -38,6 +40,7 @@ fun SettingsTopBar(onBack: () -> Unit) {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
         Spacer(Modifier.weight(1f))
         // Invisible spacer to keep title centred

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -201,7 +203,7 @@ fun SettingsScreen(
                     textDecoration = TextDecoration.Underline,
                     modifier = Modifier
                         .clip(RoundedCornerShape(4.dp))
-                        .clickable { viewModel.onDeleteAccountClicked() }
+                        .clickable(role = Role.Button) { viewModel.onDeleteAccountClicked() }
                         .padding(horizontal = 8.dp, vertical = 4.dp),
                 )
             }

--- a/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
+++ b/app/src/main/java/must/kdroiders/hustlehub/ui/features/settings/presentation/view/SettingsScreen.kt
@@ -31,12 +31,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+// import androidx.hilt.navigation.compose.hiltViewModel
 import must.kdroiders.hustlehub.ui.features.settings.presentation.components.LogOutButton
 import must.kdroiders.hustlehub.ui.features.settings.presentation.components.ProfileIdentityCard
 import must.kdroiders.hustlehub.ui.features.settings.presentation.components.SettingsDivider
@@ -50,6 +49,9 @@ import must.kdroiders.hustlehub.ui.features.settings.presentation.viewmodel.Sett
 import must.kdroiders.hustlehub.ui.features.settings.presentation.viewmodel.SettingsViewModel
 import must.kdroiders.hustlehub.ui.theme.HustleActiveGreen
 import must.kdroiders.hustlehub.ui.theme.HustleHubTheme
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 /**
  * Settings screen — full-screen destination pushed over MainShell.
@@ -61,21 +63,23 @@ import must.kdroiders.hustlehub.ui.theme.HustleHubTheme
 fun SettingsScreen(
     onBack: () -> Unit = {},
     onNavigateToChangePassword: () -> Unit = {},
-    viewModel: SettingsViewModel = hiltViewModel(),
+    onNavigateToNotificationPreferences: () -> Unit = {},
+    settingsViewModel: SettingsViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val state by settingsViewModel.uiState.collectAsState()
 
-    val context = androidx.compose.ui.platform.LocalContext.current
+    val context = LocalContext.current
 
     // Consume one-shot navigation events
     LaunchedEffect(Unit) {
-        viewModel.events.collect { event ->
+        settingsViewModel.events.collect { event ->
             when (event) {
-                is SettingsEvent.LoggedOut -> onBack() // parent nav graph pops to Login
+                is SettingsEvent.LoggedOut -> onBack()
                 is SettingsEvent.NavigateToChangePassword -> onNavigateToChangePassword()
+                is SettingsEvent.NavigateToNotifications -> onNavigateToNotificationPreferences()
                 else -> {
-                    android.widget.Toast
-                        .makeText(context, "Coming soon", android.widget.Toast.LENGTH_SHORT)
+                    Toast
+                        .makeText(context, "Coming soon", Toast.LENGTH_SHORT)
                         .show()
                 }
             }
@@ -105,7 +109,7 @@ fun SettingsScreen(
                 displayName = state.displayName,
                 username = state.username,
                 avatarUrl = state.avatarUrl,
-                onEditClick = viewModel::onEditProfileClicked,
+                onEditClick = settingsViewModel::onEditProfileClicked,
             )
 
             Spacer(Modifier.height(28.dp))
@@ -119,14 +123,14 @@ fun SettingsScreen(
                     label = "Verification Status",
                     subtitle = if (state.isVerified) "Verified Student" else "Not Verified",
                     subtitleColor = if (state.isVerified) HustleActiveGreen else MaterialTheme.colorScheme.error,
-                    onClick = viewModel::onVerificationClicked,
+                    onClick = settingsViewModel::onVerificationClicked,
                 )
                 SettingsDivider()
                 SettingsRowNavigate(
                     icon = Icons.Default.CreditCard,
                     label = "Payment Methods",
                     trailing = state.paymentMethod,
-                    onClick = viewModel::onPaymentMethodsClicked,
+                    onClick = settingsViewModel::onPaymentMethodsClicked,
                 )
             }
 
@@ -139,26 +143,26 @@ fun SettingsScreen(
                 SettingsRowNavigate(
                     icon = Icons.Default.Notifications,
                     label = "Notifications",
-                    onClick = viewModel::onNotificationsClicked,
+                    onClick = settingsViewModel::onNotificationsClicked,
                 )
                 SettingsDivider()
                 SettingsRowNavigate(
                     icon = Icons.Default.Lock,
                     label = "Privacy & Security",
-                    onClick = viewModel::onPrivacyClicked,
+                    onClick = settingsViewModel::onPrivacyClicked,
                 )
                 SettingsDivider()
                 SettingsRowNavigate(
                     icon = Icons.Default.Lock,
                     label = "Change Password",
-                    onClick = viewModel::onChangePasswordClicked,
+                    onClick = settingsViewModel::onChangePasswordClicked,
                 )
                 SettingsDivider()
                 SettingsRowToggle(
                     icon = Icons.Default.DarkMode,
                     label = "Dark Mode",
                     checked = state.isDarkMode,
-                    onCheckedChange = viewModel::onDarkModeToggled,
+                    onCheckedChange = settingsViewModel::onDarkModeToggled,
                 )
             }
 
@@ -171,13 +175,13 @@ fun SettingsScreen(
                 SettingsRowExternalLink(
                     icon = Icons.AutoMirrored.Filled.Help,
                     label = "Help Center",
-                    onClick = viewModel::onHelpCenterClicked,
+                    onClick = settingsViewModel::onHelpCenterClicked,
                 )
                 SettingsDivider()
                 SettingsRowNavigate(
                     icon = Icons.Default.ReportProblem,
                     label = "Report a Problem",
-                    onClick = viewModel::onReportProblemClicked,
+                    onClick = settingsViewModel::onReportProblemClicked,
                 )
             }
 
@@ -186,7 +190,7 @@ fun SettingsScreen(
             // Log Out button
             LogOutButton(
                 isLoading = state.isLoggingOut,
-                onClick = viewModel::onLogOutClicked,
+                onClick = settingsViewModel::onLogOutClicked,
             )
 
             Spacer(Modifier.height(16.dp))
@@ -203,7 +207,7 @@ fun SettingsScreen(
                     textDecoration = TextDecoration.Underline,
                     modifier = Modifier
                         .clip(RoundedCornerShape(4.dp))
-                        .clickable(role = Role.Button) { viewModel.onDeleteAccountClicked() }
+                        .clickable(role = Role.Button) { settingsViewModel.onDeleteAccountClicked() }
                         .padding(horizontal = 8.dp, vertical = 4.dp),
                 )
             }

--- a/app/src/test/java/must/kdroiders/hustlehub/core/notification/InAppBannerManagerTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/core/notification/InAppBannerManagerTest.kt
@@ -6,7 +6,6 @@ import org.junit.Before
 import org.junit.Test
 
 class InAppBannerManagerTest {
-
     @Before
     fun setup() {
         InAppBannerManager.clearQueue()

--- a/app/src/test/java/must/kdroiders/hustlehub/core/notification/InAppBannerManagerTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/core/notification/InAppBannerManagerTest.kt
@@ -1,0 +1,57 @@
+package must.kdroiders.hustlehub.core.notification
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class InAppBannerManagerTest {
+
+    @Before
+    fun setup() {
+        InAppBannerManager.clearQueue()
+        ActiveConversationTracker.activeConversationId = null
+    }
+
+    @Test
+    fun `postBanner displays banner when active banner is null`() {
+        val banner = InAppBannerData(title = "Jane", body = "Hello", conversationId = "conv-1")
+        InAppBannerManager.postBanner(banner)
+
+        assertEquals(banner, InAppBannerManager.activeBanner.value)
+    }
+
+    @Test
+    fun `postBanner skips banner when user is on active conversation screen`() {
+        ActiveConversationTracker.activeConversationId = "conv-active"
+        val banner = InAppBannerData(title = "Jane", body = "Hello", conversationId = "conv-active")
+        InAppBannerManager.postBanner(banner)
+
+        assertNull(InAppBannerManager.activeBanner.value)
+    }
+
+    @Test
+    fun `postBanner queues subsequent banners in FIFO order`() {
+        val banner1 = InAppBannerData(title = "Jane", body = "Message 1", conversationId = "conv-1")
+        val banner2 = InAppBannerData(title = "Bob", body = "Message 2", conversationId = "conv-2")
+
+        InAppBannerManager.postBanner(banner1)
+        InAppBannerManager.postBanner(banner2)
+
+        assertEquals(banner1, InAppBannerManager.activeBanner.value)
+
+        InAppBannerManager.dismissCurrentBanner()
+
+        assertEquals(banner2, InAppBannerManager.activeBanner.value)
+    }
+
+    @Test
+    fun `dismissCurrentBanner sets active banner to null when queue empty`() {
+        val banner1 = InAppBannerData(title = "Jane", body = "Message 1", conversationId = "conv-1")
+        InAppBannerManager.postBanner(banner1)
+
+        InAppBannerManager.dismissCurrentBanner()
+
+        assertNull(InAppBannerManager.activeBanner.value)
+    }
+}

--- a/app/src/test/java/must/kdroiders/hustlehub/navigation/DeepLinkHandlerTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/navigation/DeepLinkHandlerTest.kt
@@ -12,7 +12,6 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
 class DeepLinkHandlerTest {
-
     private fun parseDeepLink(uriString: String): DeepLinkAction? {
         val uri = Uri.parse(uriString)
         if (uri.scheme != "hustlehub") return null

--- a/app/src/test/java/must/kdroiders/hustlehub/navigation/DeepLinkHandlerTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/navigation/DeepLinkHandlerTest.kt
@@ -1,0 +1,107 @@
+package must.kdroiders.hustlehub.navigation
+
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DeepLinkHandlerTest {
+
+    private fun parseDeepLink(uriString: String): DeepLinkAction? {
+        val uri = Uri.parse(uriString)
+        if (uri.scheme != "hustlehub") return null
+        val host = uri.host ?: return null
+        val lastSegment = uri.lastPathSegment
+
+        return when (host) {
+            "chat" -> {
+                val conversationId = lastSegment ?: uri.getQueryParameter("conversationId")
+                if (!conversationId.isNullOrBlank()) DeepLinkAction.OpenChat(conversationId) else null
+            }
+            "service" -> {
+                if (!lastSegment.isNullOrBlank()) DeepLinkAction.OpenServiceDetail(lastSegment) else null
+            }
+            "profile" -> {
+                if (!lastSegment.isNullOrBlank()) DeepLinkAction.OpenProviderProfile(lastSegment) else null
+            }
+            "review" -> {
+                val serviceId = lastSegment
+                val providerId = uri.getQueryParameter("providerId") ?: ""
+                if (!serviceId.isNullOrBlank()) DeepLinkAction.OpenWriteReview(serviceId, providerId) else null
+            }
+            "notifications" -> DeepLinkAction.OpenNotifications
+            "app" -> {
+                when {
+                    uri.path?.contains("chat") == true -> {
+                        val conversationId = uri.getQueryParameter("conversationId")
+                        if (!conversationId.isNullOrBlank()) DeepLinkAction.OpenChat(conversationId) else null
+                    }
+                    uri.path?.contains("profile") == true -> DeepLinkAction.OpenProfile
+                    uri.path?.contains("inquiries") == true -> DeepLinkAction.OpenChatList
+                    else -> null
+                }
+            }
+            else -> null
+        }
+    }
+
+    @Test
+    fun `chat deep link parses conversationId correctly`() {
+        val action = parseDeepLink("hustlehub://chat/conv-12345")
+        assertTrue(action is DeepLinkAction.OpenChat)
+        assertEquals("conv-12345", (action as DeepLinkAction.OpenChat).conversationId)
+    }
+
+    @Test
+    fun `service deep link parses serviceId correctly`() {
+        val action = parseDeepLink("hustlehub://service/serv-999")
+        assertTrue(action is DeepLinkAction.OpenServiceDetail)
+        assertEquals("serv-999", (action as DeepLinkAction.OpenServiceDetail).serviceId)
+    }
+
+    @Test
+    fun `profile deep link parses providerId correctly`() {
+        val action = parseDeepLink("hustlehub://profile/user-888")
+        assertTrue(action is DeepLinkAction.OpenProviderProfile)
+        assertEquals("user-888", (action as DeepLinkAction.OpenProviderProfile).providerId)
+    }
+
+    @Test
+    fun `review deep link parses serviceId and providerId query param`() {
+        val action = parseDeepLink("hustlehub://review/serv-100?providerId=usr-200")
+        assertTrue(action is DeepLinkAction.OpenWriteReview)
+        assertEquals("serv-100", (action as DeepLinkAction.OpenWriteReview).serviceId)
+        assertEquals("usr-200", action.providerId)
+    }
+
+    @Test
+    fun `notifications deep link parses to OpenNotifications action`() {
+        val action = parseDeepLink("hustlehub://notifications")
+        assertEquals(DeepLinkAction.OpenNotifications, action)
+    }
+
+    @Test
+    fun `legacy app chat deep link parses conversationId query param`() {
+        val action = parseDeepLink("hustlehub://app/chat?conversationId=legacy-conv")
+        assertTrue(action is DeepLinkAction.OpenChat)
+        assertEquals("legacy-conv", (action as DeepLinkAction.OpenChat).conversationId)
+    }
+
+    @Test
+    fun `invalid scheme returns null gracefully`() {
+        val action = parseDeepLink("https://hustlehub.com/chat/123")
+        assertNull(action)
+    }
+
+    @Test
+    fun `unknown host returns null gracefully`() {
+        val action = parseDeepLink("hustlehub://unknownhost/123")
+        assertNull(action)
+    }
+}

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/auth/domain/usecase/SignOutUseCaseTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/auth/domain/usecase/SignOutUseCaseTest.kt
@@ -1,7 +1,8 @@
 package must.kdroiders.hustlehub.ui.features.auth.domain.usecase
 
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import must.kdroiders.hustlehub.ui.features.auth.domain.repository.AuthRepository
 import org.junit.Before
 import org.junit.Test
@@ -20,8 +21,9 @@ class SignOutUseCaseTest {
     }
 
     @Test
-    fun `should_call_authRepository_logout_when_invoked`() {
+    fun `should_call_authRepository_logout_when_invoked`() = runTest {
         signOutUseCase()
-        verify(exactly = 1) { authRepository.logout() }
+        coVerify(exactly = 1) { authRepository.logout() }
     }
 }
+

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/auth/domain/usecase/SignOutUseCaseTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/auth/domain/usecase/SignOutUseCaseTest.kt
@@ -21,9 +21,9 @@ class SignOutUseCaseTest {
     }
 
     @Test
-    fun `should_call_authRepository_logout_when_invoked`() = runTest {
-        signOutUseCase()
-        coVerify(exactly = 1) { authRepository.logout() }
-    }
+    fun `should_call_authRepository_logout_when_invoked`() =
+        runTest {
+            signOutUseCase()
+            coVerify(exactly = 1) { authRepository.logout() }
+        }
 }
-

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModelTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModelTest.kt
@@ -1,0 +1,81 @@
+package must.kdroiders.hustlehub.ui.features.chat.presentation.viewmodel
+
+import android.content.Context
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import must.kdroiders.hustlehub.ui.features.chat.data.local.dao.ConversationDao
+import must.kdroiders.hustlehub.ui.features.notification.domain.repository.NotificationRepository
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule : TestWatcher() {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}
+
+class UnreadCountViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val context: Context = mockk(relaxed = true)
+    private val conversationDao: ConversationDao = mockk(relaxed = true)
+    private val notificationRepository: NotificationRepository = mockk(relaxed = true)
+
+    private lateinit var viewModel: UnreadCountViewModel
+
+    @Before
+    fun setup() {
+        coEvery { conversationDao.getTotalUnreadCount() } returns flowOf(5)
+        coEvery { notificationRepository.getUnreadCount() } returns Result.success(3)
+
+        viewModel = UnreadCountViewModel(
+            context = context,
+            conversationDao = conversationDao,
+            notificationRepository = notificationRepository,
+        )
+    }
+
+    @Test
+    fun `unreadMessageCount reflects conversationDao flow`() = runTest {
+        assertEquals(5, viewModel.unreadMessageCount.value)
+    }
+
+    @Test
+    fun `unreadNotificationCount reflects notificationRepository getUnreadCount`() = runTest {
+        assertEquals(3, viewModel.unreadNotificationCount.value)
+    }
+
+    @Test
+    fun `totalUnreadCount combines messages and notifications`() = runTest {
+        assertEquals(8, viewModel.totalUnreadCount.value)
+    }
+
+    @Test
+    fun `clearNotificationsBadge clears unreadNotificationCount to zero`() = runTest {
+        coEvery { notificationRepository.markAllRead() } returns Result.success(Unit)
+
+        viewModel.clearNotificationsBadge()
+
+        assertEquals(0, viewModel.unreadNotificationCount.value)
+        assertEquals(5, viewModel.totalUnreadCount.value)
+        coVerify(exactly = 1) { notificationRepository.markAllRead() }
+    }
+}

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModelTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/chat/presentation/viewmodel/UnreadCountViewModelTest.kt
@@ -54,28 +54,32 @@ class UnreadCountViewModelTest {
     }
 
     @Test
-    fun `unreadMessageCount reflects conversationDao flow`() = runTest {
-        assertEquals(5, viewModel.unreadMessageCount.value)
-    }
+    fun `unreadMessageCount reflects conversationDao flow`() =
+        runTest {
+            assertEquals(5, viewModel.unreadMessageCount.value)
+        }
 
     @Test
-    fun `unreadNotificationCount reflects notificationRepository getUnreadCount`() = runTest {
-        assertEquals(3, viewModel.unreadNotificationCount.value)
-    }
+    fun `unreadNotificationCount reflects notificationRepository getUnreadCount`() =
+        runTest {
+            assertEquals(3, viewModel.unreadNotificationCount.value)
+        }
 
     @Test
-    fun `totalUnreadCount combines messages and notifications`() = runTest {
-        assertEquals(8, viewModel.totalUnreadCount.value)
-    }
+    fun `totalUnreadCount combines messages and notifications`() =
+        runTest {
+            assertEquals(8, viewModel.totalUnreadCount.value)
+        }
 
     @Test
-    fun `clearNotificationsBadge clears unreadNotificationCount to zero`() = runTest {
-        coEvery { notificationRepository.markAllRead() } returns Result.success(Unit)
+    fun `clearNotificationsBadge clears unreadNotificationCount to zero`() =
+        runTest {
+            coEvery { notificationRepository.markAllRead() } returns Result.success(Unit)
 
-        viewModel.clearNotificationsBadge()
+            viewModel.clearNotificationsBadge()
 
-        assertEquals(0, viewModel.unreadNotificationCount.value)
-        assertEquals(5, viewModel.totalUnreadCount.value)
-        coVerify(exactly = 1) { notificationRepository.markAllRead() }
-    }
+            assertEquals(0, viewModel.unreadNotificationCount.value)
+            assertEquals(5, viewModel.totalUnreadCount.value)
+            coVerify(exactly = 1) { notificationRepository.markAllRead() }
+        }
 }

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationPreferencesViewModelTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationPreferencesViewModelTest.kt
@@ -50,66 +50,71 @@ class NotificationPreferencesViewModelTest {
                 vibrationEnabled = true,
                 quietHoursStart = 22,
                 quietHoursEnd = 7,
-            )
+            ),
         )
         viewModel = NotificationPreferencesViewModel(repository)
     }
 
     @Test
-    fun `init loads preferences from repository`() = runTest {
-        val state = viewModel.uiState.value
-        assertTrue(state.preferences.newMessages)
-        assertFalse(state.preferences.marketing)
-        assertEquals(22, state.preferences.quietHoursStart)
-        assertEquals(7, state.preferences.quietHoursEnd)
-        coVerify(exactly = 1) { repository.getPreferences() }
-    }
+    fun `init loads preferences from repository`() =
+        runTest {
+            val state = viewModel.uiState.value
+            assertTrue(state.preferences.newMessages)
+            assertFalse(state.preferences.marketing)
+            assertEquals(22, state.preferences.quietHoursStart)
+            assertEquals(7, state.preferences.quietHoursEnd)
+            coVerify(exactly = 1) { repository.getPreferences() }
+        }
 
     @Test
-    fun `onNewMessagesToggled updates state and calls updatePreferences`() = runTest {
-        coEvery { repository.updatePreferences(any()) } returns Result.success(
-            NotificationPreferences(newMessages = false)
-        )
+    fun `onNewMessagesToggled updates state and calls updatePreferences`() =
+        runTest {
+            coEvery { repository.updatePreferences(any()) } returns Result.success(
+                NotificationPreferences(newMessages = false),
+            )
 
-        viewModel.onNewMessagesToggled(false)
+            viewModel.onNewMessagesToggled(false)
 
-        assertFalse(viewModel.uiState.value.preferences.newMessages)
-        coVerify { repository.updatePreferences(match { !it.newMessages }) }
-    }
-
-    @Test
-    fun `onMarketingToggled updates state and calls updatePreferences`() = runTest {
-        coEvery { repository.updatePreferences(any()) } returns Result.success(
-            NotificationPreferences(marketing = true)
-        )
-
-        viewModel.onMarketingToggled(true)
-
-        assertTrue(viewModel.uiState.value.preferences.marketing)
-        coVerify { repository.updatePreferences(match { it.marketing }) }
-    }
+            assertFalse(viewModel.uiState.value.preferences.newMessages)
+            coVerify { repository.updatePreferences(match { !it.newMessages }) }
+        }
 
     @Test
-    fun `onQuietHoursStartChanged updates state and saves`() = runTest {
-        coEvery { repository.updatePreferences(any()) } returns Result.success(
-            NotificationPreferences(quietHoursStart = 23)
-        )
+    fun `onMarketingToggled updates state and calls updatePreferences`() =
+        runTest {
+            coEvery { repository.updatePreferences(any()) } returns Result.success(
+                NotificationPreferences(marketing = true),
+            )
 
-        viewModel.onQuietHoursStartChanged(23)
+            viewModel.onMarketingToggled(true)
 
-        assertEquals(23, viewModel.uiState.value.preferences.quietHoursStart)
-        coVerify { repository.updatePreferences(match { it.quietHoursStart == 23 }) }
-    }
+            assertTrue(viewModel.uiState.value.preferences.marketing)
+            coVerify { repository.updatePreferences(match { it.marketing }) }
+        }
 
     @Test
-    fun `onQuietHoursEndChanged updates state and saves`() = runTest {
-        coEvery { repository.updatePreferences(any()) } returns Result.success(
-            NotificationPreferences(quietHoursEnd = 6)
-        )
+    fun `onQuietHoursStartChanged updates state and saves`() =
+        runTest {
+            coEvery { repository.updatePreferences(any()) } returns Result.success(
+                NotificationPreferences(quietHoursStart = 23),
+            )
 
-        viewModel.onQuietHoursEndChanged(6)
+            viewModel.onQuietHoursStartChanged(23)
 
-        assertEquals(6, viewModel.uiState.value.preferences.quietHoursEnd)
-        coVerify { repository.updatePreferences(match { it.quietHoursEnd == 6 }) }
-    }
+            assertEquals(23, viewModel.uiState.value.preferences.quietHoursStart)
+            coVerify { repository.updatePreferences(match { it.quietHoursStart == 23 }) }
+        }
+
+    @Test
+    fun `onQuietHoursEndChanged updates state and saves`() =
+        runTest {
+            coEvery { repository.updatePreferences(any()) } returns Result.success(
+                NotificationPreferences(quietHoursEnd = 6),
+            )
+
+            viewModel.onQuietHoursEndChanged(6)
+
+            assertEquals(6, viewModel.uiState.value.preferences.quietHoursEnd)
+            coVerify { repository.updatePreferences(match { it.quietHoursEnd == 6 }) }
+        }
 }

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationPreferencesViewModelTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationPreferencesViewModelTest.kt
@@ -1,0 +1,115 @@
+package must.kdroiders.hustlehub.ui.features.notification.presentation.viewmodel
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import must.kdroiders.hustlehub.ui.features.notification.domain.model.NotificationPreferences
+import must.kdroiders.hustlehub.ui.features.notification.domain.repository.NotificationRepository
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule : TestWatcher() {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}
+
+class NotificationPreferencesViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val repository: NotificationRepository = mockk(relaxed = true)
+    private lateinit var viewModel: NotificationPreferencesViewModel
+
+    @Before
+    fun setup() {
+        coEvery { repository.getPreferences() } returns Result.success(
+            NotificationPreferences(
+                newMessages = true,
+                newReviews = true,
+                serviceInquiries = true,
+                marketing = false,
+                soundEnabled = true,
+                vibrationEnabled = true,
+                quietHoursStart = 22,
+                quietHoursEnd = 7,
+            )
+        )
+        viewModel = NotificationPreferencesViewModel(repository)
+    }
+
+    @Test
+    fun `init loads preferences from repository`() = runTest {
+        val state = viewModel.uiState.value
+        assertTrue(state.preferences.newMessages)
+        assertFalse(state.preferences.marketing)
+        assertEquals(22, state.preferences.quietHoursStart)
+        assertEquals(7, state.preferences.quietHoursEnd)
+        coVerify(exactly = 1) { repository.getPreferences() }
+    }
+
+    @Test
+    fun `onNewMessagesToggled updates state and calls updatePreferences`() = runTest {
+        coEvery { repository.updatePreferences(any()) } returns Result.success(
+            NotificationPreferences(newMessages = false)
+        )
+
+        viewModel.onNewMessagesToggled(false)
+
+        assertFalse(viewModel.uiState.value.preferences.newMessages)
+        coVerify { repository.updatePreferences(match { !it.newMessages }) }
+    }
+
+    @Test
+    fun `onMarketingToggled updates state and calls updatePreferences`() = runTest {
+        coEvery { repository.updatePreferences(any()) } returns Result.success(
+            NotificationPreferences(marketing = true)
+        )
+
+        viewModel.onMarketingToggled(true)
+
+        assertTrue(viewModel.uiState.value.preferences.marketing)
+        coVerify { repository.updatePreferences(match { it.marketing }) }
+    }
+
+    @Test
+    fun `onQuietHoursStartChanged updates state and saves`() = runTest {
+        coEvery { repository.updatePreferences(any()) } returns Result.success(
+            NotificationPreferences(quietHoursStart = 23)
+        )
+
+        viewModel.onQuietHoursStartChanged(23)
+
+        assertEquals(23, viewModel.uiState.value.preferences.quietHoursStart)
+        coVerify { repository.updatePreferences(match { it.quietHoursStart == 23 }) }
+    }
+
+    @Test
+    fun `onQuietHoursEndChanged updates state and saves`() = runTest {
+        coEvery { repository.updatePreferences(any()) } returns Result.success(
+            NotificationPreferences(quietHoursEnd = 6)
+        )
+
+        viewModel.onQuietHoursEndChanged(6)
+
+        assertEquals(6, viewModel.uiState.value.preferences.quietHoursEnd)
+        coVerify { repository.updatePreferences(match { it.quietHoursEnd == 6 }) }
+    }
+}

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationViewModelTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationViewModelTest.kt
@@ -3,24 +3,16 @@ package must.kdroiders.hustlehub.ui.features.notification.presentation.viewmodel
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import must.kdroiders.hustlehub.ui.features.notification.domain.model.Notification
 import must.kdroiders.hustlehub.ui.features.notification.domain.model.NotificationType
 import must.kdroiders.hustlehub.ui.features.notification.domain.repository.NotificationRepository
 import must.kdroiders.hustlehub.ui.features.notification.presentation.view.groupNotificationsByDate
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TestWatcher
-import org.junit.runner.Description
 import java.time.Instant
 
 class NotificationViewModelTest {
@@ -60,48 +52,52 @@ class NotificationViewModelTest {
     }
 
     @Test
-    fun `loadNotifications fetches notifications and calculates unread count`() = runTest {
-        val state = viewModel.uiState.value
-        assertEquals(2, state.notifications.size)
-        assertEquals(1, state.unreadCount) // notif-1 is unread
-        coVerify(exactly = 1) { repository.getNotifications(0, 50) }
-    }
+    fun `loadNotifications fetches notifications and calculates unread count`() =
+        runTest {
+            val state = viewModel.uiState.value
+            assertEquals(2, state.notifications.size)
+            assertEquals(1, state.unreadCount) // notif-1 is unread
+            coVerify(exactly = 1) { repository.getNotifications(0, 50) }
+        }
 
     @Test
-    fun `markAsRead updates target notification optimistically`() = runTest {
-        coEvery { repository.markRead("notif-1") } returns Result.success(Unit)
+    fun `markAsRead updates target notification optimistically`() =
+        runTest {
+            coEvery { repository.markRead("notif-1") } returns Result.success(Unit)
 
-        viewModel.markAsRead("notif-1")
+            viewModel.markAsRead("notif-1")
 
-        val state = viewModel.uiState.value
-        assertTrue(state.notifications.first { it.id == "notif-1" }.isRead)
-        assertEquals(0, state.unreadCount)
-        coVerify(exactly = 1) { repository.markRead("notif-1") }
-    }
-
-    @Test
-    fun `markAllAsRead marks all notifications as read optimistically`() = runTest {
-        coEvery { repository.markAllRead() } returns Result.success(Unit)
-
-        viewModel.markAllAsRead()
-
-        val state = viewModel.uiState.value
-        assertTrue(state.notifications.all { it.isRead })
-        assertEquals(0, state.unreadCount)
-        coVerify(exactly = 1) { repository.markAllRead() }
-    }
+            val state = viewModel.uiState.value
+            assertTrue(state.notifications.first { it.id == "notif-1" }.isRead)
+            assertEquals(0, state.unreadCount)
+            coVerify(exactly = 1) { repository.markRead("notif-1") }
+        }
 
     @Test
-    fun `deleteNotification removes notification from state optimistically`() = runTest {
-        coEvery { repository.deleteNotification("notif-1") } returns Result.success(Unit)
+    fun `markAllAsRead marks all notifications as read optimistically`() =
+        runTest {
+            coEvery { repository.markAllRead() } returns Result.success(Unit)
 
-        viewModel.deleteNotification("notif-1")
+            viewModel.markAllAsRead()
 
-        val state = viewModel.uiState.value
-        assertEquals(1, state.notifications.size)
-        assertEquals("notif-2", state.notifications.first().id)
-        coVerify(exactly = 1) { repository.deleteNotification("notif-1") }
-    }
+            val state = viewModel.uiState.value
+            assertTrue(state.notifications.all { it.isRead })
+            assertEquals(0, state.unreadCount)
+            coVerify(exactly = 1) { repository.markAllRead() }
+        }
+
+    @Test
+    fun `deleteNotification removes notification from state optimistically`() =
+        runTest {
+            coEvery { repository.deleteNotification("notif-1") } returns Result.success(Unit)
+
+            viewModel.deleteNotification("notif-1")
+
+            val state = viewModel.uiState.value
+            assertEquals(1, state.notifications.size)
+            assertEquals("notif-2", state.notifications.first().id)
+            coVerify(exactly = 1) { repository.deleteNotification("notif-1") }
+        }
 
     @Test
     fun `groupNotificationsByDate groups items into Today and Yesterday`() {

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationViewModelTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/notification/presentation/viewmodel/NotificationViewModelTest.kt
@@ -1,0 +1,114 @@
+package must.kdroiders.hustlehub.ui.features.notification.presentation.viewmodel
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import must.kdroiders.hustlehub.ui.features.notification.domain.model.Notification
+import must.kdroiders.hustlehub.ui.features.notification.domain.model.NotificationType
+import must.kdroiders.hustlehub.ui.features.notification.domain.repository.NotificationRepository
+import must.kdroiders.hustlehub.ui.features.notification.presentation.view.groupNotificationsByDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.time.Instant
+
+class NotificationViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val repository: NotificationRepository = mockk(relaxed = true)
+    private lateinit var viewModel: NotificationViewModel
+
+    private val sampleNotifications = listOf(
+        Notification(
+            id = "notif-1",
+            userId = "user-1",
+            type = NotificationType.NEW_MESSAGE,
+            title = "New Message",
+            body = "Jane sent you a message",
+            data = null,
+            isRead = false,
+            sentAt = Instant.now().toString(),
+        ),
+        Notification(
+            id = "notif-2",
+            userId = "user-1",
+            type = NotificationType.NEW_REVIEW,
+            title = "New Review",
+            body = "Mary left a 5-star review",
+            data = null,
+            isRead = true,
+            sentAt = Instant.now().minusSeconds(86400).toString(),
+        ),
+    )
+
+    @Before
+    fun setup() {
+        coEvery { repository.getNotifications(any(), any()) } returns Result.success(sampleNotifications)
+        viewModel = NotificationViewModel(repository)
+    }
+
+    @Test
+    fun `loadNotifications fetches notifications and calculates unread count`() = runTest {
+        val state = viewModel.uiState.value
+        assertEquals(2, state.notifications.size)
+        assertEquals(1, state.unreadCount) // notif-1 is unread
+        coVerify(exactly = 1) { repository.getNotifications(0, 50) }
+    }
+
+    @Test
+    fun `markAsRead updates target notification optimistically`() = runTest {
+        coEvery { repository.markRead("notif-1") } returns Result.success(Unit)
+
+        viewModel.markAsRead("notif-1")
+
+        val state = viewModel.uiState.value
+        assertTrue(state.notifications.first { it.id == "notif-1" }.isRead)
+        assertEquals(0, state.unreadCount)
+        coVerify(exactly = 1) { repository.markRead("notif-1") }
+    }
+
+    @Test
+    fun `markAllAsRead marks all notifications as read optimistically`() = runTest {
+        coEvery { repository.markAllRead() } returns Result.success(Unit)
+
+        viewModel.markAllAsRead()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.notifications.all { it.isRead })
+        assertEquals(0, state.unreadCount)
+        coVerify(exactly = 1) { repository.markAllRead() }
+    }
+
+    @Test
+    fun `deleteNotification removes notification from state optimistically`() = runTest {
+        coEvery { repository.deleteNotification("notif-1") } returns Result.success(Unit)
+
+        viewModel.deleteNotification("notif-1")
+
+        val state = viewModel.uiState.value
+        assertEquals(1, state.notifications.size)
+        assertEquals("notif-2", state.notifications.first().id)
+        coVerify(exactly = 1) { repository.deleteNotification("notif-1") }
+    }
+
+    @Test
+    fun `groupNotificationsByDate groups items into Today and Yesterday`() {
+        val groups = groupNotificationsByDate(sampleNotifications)
+        assertTrue(groups.containsKey("Today"))
+        assertTrue(groups.containsKey("Yesterday"))
+        assertEquals(1, groups["Today"]?.size)
+        assertEquals(1, groups["Yesterday"]?.size)
+    }
+}

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImplTest.kt
@@ -1,0 +1,61 @@
+package must.kdroiders.hustlehub.ui.features.profile.data.repository
+
+import android.content.Context
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import must.kdroiders.hustlehub.ui.features.auth.data.remote.AuthApiService
+import must.kdroiders.hustlehub.ui.features.media.data.remote.MediaApiService
+import must.kdroiders.hustlehub.ui.features.profile.data.remote.FcmTokenRequest
+import must.kdroiders.hustlehub.ui.features.profile.data.remote.UserApiService
+import must.kdroiders.hustlehub.ui.features.service.data.remote.ServiceApiService
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+class UserRepositoryImplTest {
+    private lateinit var context: Context
+    private lateinit var authApiService: AuthApiService
+    private lateinit var userApiService: UserApiService
+    private lateinit var mediaApiService: MediaApiService
+    private lateinit var serviceApiService: ServiceApiService
+    private lateinit var userRepository: UserRepositoryImpl
+
+    @Before
+    fun setup() {
+        context = mockk(relaxed = true)
+        authApiService = mockk(relaxed = true)
+        userApiService = mockk(relaxed = true)
+        mediaApiService = mockk(relaxed = true)
+        serviceApiService = mockk(relaxed = true)
+        userRepository = UserRepositoryImpl(
+            context = context,
+            authApiService = authApiService,
+            userApiService = userApiService,
+            mediaApiService = mediaApiService,
+            serviceApiService = serviceApiService,
+        )
+    }
+
+    @Test
+    fun `updateFcmToken calls userApiService updateFcmToken`() = runTest {
+        coEvery { userApiService.updateFcmToken(FcmTokenRequest("test-token")) } returns Response.success(Unit)
+
+        val result = userRepository.updateFcmToken("test-token")
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { userApiService.updateFcmToken(FcmTokenRequest("test-token")) }
+    }
+
+    @Test
+    fun `removeFcmToken calls userApiService removeFcmToken`() = runTest {
+        coEvery { userApiService.removeFcmToken("test-token") } returns Response.success(Unit)
+
+        val result = userRepository.removeFcmToken("test-token")
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { userApiService.removeFcmToken("test-token") }
+    }
+}

--- a/app/src/test/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/must/kdroiders/hustlehub/ui/features/profile/data/repository/UserRepositoryImplTest.kt
@@ -40,22 +40,24 @@ class UserRepositoryImplTest {
     }
 
     @Test
-    fun `updateFcmToken calls userApiService updateFcmToken`() = runTest {
-        coEvery { userApiService.updateFcmToken(FcmTokenRequest("test-token")) } returns Response.success(Unit)
+    fun `updateFcmToken calls userApiService updateFcmToken`() =
+        runTest {
+            coEvery { userApiService.updateFcmToken(FcmTokenRequest("test-token")) } returns Response.success(Unit)
 
-        val result = userRepository.updateFcmToken("test-token")
+            val result = userRepository.updateFcmToken("test-token")
 
-        assertTrue(result.isSuccess)
-        coVerify(exactly = 1) { userApiService.updateFcmToken(FcmTokenRequest("test-token")) }
-    }
+            assertTrue(result.isSuccess)
+            coVerify(exactly = 1) { userApiService.updateFcmToken(FcmTokenRequest("test-token")) }
+        }
 
     @Test
-    fun `removeFcmToken calls userApiService removeFcmToken`() = runTest {
-        coEvery { userApiService.removeFcmToken("test-token") } returns Response.success(Unit)
+    fun `removeFcmToken calls userApiService removeFcmToken`() =
+        runTest {
+            coEvery { userApiService.removeFcmToken("test-token") } returns Response.success(Unit)
 
-        val result = userRepository.removeFcmToken("test-token")
+            val result = userRepository.removeFcmToken("test-token")
 
-        assertTrue(result.isSuccess)
-        coVerify(exactly = 1) { userApiService.removeFcmToken("test-token") }
-    }
+            assertTrue(result.isSuccess)
+            coVerify(exactly = 1) { userApiService.removeFcmToken("test-token") }
+        }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,11 +43,13 @@ googleid = "1.2.0"
 krossbow = "7.0.0"
 media3 = "1.2.0"
 desugarJdkLibs = "2.1.4"
+shortcutBadger = "1.1.22"
 
 # expressive
 material3 = "1.5.0-alpha22"
 
 [libraries]
+shortcut-badger = { module = "me.leolin:ShortcutBadger", version.ref = "shortcutBadger" }
 desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## 📝 What does this PR do?
Implements a complete real-time push and in-app notification ecosystem across the Spring Boot backend and Android Jetpack Compose app covering Issues #103 to #109. 

It handles FCM SDK integration, server-side event push triggers, notification history with date grouping & swipe-to-delete, top slide-down in-app notification banners, deep link navigation, quiet hours & category preferences, navigation & launcher app icon unread badges, and full WCAG accessibility compliance (TalkBack node merging, custom accessibility actions, vector icons).

---

## 🔄 Main Changes

### Added
- **FCM Push Notification Setup (#103)**: Integrated Firebase Cloud Messaging (`HustleHubMessagingService`), high-importance notification channels (`channel_messages`, `channel_reviews`, `channel_system`), `POST_NOTIFICATIONS` runtime permission handling, and FCM token registration to Spring Boot backend.
- **In-App Notification Banner & Queue Manager (#108)**: Created `InAppNotificationBanner.kt` slide-down composable overlay with 4s auto-dismiss, swipe-up early dismiss, thread-safe FIFO queueing (`InAppBannerManager.kt`), and active chat exclusion logic.
- **Notification History Screen (#107)**: Created `NotificationScreen.kt` with notifications grouped by date (Today, Yesterday, This Week, Older), swipe-to-delete using `SwipeToDismissBox`, mark-all-as-read action, and optimistic state updates with rollback.
- **Server-Side Push Triggers (#109)**: Implemented event-driven dispatches in Spring Boot backend (`onMessageCreate`, `onReviewCreate`, `onServiceInquiry`) with PostgreSQL history persistence, multicast delivery, and stale token cleanup (`MessagingErrorCode.UNREGISTERED`).
- **Unread Notification Badges & App Icon Badge (#106)**: Added `BadgedBox` to bottom navigation icons (Chat & Notifications) and integrated `ShortcutBadger` / `NotificationManager` for total unread counts on Android 8+ app launcher icons.
- **Unit & Integration Test Suites**: Created test suites (`NotificationEventTriggerTest.kt`, `InAppBannerManagerTest.kt`, `NotificationViewModelTest.kt`, `NotificationServiceTest.kt`) with 100% passing results.

### Changed
- **Notification Preferences & Quiet Hours (#104)**: Added quiet hours windowing calculation in UTC and category toggle filters (`newMessages`, `newReviews`, `serviceInquiries`, `marketing`).
- **Deep Linking Navigation (#105)**: Configured `hustlehub://chat/{id}` and `hustlehub://review/{id}` URI deep linking routing in `HustleHubNavGraph.kt` for cold starts and background FCM intents.
- **UI & Layout Standardization**: Refactored notification preferences screen to use project's standardized `HustleScaffold`. Replaced all raw emojis with accessible Material 3 vector icons (`Chat`, `RateReview`, `Work`, `Campaign`, `Info`).

### WCAG Accessibility Highlights ♿
- **TalkBack Card Merging**: Applied `semantics(mergeDescendants = true)` so notification items are read as cohesive single spoken nodes.
- **Custom Accessibility Actions**: Added `CustomAccessibilityAction("Dismiss notification")` so screen reader users can dismiss banners and history items without physical drag gestures.
- **Semantics & Touch Targets**: Added `heading()` for section headers, `role = Role.Button` for interactive banners, and enforced minimum $\ge 48\text{dp}$ touch target sizes.

### Fixed
- **Android Lint (`[AppLinkUrlError]`)**: Removed `android:autoVerify="true"` from custom `hustlehub://` scheme filter in `AndroidManifest.xml`.
- **Deprecated APIs**: Resolved Material 3 deprecation warnings (`Icons.AutoMirrored.Filled.Chat`, `ExposedDropdownMenuAnchorType`).

---

## ✅ Type of change
- [x] New feature
- [x] Bug fix
- [x] UI update
- [x] Refactor / cleanup
- [x] Documentation

---

## 🧪 I have tested that...
- [x] The app builds without errors
- [x] My feature/fix works as expected
- [x] I didn't break anything else

---

## 🔍 Code quality
- [x] Quality checks passed (`./gradlew qualityCheck`)
- [x] Ktlint passed (`./gradlew ktlintCheck`)
- [x] Detekt passed (`./gradlew detekt`)
- [x] Android Lint passed (`./gradlew lint`)
- [x] Spring Boot backend tests passed (`./gradlew test` -> 113 tests passed)
- [x] My commit message follows convention (`feat:`, `fix:`, `chore:` etc.)

---

## Closes #
Closes #103, Closes #104, Closes #105, Closes #106, Closes #107, Closes #108, Closes #109
